### PR TITLE
runtime: fix critical failure in connection management update in some bad interaction with stopped deployments (closes #2)

### DIFF
--- a/lib/syskit/deployment.rb
+++ b/lib/syskit/deployment.rb
@@ -297,8 +297,8 @@ module Syskit
 
                 # task_handles is only initialized when ready is reached ...
                 # so can be nil here
-                all_tasks = task_handles.values.to_value_set
-                all_tasks.each do |task|
+                all_orocos_tasks = task_handles.values.to_value_set
+                all_orocos_tasks.each do |task|
                     task.each_parent_vertex(ActualDataFlow) do |parent_task|
                         if parent_task.process
                             next if !parent_task.process.running?
@@ -320,6 +320,11 @@ module Syskit
                     # not support selective disconnection over CORBA
                     ActualDataFlow.remove(task)
                     RequiredDataFlow.remove(task)
+                end
+
+                if pending = Flows::DataFlow.pending_changes
+                    _, _, removed, _ = *pending
+                    removed.delete_if { |(source, sink), _| all_orocos_tasks.include?(source) || all_orocos_tasks.include?(sink) }
                 end
             end
 

--- a/test/runtime/test_connection_management.rb
+++ b/test/runtime/test_connection_management.rb
@@ -23,4 +23,61 @@ describe Syskit::Runtime::ConnectionManagement do
             Syskit::Runtime::ConnectionManagement.new(plan).update_required_dataflow_graph([task])
         end
     end
+
+    describe "#update" do
+        attr_reader :source_task, :sink_task
+        before do
+            @source_task = syskit_deploy_task_context("source", 'source') do
+                output_port 'out', '/double'
+            end
+            @sink_task = syskit_deploy_task_context("sink", 'sink') do
+                input_port 'in', '/double'
+            end
+        end
+
+        it "should connect tasks only once they have been set up" do
+            source_task.connect_to(sink_task)
+            FlexMock.use(source_task.orocos_task.port('out')) do |mock|
+                mock.should_receive(:connect_to).never
+                Syskit::Runtime::ConnectionManagement.update(plan)
+            end
+
+            FlexMock.use(source_task.orocos_task.port('out')) do |mock|
+                mock.should_receive(:connect_to).once
+                syskit_setup_component(source_task)
+                syskit_setup_component(sink_task)
+                Syskit::Runtime::ConnectionManagement.update(plan)
+            end
+        end
+
+        # This is really a system test. We simulate having pending new and
+        # removed connections that are queued because some tasks are not set up,
+        # and then kill the tasks involved. The resulting operation should work
+        # fine (i.e. not creating the dead connections)
+        it "should ignore pending new connections that involve a dead task" do
+            source_task.connect_to(sink_task)
+            Syskit::Runtime::ConnectionManagement.update(plan)
+            source_task.execution_agent.stop!
+            # This is normally done by Runtime.update_deployment_states
+            source_task.execution_agent.cleanup_dead_connections
+            Syskit::Runtime::ConnectionManagement.update(plan)
+        end
+
+        it "should ignore pending removed connections that involve a dead task" do
+            source_task.connect_to(sink_task)
+            syskit_setup_component(source_task)
+            syskit_setup_component(sink_task)
+            Syskit::Runtime::ConnectionManagement.update(plan)
+
+            source_task.disconnect_ports(sink_task, [['out', 'in']])
+            FlexMock.use(Syskit::Runtime::ConnectionManagement) do |mock|
+                mock.new_instances.should_receive(:apply_connection_changes).at_least.once.and_throw(:cancelled)
+                Syskit::Runtime::ConnectionManagement.update(plan)
+                source_task.execution_agent.stop!
+                # This is normally done by Runtime.update_deployment_states
+                source_task.execution_agent.cleanup_dead_connections
+            end
+            Syskit::Runtime::ConnectionManagement.update(plan)
+        end
+    end
 end


### PR DESCRIPTION
See commit message for the details.

This is tested on the orogen_loaders branch, but untested on master. @goldhoorn and @cclausen, please test and tell me if I can apply it to master.
