### PR TITLE
models/component: fixed wrong port default-mapping

### DIFF
--- a/lib/syskit/models/component.rb
+++ b/lib/syskit/models/component.rb
@@ -211,7 +211,7 @@ module Syskit
                     if self <= model
                         mappings = Hash.new
                         model.each_port do |port|
-                            mappings[port.name] = port.name
+                            mappings[port.actual_name] = port.name
                         end
                         mappings
                     else


### PR DESCRIPTION
The default mapping which was inserted into port_mappings not meet
models.composition.rb:691:

```
child_task.forward_ports(self_task, [child.port_mappings[port.actual_name], export_name] => Hash.new)
```

This results in some szenarios in a nil entry for the portmapping, which causes
the model-instanciation to fail.

This commit make the resolution of port consistend.
