### PR TITLE
Added missing include for process manager

### DIFF
--- a/lib/syskit.rb
+++ b/lib/syskit.rb
@@ -2,6 +2,8 @@ require 'orocos'
 require 'metaruby'
 require 'metaruby/dsls/find_through_method_missing'
 require 'orocos/process_server'
+require 'orocos/remote_processes/protocol'
+require 'orocos/ruby_tasks/process_manager'
 require 'roby'
 require 'orogen'
 


### PR DESCRIPTION
This commit fixes a issue where from a syskit start the process server could not be found.
