### PR TITLE
Provide pretty_print for MasterDeviceIstance

### DIFF
--- a/lib/syskit/robot/master_device_instance.rb
+++ b/lib/syskit/robot/master_device_instance.rb
@@ -24,6 +24,11 @@ module Syskit
                 "#{name}[#{model.short_name}]"
             end
 
+            def pretty_print(pp)
+                pp.text = "MasterDeviceInstance(#{sort_name}_dev)"
+            end
+
+
             # The driver for this device
             # @return [BoundDataService]
             attr_reader :driver_model


### PR DESCRIPTION
This prevents a flood on the commandline

This fixes #19 
