### PR TITLE
Some objects that are protected and maybe shouldn't?

### DIFF
--- a/lib/syskit/instance_requirements.rb
+++ b/lib/syskit/instance_requirements.rb
@@ -14,15 +14,15 @@ module Syskit
             # The model selection that can be used to instanciate this task, as
             # a DependencyInjection object
             attr_reader :selections
-            protected :selections
+            #protected :selections
             # A DI context that should be used to instanciate this task
             attr_reader :dependency_injection_context
-            protected :dependency_injection_context
+            #protected :dependency_injection_context
             # The set of pushed selections
             #
             # @see push_selections
             attr_reader :pushed_selections
-            protected :pushed_selections
+            #protected :pushed_selections
 
             # A set of hints for deployment disambiguation
             #


### PR DESCRIPTION
Removing the declaration of protected solves an issue when running syskit browse and visiting the profiles.

This is the error that comes up if not:
tools/syskit/lib/syskit/instance_requirements.rb:721:in `method_missing': protected method`pushed_selections' called for Syskit::PlaceholderTaskBase::PoseSrv:Syskit::InstanceRequirements (NoMethodError)
