### PR TITLE
Allow Task to be driver for multiple Devices

### DIFF
--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -507,7 +507,7 @@ module Syskit
                 # Check that all devices are properly assigned
                 missing_devices = all_tasks.find_all do |t|
                     t.model < Device &&
-                        t.model.each_master_driver_service.any? { |srv| !t.find_device_attached_to(srv) }
+                        t.model.each_master_driver_service.all? { |srv| !t.find_device_attached_to(srv) }
                 end
                 if !missing_devices.empty?
                     raise DeviceAllocationFailed.new(self, missing_devices),


### PR DESCRIPTION
When there is a TaskContext that is a driver for multiple Device types, an error like the following occures during instanciation of one the names Devices.

```
cannot find a device to tie to 1 task(s)
for TrajectoryGeneration::TestPlant:0xb110e58{something_dev => device(Devices::Device1, :as => hi), conf => [default]}[]
  no candidates for TrajectoryGeneration::TestPlant:dummy_position,
  no candidates for TrajectoryGeneration::TestPlant:dummy_velocity,
  no candidates for TrajectoryGeneration::TestPlant:something_else
```

Here is a code snippet to illustrate the situation.

```
using_task_library 'trajectory_generation'

module Devices
   device_type "Device1"
   device_type "Device2"
end

TrajectoryGeneration::TestPlant.driver_for Devices::Device1, :as => "something"
TrajectoryGeneration::TestPlant.driver_for Devices::Device2, :as => "something_else"

module Profiles
profile "Test" do
    robot do
        device(Devices::Device1, :as => "hi")
    end
end
end
```

I assume this supposed to be supported Syskit and there was just a bug in the changed line of code.
