### PR TITLE
Allow multiple devices per task

### DIFF
--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -311,16 +311,6 @@ module Syskit
                 _, model, _ = leaf_task.requirements.resolved_dependency_injection.selection_for(nil, requirements)
                 if model && dev = model.arguments[argument_name]
                     return dev
-                else
-                    devices = Set.new
-                    leaf_task.each_parent_task do |parent|
-                        if sel = find_selected_device_in_hierarchy(argument_name, parent, requirements)
-                            devices << sel
-                        end
-                    end
-                    if devices.size == 1
-                        return devices.first
-                    end
                 end
             end
 

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -526,7 +526,7 @@ module Syskit
                 # Check that all devices are properly assigned
                 missing_devices = components.find_all do |t|
                     t.model.each_master_driver_service.
-                        any? { |srv| !t.find_device_attached_to(srv) }
+                        all? { |srv| !t.find_device_attached_to(srv) }
                 end
                 if !missing_devices.empty?
                     raise DeviceAllocationFailed.new(plan, missing_devices),


### PR DESCRIPTION
This is the same issue as #37 but for orogen_loaders branch. Also a second commit is included. See below for the reason.

When there is a TaskContext that is a driver for multiple Device types, an error like the following occures during instanciation of one the names Devices.

```
cannot find a device to tie to 1 task(s)
for TrajectoryGeneration::TestPlant:0xb110e58{something_dev => device(Devices::Device1, :as => hi), conf => [default]}[]
  no candidates for TrajectoryGeneration::TestPlant:something,
  no candidates for TrajectoryGeneration::TestPlant:something_else
```

Here is a code snippet to illustrate the situation.

```
using_task_library 'trajectory_generation'

module Devices
   device_type "Device1"
   device_type "Device2"
end

TrajectoryGeneration::TestPlant.driver_for Devices::Device1, :as => "something"
TrajectoryGeneration::TestPlant.driver_for Devices::Device2, :as => "something_else"

module Profiles
profile "Test" do
    robot do
        device(Devices::Device1, :as => "hi")
    end
end
end
```
I assume this supposed to be supported Syskit and there was just a bug in the changed line of code of the first commit.

---

When we have a second device, that provides the other driver, during isntanciation now another error occures. The second driver is also automatically assigned to the first device:

```
 robot do
        device(Devices::Device1, :as => "hi").with_conf('hi')
        device(Devices::Device2, :as => "hu").with_conf('hu')
    end
```
```
/media/data/Development/BesMan-orogen_loaders/tools/syskit/lib/syskit/network_generation/engine.rb:542:in `block (2 levels) in verify_device_allocation': device hu is assigned to both TrajectoryGeneration::TestPlant:0xbfdbce4{something_dev => device(Devices::Device1, :as => hi), conf => [hi], something_else_dev => device(Devices::Device2, :as => hu)}[] and TrajectoryGeneration::TestPlant:0xc5fff08{something_dev => device(Devices::Device1, :as => hi), conf => [hi], dummy_velocity_dev => device(Devices::Device2, :as => hu)}[], and the tasks refuse to be merged (Syskit::SpecError)
```

The second commit deals with this by removing automatic assignment of drivers to devices. Probably there's also another way to achive this.. this solution seems to work for me, but other suggestions are welcome.
