### PR TITLE
Fullfills? function for MasterDeviceInstance

### DIFF
--- a/lib/syskit/robot/master_device_instance.rb
+++ b/lib/syskit/robot/master_device_instance.rb
@@ -274,6 +274,10 @@ module Syskit
                 device_model.each_fullfilled_model(&block)
             end
 
+            def fullfills?(ds)
+                device_model.fullfills?(ds)
+            end
+
             DRoby = Struct.new :name, :device_model, :driver_model do
                 def proxy(peer)
                     MasterDeviceInstance.new(nil, name, peer.local_object(device_model), Hash.new, peer.local_object(driver_model), Hash.new)


### PR DESCRIPTION
This patch creates a `fullfills?` function within `MaserDeviceInstance`. It just calls the corresponding `fullfills?` function of it's member `device_model`.

I allows operations like `my_device_dev.fullfills? Services::MyService` as when working with `InstanceRequirements` or `Compositions` etc.. Thus it creates more consitency.