### PR TITLE
Orocos::HTML is now named OroGen::HTML (cf. tools/orogen)

### DIFF
--- a/lib/syskit/gui/model_views/task_context.rb
+++ b/lib/syskit/gui/model_views/task_context.rb
@@ -7,7 +7,7 @@ module Syskit::GUI
             def initialize(page)
                 super(page)
                 @task_model_view = Roby::GUI::ModelViews::Task.new(page)
-                @orogen_rendering = Orocos::HTML::TaskContext.new(page)
+                @orogen_rendering = OroGen::HTML::TaskContext.new(page)
                 buttons = Array.new
                 buttons.concat(self.class.common_graph_buttons('interface'))
                 Syskit::Graphviz.available_task_annotations.sort.each do |ann_name|

--- a/lib/syskit/gui/model_views/type.rb
+++ b/lib/syskit/gui/model_views/type.rb
@@ -8,7 +8,7 @@ module Syskit::GUI
             def initialize(page)
                 super()
                 @page = page
-                @type_rendering = Orocos::HTML::Type.new(page)
+                @type_rendering = OroGen::HTML::Type.new(page)
             end
 
             def enable


### PR DESCRIPTION
Already some time ago ```OroGen::HTML``` was renamed to ```OroGen::HTML``` (https://github.com/orocos-toolchain/orogen/commit/68377afa9d93ca7304ce74f30f84af7b5ce5d2cc). Syskit still used the old naming in  ```lib/syskit/gui/model_views/task_context.rb```
 and ```lib/syskit/gui/model_views/type.rb```
