### PR TITLE
connect_to_orocos_process_server failed to create Orocos::RemoteProcesses::Client

### DIFF
--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -1,4 +1,5 @@
 require 'orocos/ruby_process_server'
+require 'orocos/remote_processes/client'
 module Syskit
     module RobyApp
         # Syskit engine configuration interface


### PR DESCRIPTION
Added missing require statement to include Orocos::RemoteProcesses::Client.

See also #43