### PR TITLE
Allow to specify remote targets for deployments

### DIFF
--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -407,7 +407,7 @@ module Syskit
             # @see #use_deployment
             def use_deployments_from(project_name, options = Hash.new)
                 Syskit.info "using deployments from #{project_name}"
-                orogen = app.using_task_library(project_name, options)
+                orogen = app.using_task_library(project_name, options[:loader])
 
                 result = []
                 orogen.deployers.each_value do |deployment_def|

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -350,7 +350,7 @@ module Syskit
             #   the model for the deployment will be loaded from that process
             #   server
             def using_deployment(name, options = Hash.new)
-                options = Kernel.validate_options options, :loader => default_loader
+                options = Kernel.validate_options options, :loader => default_loader, :on => "localhost"
                 deployer = options[:loader].deployment_model_from_name(name)
                 deployment_define_from_orogen(deployer)
             end

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -265,7 +265,7 @@ module Syskit
             #
             # @return [OroGen::Spec::Project]
             def using_task_library(name, options = Hash.new)
-                options = Kernel.validate_options options, :loader => default_loader, :on => 'localhost'
+                options = Kernel.validate_options options, :loader => default_loader
                 options[:loader].project_model_from_name(name)
             end
 
@@ -344,13 +344,8 @@ module Syskit
 
             # Loads the oroGen deployment model for the given name and returns
             # the corresponding syskit model
-            #
-            # @option options [String] :on the name of the process server this
-            #   deployment should be on. It is used for loading as well, i.e.
-            #   the model for the deployment will be loaded from that process
-            #   server
             def using_deployment(name, options = Hash.new)
-                options = Kernel.validate_options options, :loader => default_loader, :on => "localhost"
+                options = Kernel.validate_options options, :loader => default_loader
                 deployer = options[:loader].deployment_model_from_name(name)
                 deployment_define_from_orogen(deployer)
             end

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -265,7 +265,7 @@ module Syskit
             #
             # @return [OroGen::Spec::Project]
             def using_task_library(name, options = Hash.new)
-                options = Kernel.validate_options options, :loader => default_loader
+                options = Kernel.validate_options options, :loader => default_loader, :on => 'localhost'
                 options[:loader].project_model_from_name(name)
             end
 


### PR DESCRIPTION
``` Syskit.conf.use_deployments_from("aila_vision_deployments", :on => "vision_cpu")``` led to the following error:
```
= /home/sempromuser/RockDev/tools/syskit/lib/syskit/roby_app/plugin.rb:268:in `using_task_library': unknown options 'on' (ArgumentError)
= Backtrace
| 
|   /home/sempromuser/RockDev/tools/syskit/lib/syskit/roby_app/plugin.rb:268:in `using_task_library'
|   /home/sempromuser/RockDev/tools/syskit/lib/syskit/roby_app/configuration.rb:410:in `use_deployments_from'
|   ./models/profiles/aila.rb:29:in `<top (required)>'
|   /home/sempromuser/RockDev/tools/syskit/bin/syskit:19:in `<main>'
```

This this PR fixes the problem by adding ```:on => "localhost"``` to the optione evaluation in ```using_task_library``` and ```using_deployment```