### PR TITLE
Allow compositions to be device drivers

### DIFF
--- a/lib/syskit/robot/robot_definition.rb
+++ b/lib/syskit/robot/robot_definition.rb
@@ -131,7 +131,7 @@ module Syskit
                     # concrete task model. So, search for one.
                     #
                     # Get all task models that implement this device
-                    tasks = TaskContext.submodels.
+                    tasks = Component.submodels.
                         find_all { |t| t.fullfills?(device_model) }
 
                     # Now, get the most abstract ones


### PR DESCRIPTION
Previously only single TaskContexts could be used as device drivers. This PR allows also the assignment of compositions as driver for a device.

Two changes have been made:
1) search for Components (not TaskContexts), that fullfill the device model in RobotDefinition.device
2) Allow to specify a use-statement for devices. The given dependency hash is applied in MasterDeviceIsntance.to_instance_requirements only for Compositions (not for task contexts)