### PR TITLE
gui: start the syskit ide subcommand

### DIFF
--- a/lib/syskit/gui/browse.rb
+++ b/lib/syskit/gui/browse.rb
@@ -1,0 +1,36 @@
+require 'syskit/gui/model_browser'
+module Syskit
+    module GUI
+        class Browse < Qt::Widget
+            attr_reader :main_layout
+            attr_reader :btn_reload_models
+            attr_reader :model_browser
+
+            def initialize(parent = nil)
+                super
+                @main_layout = Qt::VBoxLayout.new(self)
+
+                @model_browser = ModelBrowser.new(self)
+                @btn_reload_models = Qt::PushButton.new("Reload Models", self)
+
+                main_layout.add_widget btn_reload_models
+                main_layout.add_widget model_browser
+
+                btn_reload_models.connect(SIGNAL('clicked()')) do
+                    model_browser.registered_exceptions.clear
+                    Roby.app.clear_exceptions
+                    Roby.app.reload_models
+                    model_browser.update_exceptions
+                    model_browser.reload
+                end
+
+                model_browser
+            end
+
+            def select_by_module(mod)
+                model_browser.select_by_module(mod)
+            end
+        end
+    end
+end
+

--- a/lib/syskit/gui/ide.rb
+++ b/lib/syskit/gui/ide.rb
@@ -1,0 +1,92 @@
+require 'Qt'
+require 'open3'
+require 'syskit/gui/model_browser'
+require 'shellwords'
+module Syskit
+    module GUI
+        # The main Syskit IDE window
+        class IDE < Qt::Widget
+            attr_reader :layout
+            attr_reader :btn_reload_models
+            attr_reader :tab_widget
+            attr_reader :model_browser
+
+            def initialize(parent = nil)
+                super
+
+                @layout = Qt::VBoxLayout.new(self)
+                @tab_widget = Qt::TabWidget.new(self)
+                @model_browser = ModelBrowser.new
+                @btn_reload_models = Qt::PushButton.new("Reload Models", self)
+
+                connect(model_browser, SIGNAL('fileOpenClicked(const QUrl&)'),
+                        self, SLOT('fileOpenClicked(const QUrl&)'))
+
+                layout.add_widget btn_reload_models
+                layout.add_widget tab_widget
+                tab_widget.add_tab model_browser, "Browse"
+
+                model_browser.model_selector.filter_box.set_focus(Qt::OtherFocusReason)
+
+                btn_reload_models.connect(SIGNAL('clicked()')) do
+                    model_browser.registered_exceptions.clear
+                    Roby.app.clear_exceptions
+                    Roby.app.reload_models
+                    model_browser.update_exceptions
+                    model_browser.reload
+                end
+            end
+
+            def global_settings
+                @global_settings ||= Qt::Settings.new('syskit')
+            end
+
+            def settings
+                @settings ||= Qt::Settings.new('syskit', 'ide')
+            end
+
+            def restore_from_settings(settings = self.settings)
+                self.size = settings.value("MainWindow/size", Qt::Variant.new(Qt::Size.new(800, 600))).to_size
+                %w{model_browser}.each do |child_object_name|
+                    settings.begin_group(child_object_name)
+                    begin
+                        send(child_object_name).restore_from_settings(settings)
+                    ensure
+                        settings.end_group
+                    end
+                end
+            end
+            def save_to_settings(settings = self.settings)
+                settings.set_value("MainWindow/size", Qt::Variant.new(size))
+                %w{model_browser}.each do |child_object_name|
+                    settings.begin_group(child_object_name)
+                    begin
+                        send(child_object_name).save_to_settings(settings)
+                    ensure
+                        settings.end_group
+                    end
+                end
+            end
+
+            def fileOpenClicked(url)
+                edit_cmd = global_settings.value('Main/cmdline', Qt::Variant.new)
+                if edit_cmd.null?
+                    Qt::MessageBox.warning(self, "Edit File", "No editor configured to open file #{url.to_string}. Edit #{global_settings.file_name} and add a cmdline= line in the [Main] section there. The %PATH and %LINENO placeholders will be replaced (if present) by the path and line number that should be edited")
+                else
+                    edit_cmd = edit_cmd.to_string.
+                        gsub("%FILEPATH", url.to_local_file).
+                        gsub("%LINENO", url.query_item_value('lineno'))
+
+                    edit_cmd = Shellwords.shellsplit(edit_cmd)
+                    stdin, stdout, stderr, wait_thr = Open3.popen3(*edit_cmd)
+                    status = wait_thr.value
+                    if !status.success?
+                        Qt::MessageBox.warning(self, "Edit File", "Runninga \"#{edit_cmd.join('" "')}\" failed\n\nProcess reported: #{stderr.read}")
+                    end
+                end
+            end
+            slots 'fileOpenClicked(const QUrl&)'
+        end
+    end
+end
+

--- a/lib/syskit/gui/model_browser.rb
+++ b/lib/syskit/gui/model_browser.rb
@@ -1,3 +1,4 @@
+require 'syskit'
 require 'metaruby/gui'
 require 'syskit/gui/model_views'
 require 'syskit/gui/page'
@@ -19,18 +20,18 @@ module Syskit
             def initialize(parent = nil)
                 super
 
+                if ENV['SYSKIT_GUI_DEBUG_HTML']
+                    display.page.settings.setAttribute(Qt::WebSettings::DeveloperExtrasEnabled, true)
+                    @inspector = Qt::WebInspector.new
+                    @inspector.page = display.page
+                    @inspector.show
+                end
+
+                page.load_javascript File.expand_path("composer_buttons.js", File.dirname(__FILE__))
                 AVAILABLE_VIEWS.each do |view|
                     register_type(view.root_model, view.renderer, view.name, view.priority)
                 end
                 update_model_selector
-
-                btn_reload_models.connect(SIGNAL('clicked()')) do
-                    registered_exceptions.clear
-                    Roby.app.clear_exceptions
-                    Roby.app.reload_models
-                    update_exceptions
-                    model_selector.reload
-                end
             end
 
             def registered_exceptions

--- a/lib/syskit/gui/model_views/profile.rb
+++ b/lib/syskit/gui/model_views/profile.rb
@@ -144,13 +144,12 @@ module Syskit::GUI
                         text = ModelViews.render_mapping(page, key, object)
                         key_text, value_text = text.first.split(" => ")
                         text[0] = "%s => #{value_text}"
-                        Element.new(object, "<pre>#{text.join("\n")}</pre>", id, key_text, Hash.new)
+                        Element.new(object, "<pre>#{text.join("\n")}</pre>", id, key_text, Hash.new(buttons: []), Hash.new)
                     else
-                        Element.new(object, "%s", id, key, Hash.new)
+                        Element.new(object, "%s", id, key, Hash.new(buttons: []), Hash.new)
                     end
                 end
             end
-
 
             def compute_toplevel_links(model, options)
                 explicit_selections = mapping_to_links(

--- a/lib/syskit/scripts/ide.rb
+++ b/lib/syskit/scripts/ide.rb
@@ -1,14 +1,11 @@
+require 'syskit/gui/ide'
 require 'roby/standalone'
 require 'syskit/scripts/common'
-require 'Qt'
-require 'syskit/gui/browse'
-
-Scripts = Syskit::Scripts
 
 load_all = false
 parser = OptionParser.new do |opt|
     opt.banner = <<-EOD
-Usage: browse [file] [options]
+Usage: ide [file] [options]
 Loads the models from this bundle and allows to browse them. If a file is given, only this file is loaded.
     EOD
 
@@ -16,7 +13,7 @@ Loads the models from this bundle and allows to browse them. If a file is given,
         load_all = true
     end
 end
-Scripts.common_options(parser, true)
+Syskit::Scripts.common_options(parser, true)
 remaining = parser.parse(ARGV)
 
 # We don't need the process server, win some startup time
@@ -34,30 +31,16 @@ Roby.app.auto_load_models = direct_files.empty?
 Roby.app.additional_model_files.concat(direct_files)
 
 app = Qt::Application.new(ARGV)
-settings = Qt::Settings.new('syskit', '')
 
-Scripts.run do
+Syskit::Scripts.run do
     Roby.app.syskit_engine.prepare
-    main = Syskit::GUI::Browse.new
+    main = Syskit::GUI::IDE.new
 
-    # Select the model given on the command line (if any)
-    if !model_names.empty?
-        model = begin
-                    constant(model_names.first)
-                rescue NameError
-                    Syskit.warn "cannot find a model named #{remaining.first}"
-                end
-        if model
-            main.select_by_module(model)
-        end
-    end
-
-    size = settings.value("MainWindow/size", Qt::Variant.new(Qt::Size.new(800, 600))).to_size
-    main.resize(size)
+    main.restore_from_settings
     main.show
     $qApp.exec
-    settings.setValue('MainWindow/size', Qt::Variant.new(main.size))
-    settings.sync
+    main.save_to_settings
+    main.settings.sync
 end
 
 

--- a/lib/syskit/scripts/ide.rb
+++ b/lib/syskit/scripts/ide.rb
@@ -35,6 +35,7 @@ app = Qt::Application.new(ARGV)
 Syskit::Scripts.run do
     Roby.app.syskit_engine.prepare
     main = Syskit::GUI::IDE.new
+    main.window_title = "Syskit IDE - #{Roby.app.app_name}"
 
     main.restore_from_settings
     main.show


### PR DESCRIPTION
syskit ide will in term replace syskit browse, but not quite yet.

For now, this is mostly like syskit browse, but with bugfixes, and with
the ability to open files in an external editor (needs some configuration)

Closes #63