### PR TITLE
support compositions as device drivers (closes #47)

### DIFF
--- a/lib/syskit/instance_requirements.rb
+++ b/lib/syskit/instance_requirements.rb
@@ -501,7 +501,7 @@ module Syskit
             end
 
             # Specifies new arguments that must be set to the instanciated task
-            def with_arguments(arguments)
+            def with_arguments(**arguments)
                 @arguments.merge!(arguments)
                 self
             end

--- a/lib/syskit/instance_requirements.rb
+++ b/lib/syskit/instance_requirements.rb
@@ -501,7 +501,7 @@ module Syskit
             end
 
             # Specifies new arguments that must be set to the instanciated task
-            def with_arguments(**arguments)
+            def with_arguments(arguments)
                 @arguments.merge!(arguments)
                 self
             end

--- a/lib/syskit/models/data_service.rb
+++ b/lib/syskit/models/data_service.rb
@@ -358,7 +358,7 @@ module Syskit
                 # concrete task model. So, search for one.
                 #
                 # Get all task models that implement this device
-                Syskit::TaskContext.submodels.
+                Syskit::Component.submodels.
                     find_all { |t| t.fullfills?(self) && !t.abstract? }
             end
 

--- a/lib/syskit/robot/master_device_instance.rb
+++ b/lib/syskit/robot/master_device_instance.rb
@@ -32,8 +32,6 @@ module Syskit
             # The driver for this device
             # @return [BoundDataService]
             attr_reader :driver_model
-            # The task arguments
-            attr_reader :task_arguments
             # Configuration data structure
             attr_reader :configuration
             # Block given to #configure to configure the device. It will be
@@ -52,9 +50,10 @@ module Syskit
                 @slaves      = Hash.new
                 @conf = Array.new
                 @com_busses = Array.new
-                @requirements = Syskit::InstanceRequirements.new
+                @requirements = Syskit::InstanceRequirements.new([driver_model.to_component_model])
+                requirements.with_arguments(:"#{driver_model.name}_dev" => self)
+                requirements.with_arguments(**task_arguments)
 
-                task_arguments["#{driver_model.name}_dev"] = self
                 sample_size 1
                 burst   0
             end
@@ -76,7 +75,7 @@ module Syskit
             # Declares that the following configuration chain should be used for
             # this device
             def with_conf(*conf)
-                task_arguments[:conf] = conf
+                requirements.with_conf(*conf)
                 self
             end
 
@@ -246,10 +245,18 @@ module Syskit
                 super
             end
 
+            # If this device's driver is a composition, allows to specify
+            # dependency injections for it
+            def use(dependency_injection)
+                requirements.use(dependency_injection)
+            end
+
+            # Specify frame selection for the device's driver
             def use_frames(frame_mappings)
                 requirements.use_frames(frame_mappings)
             end
 
+            # Specify deployment selection hints for the device's driver
 	    def prefer_deployed_tasks(hints)
 		requirements.prefer_deployed_tasks(hints)
 		self
@@ -264,9 +271,9 @@ module Syskit
             # Returns the InstanceRequirements object that can be used to
             # represent this device
             def to_instance_requirements
-                driver_model.to_instance_requirements.dup.
-                    with_arguments(task_arguments).
-                    merge(requirements)
+                result = requirements.dup
+                result.select_service(driver_model)
+                result
             end
 
             def as_plan; to_instance_requirements.as_plan end

--- a/lib/syskit/robot/master_device_instance.rb
+++ b/lib/syskit/robot/master_device_instance.rb
@@ -45,13 +45,16 @@ module Syskit
 
             def initialize(robot, name, device_model, options,
                            driver_model, task_arguments)
-                @robot, @name, @device_model, @driver_model, @task_arguments =
-                    robot, name, device_model, driver_model, task_arguments
+                @robot, @name, @device_model, @task_arguments =
+                    robot, name, device_model, task_arguments
                 @slaves      = Hash.new
                 @conf = Array.new
                 @com_busses = Array.new
-                @requirements = Syskit::InstanceRequirements.new([driver_model.to_component_model])
-                requirements.with_arguments(:"#{driver_model.name}_dev" => self)
+
+                driver_model = driver_model.to_instance_requirements
+                @driver_model = driver_model.service
+                @requirements = driver_model.to_component_model
+                requirements.with_arguments("#{driver_model.service.name}_dev" => self)
                 requirements.with_arguments(**task_arguments)
 
                 sample_size 1

--- a/lib/syskit/robot/robot_definition.rb
+++ b/lib/syskit/robot/robot_definition.rb
@@ -142,6 +142,7 @@ module Syskit
                     end
                 end
 
+                driver_model = driver_model.to_instance_requirements
                 device_instance = options[:class].new(
                     self, name, device_model, device_options,
                     driver_model, root_task_arguments)
@@ -150,7 +151,7 @@ module Syskit
                 device_model.apply_device_configuration_extensions(devices[name])
 
                 # And register all the slave services there is on the driver
-                driver_model.each_slave_data_service do |slave_service|
+                driver_model.service.each_slave_data_service do |slave_service|
                     slave_device = SlaveDeviceInstance.new(devices[name], slave_service)
                     device_instance.slaves[slave_service.name] = slave_device
                     devices["#{name}.#{slave_service.name}"] = slave_device

--- a/test/robot/test_robot_definition.rb
+++ b/test/robot/test_robot_definition.rb
@@ -2,53 +2,48 @@ require 'syskit/test/self'
 
 describe Syskit::Robot::RobotDefinition do
     describe "#device" do
-        attr_reader :device_m
+        attr_reader :device_m, :driver_m
         before do
             @device_m = Syskit::Device.new_submodel
+            @driver_m = Syskit::TaskContext.new_submodel
+            driver_m.driver_for device_m, as: 'driver_srv'
         end
 
         it "creates an object of type MasterDeviceInstance by default" do
-            driver_model = flexmock(name: 'dev_srv', each_slave_data_service: nil)
-            assert_kind_of Syskit::Robot::MasterDeviceInstance, robot.device(device_m, using: driver_model, as: 'dev')
+            assert_kind_of Syskit::Robot::MasterDeviceInstance, robot.device(device_m, using: driver_m, as: 'dev')
         end
         it "raises ArgumentError if given a task model that is not a driver for the device model" do
             driver_m = Syskit::TaskContext.new_submodel
             assert_raises(ArgumentError) { robot.device(device_m, using: driver_m, as: 'dev') }
         end
         it "registers the new device" do
-            driver_model = flexmock(name: 'dev_srv', each_slave_data_service: nil)
-            device = robot.device(device_m, using: driver_model, as: 'dev')
+            device = robot.device(device_m, using: driver_m, as: 'dev')
             assert_same device, robot.devices['dev']
         end
         it "sets the task argument that binds the driver service to the device" do
-            driver_model = flexmock(name: 'dev_srv', each_slave_data_service: nil)
-            device = robot.device(device_m, using: driver_model, as: 'dev')
-            assert_equal Hash['dev_srv_dev' => device], device.task_arguments
+            device = robot.device(device_m, using: driver_m, as: 'dev')
+            assert_same device, device.requirements.arguments['driver_srv_dev']
         end
         it "validates the given service model against Device by default" do
-            driver_model = flexmock(name: 'dev_srv', each_slave_data_service: nil)
             flexmock(device_m).should_receive(:<).with(Syskit::Device).and_return(false).once
             assert_raises(ArgumentError) do
-                robot.device(device_m, using: driver_model, as: 'dev')
+                robot.device(device_m, using: driver_m, as: 'dev')
             end
         end
         it "validates the given service model using the :expected_model option" do
             expected = flexmock
-            driver_model = flexmock(name: 'dev_srv', each_slave_data_service: nil)
             flexmock(device_m).should_receive(:<).with(expected).and_return(false).once
             assert_raises(ArgumentError) do
-                robot.device(device_m, using: driver_model, as: 'dev', expected_model: expected)
+                robot.device(device_m, using: driver_m, as: 'dev', expected_model: expected)
             end
         end
         it "creates an object of the type given to its :class option" do
-            driver_model = flexmock(name: 'dev_srv', each_slave_data_service: nil)
             klass = flexmock
             klass.should_receive(:new).once.and_return(obj = Object.new)
-            assert_same obj, robot.device(device_m, using: driver_model, as: 'dev', class: klass)
+            assert_same obj, robot.device(device_m, using: driver_m, as: 'dev', class: klass)
         end
         it "raises if no name has been given" do
-            driver_model = flexmock(name: 'dev_srv', each_slave_data_service: nil)
-            assert_raises(ArgumentError) { robot.device device_m, using: driver_model }
+            assert_raises(ArgumentError) { robot.device device_m, using: driver_m }
         end
         it "raises if a device with the given name already exists" do
             robot.devices['dev'] = Object.new
@@ -57,22 +52,21 @@ describe Syskit::Robot::RobotDefinition do
             end
         end
         it "resolves the actual driver service and gives it to the device object" do
-            driver_srv = flexmock(name: 'dev_srv', each_slave_data_service: nil)
-            driver_model = flexmock { |m| m.should_receive(:find_data_service_from_type).with(device_m).and_return(driver_srv) }
-            klass = flexmock { |m| m.should_receive(:new).with(any, any, any, any, driver_srv, any).once }
-            robot.device device_m, using: driver_model, as: 'dev', class: klass
+            task_m = Syskit::TaskContext.new_submodel
+            task_m.driver_for device_m, as: 'drv'
+            dev = robot.device(device_m, using: task_m, as: 'dev')
+            assert_equal task_m.drv_srv, dev.driver_model
         end
         it "registers all the slaves from the driver service" do
-            driver_model = flexmock(name: 'dev_srv')
-            driver_model.should_receive(:each_slave_data_service).and_yield(flexmock(name: 'slave'))
-            master = robot.device device_m, using: driver_model, as: 'dev'
+            task_m = Syskit::TaskContext.new_submodel
+            task_m.driver_for device_m, as: 'drv'
+            task_m.provides Syskit::DataService.new_submodel, as: 'slave', slave_of: 'drv'
+            master = robot.device device_m, using: task_m, as: 'dev'
             assert(slave = robot.devices["dev.slave"])
             assert_same master, slave.master_device
         end
 
         it "invalidates the dependency injection cache" do
-            driver_m = Syskit::TaskContext.new_submodel
-            driver_m.driver_for device_m, as: 'test'
             flexmock(robot).should_receive(:invalidate_dependency_injection).at_least.once
             robot.device device_m, as: 'test'
         end

--- a/test/suite_robot.rb
+++ b/test/suite_robot.rb
@@ -1,6 +1,3 @@
-if !ENV['SYSKIT_ENABLE_COVERAGE']
-    ENV['SYSKIT_ENABLE_COVERAGE'] = '1'
-end
 require 'syskit/test/self'
 
 require './test/robot/test_device'


### PR DESCRIPTION
The difference with the implementation in #47 is that we remove
the temporary variables for requirements & DI and directly build
an InstanceRequirements object under the hood. This adds validation
of the DI keys at the point where #use is called instead of doing
it later (and keeps the implementation if-free)