### PR TITLE
netgen: move handling of optional dependencies to network resolution

### DIFF
--- a/lib/syskit/dependency_injection.rb
+++ b/lib/syskit/dependency_injection.rb
@@ -317,7 +317,7 @@ module Syskit
                             end
                         end
                     end
-                    selected_requirements.merge(sel_m.to_component_model)
+                    selected_requirements.merge(sel_m.to_component_model, keep_abstract: true)
                 end
 
                 if selected_instance && !selected_instance.fullfills?(requirements, requirements.arguments)

--- a/lib/syskit/gui/model_views/composition.rb
+++ b/lib/syskit/gui/model_views/composition.rb
@@ -121,7 +121,6 @@ module Syskit::GUI
                     page.push nil, page.main_doc(model.doc)
                 end
 
-                super_options = super_options.merge(:instanciate_options => Hash[:keep_optional_children => true])
                 super(model, super_options)
                 task_model_view.render(model, :doc => false)
                 if task

--- a/lib/syskit/models/component.rb
+++ b/lib/syskit/models/component.rb
@@ -190,6 +190,20 @@ module Syskit
                 InstanceRequirements.new([self]).with_arguments(*spec, &block)
             end
 
+            # Optional dependency injection
+            #
+            # Returns an {InstanceRequirements} that you can use to inject
+            # optional dependencies that will be fullfilled only if there is
+            # already a matching task deployed in the plan
+            #
+            # This can only be meaningfully used when injected for a
+            # composition's optional child
+            #
+            # @return [InstanceRequirements]
+            def if_already_present
+                to_instance_requirements.if_already_present
+            end
+
             # @deprecated replaced by {prefer_deployed_tasks}
             def use_deployments(*selection)
                 prefer_deployed_tasks(*selection)

--- a/lib/syskit/models/data_service.rb
+++ b/lib/syskit/models/data_service.rb
@@ -29,6 +29,20 @@ module Syskit
                 port_mappings.clear
             end
 
+            # Optional dependency injection
+            #
+            # Returns an {InstanceRequirements} that you can use to inject
+            # optional dependencies that will be fullfilled only if there is
+            # already a matching task deployed in the plan
+            #
+            # This can only be meaningfully used when injected for a
+            # composition's optional child
+            #
+            # @return [InstanceRequirements]
+            def if_already_present
+                to_instance_requirements.if_already_present
+            end
+
             # @!attribute rw port_mappings
             #   Port mappings from this service's parent models to the service
             #   itself

--- a/lib/syskit/robot/master_device_instance.rb
+++ b/lib/syskit/robot/master_device_instance.rb
@@ -261,6 +261,11 @@ module Syskit
                 self
             end
 
+            def if_already_present
+                requirements.if_already_present
+                self
+            end
+
             # Returns the InstanceRequirements object that can be used to
             # represent this device
             def to_instance_requirements

--- a/test/network_generation/test_engine.rb
+++ b/test/network_generation/test_engine.rb
@@ -131,6 +131,59 @@ describe Syskit::NetworkGeneration::Engine do
         end
     end
 
+    describe "#compute_system_network" do
+        describe "handling of optional dependencies" do
+            attr_reader :cmp_m, :srv_m, :task_m, :syskit_engine
+            before do
+                @srv_m = Syskit::DataService.new_submodel
+                @cmp_m = Syskit::Composition.new_submodel
+                cmp_m.add_optional srv_m, as: 'test'
+                @task_m = Syskit::TaskContext.new_submodel
+                task_m.provides srv_m, as: 'test'
+            end
+
+            subject do
+                engine = Syskit::NetworkGeneration::Engine.new(plan)
+                engine.prepare
+                engine
+            end
+
+            def compute_system_network(*requirements)
+                tasks = requirements.map do |req|
+                    plan.add_mission(task = req.as_plan)
+                    task
+                end
+                subject.compute_system_network(tasks.map(&:planning_task), validate_generated_network: false)
+                tasks.each { |task| plan.remove_object(task) if plan.include?(task) }
+
+                cmp = plan.find_tasks(cmp_m).to_a
+                assert_equal 1, cmp.size
+                cmp.first
+            end
+
+            it "keeps the compositions' optional dependencies that are not abstract" do
+                cmp = compute_system_network(cmp_m.use('test' => task_m))
+                assert cmp.has_role?('test')
+            end
+            it "keeps the compositions' non-optional dependencies that are abstract" do
+                cmp_m.add srv_m, as: 'non_optional'
+                cmp = compute_system_network(cmp_m)
+                assert cmp.has_role?('non_optional')
+            end
+            it "removes the compositions' optional dependencies that are still abstract" do
+                cmp = compute_system_network(cmp_m)
+                assert !cmp.has_role?('test')
+            end
+            it "enables the use of the abstract flag in InstanceRequirements to use an optional dep only if it is instanciated by other means" do
+                cmp = compute_system_network(cmp_m.use('test' => task_m.to_instance_requirements.abstract))
+                assert !cmp.has_role?('test')
+                plan.remove_object(cmp)
+                cmp = compute_system_network(cmp_m.use('test' => task_m.to_instance_requirements.abstract), task_m)
+                assert cmp.has_role?('test')
+            end
+        end
+    end
+
     describe "#fix_toplevel_tasks" do
         attr_reader :original_task
         attr_reader :planning_task

--- a/test/test_dependency_injection.rb
+++ b/test/test_dependency_injection.rb
@@ -60,6 +60,20 @@ describe Syskit::DependencyInjection do
         end
     end
 
+    describe "#instance_selection_for" do
+        it "propagates the abstract flag" do
+            srv_m = Syskit::DataService.new_submodel
+            task_m = Syskit::TaskContext.new_submodel
+            task_m.provides srv_m, as: 'test'
+            di = Syskit::DependencyInjection.new('child' => task_m.to_instance_requirements.abstract)
+            assert di.instance_selection_for('child', task_m.to_instance_requirements)[0].selected.abstract?
+            di = Syskit::DependencyInjection.new(task_m => task_m.to_instance_requirements.abstract)
+            assert di.instance_selection_for(nil, task_m.to_instance_requirements)[0].selected.abstract?
+            di = Syskit::DependencyInjection.new('child' => srv_m.to_instance_requirements.abstract, srv_m => task_m)
+            assert di.instance_selection_for('child', task_m.to_instance_requirements)[0].selected.abstract?
+        end
+    end
+
     describe "#add" do
         attr_reader :di, :explicit_m, :default_m
         before do

--- a/test/test_instance_requirements.rb
+++ b/test/test_instance_requirements.rb
@@ -375,6 +375,18 @@ describe Syskit::InstanceRequirements do
                 once.pass_thru
             model_m.test_srv.to_instance_requirements.instanciate(plan, context)
         end
+
+        it "marks the task as abstract if abstract? is true" do
+            task_m = Syskit::Component.new_submodel
+            ir = task_m.to_instance_requirements.abstract
+            assert ir.instanciate(plan).abstract?
+        end
+
+        it "does not mark the task as abstract if abstract? is false" do
+            task_m = Syskit::Component.new_submodel
+            ir = task_m.to_instance_requirements
+            assert !ir.instanciate(plan).abstract?
+        end
     end
 
     describe "#unselect_service" do
@@ -438,6 +450,18 @@ describe Syskit::InstanceRequirements do
         end
         it "should keep the selected service if both have a compatible selection" do
             assert_equal task_m.test_srv, with_service.merge(with_service.dup).service
+        end
+        it "sets abstract? to false by default if any of the two IRs are not abstract" do
+            ir = task_m.to_instance_requirements.abstract.merge(task_m.to_instance_requirements)
+            assert !ir.abstract?
+            ir = task_m.to_instance_requirements.merge(task_m.to_instance_requirements.abstract)
+            assert !ir.abstract?
+        end
+        it "OR-ed abstract? if any of the two IRs is abstract and keep_abstract is true" do
+            ir = task_m.to_instance_requirements.abstract.merge(task_m.to_instance_requirements, keep_abstract: true)
+            assert ir.abstract?
+            ir = task_m.to_instance_requirements.merge(task_m.to_instance_requirements.abstract, keep_abstract: true)
+            assert ir.abstract?
         end
     end
 


### PR DESCRIPTION
So far, optional dependencies would be considered "not present" if,
at instanciation time, the dependency was not directly injected.

This is limited as the system network postprocessing is therefore not
allowed to actually replace non-selected optional dependencies by
implementations and have it picked up.

This commit moves the handling to #compute_system_network. This allows
to explicitely select services with tasks explicitely marked as abstract
(used as "matchers") which can then be replaced at network merge time.
E.g.

    cmp.use('optional' => Cmp.use('src' => a_device).if_already_present)

will keep the optional dependency if the composition is present, and
will remove it otherwise