### PR TITLE
Support explicit deselection in dependency injection

### DIFF
--- a/lib/syskit/actions/profile.rb
+++ b/lib/syskit/actions/profile.rb
@@ -68,6 +68,19 @@ module Syskit
             # @return [DependencyInjection]
             attr_reader :dependency_injection
 
+            # Dependency injection object that signifies "select nothing for
+            # this"
+            #
+            # This is used to override more generic selections, or to make sure
+            # that a compositions' optional child is not present
+            #
+            # @example disable the optional 'pose' child of Camera composition
+            #   Compositions::Camera.use('pose' => nothing)
+            #
+            def nothing
+                DependencyInjection.nothing
+            end
+
             # Robot definition class inside a profile
             #
             # It is subclassed so that we can invalidate the cached dependency

--- a/lib/syskit/dependency_injection.rb
+++ b/lib/syskit/dependency_injection.rb
@@ -274,8 +274,9 @@ module Syskit
                 used_keys = Set.new
                 selected_services = Hash.new
                 selections = Set.new
-                if name && (sel = selection[name])
+                if name && selection.has_key?(name)
                     used_keys << name
+                    sel = selection[name] || requirements
                     selections << sel
                     selection.each do |key, value|
                         next if !value.respond_to?(:component_model) || value.component_model != sel

--- a/lib/syskit/dependency_injection.rb
+++ b/lib/syskit/dependency_injection.rb
@@ -139,13 +139,13 @@ module Syskit
 
             def add_mask(mask)
                 mask.each do |key|
-                    explicit[key] = nil
+                    explicit[key] = DependencyInjection.do_not_inherit
                 end
             end
 
             # True if there is an explicit selection for the given name
             def has_selection_for?(name)
-                !!explicit[name]
+                !!direct_selection_for(name)
             end
             
             # Normalizes an explicit selection
@@ -155,9 +155,9 @@ module Syskit
             #
             # A normalized selection has this form:
             #
-            # * string to String,Component,DataService,BoundDataService,nil
-            # * Component to String,Component,nil
-            # * DataService to String,DataService,BoundDataService,nil
+            # * string to String,{Component},{DataService},{BoundDataService},{.do_not_inherit},{.nothing}
+            # * Component to String,{Component},{.do_not_inherit},{.nothing}
+            # * DataService to String,{DataService},{BoundDataService},{.do_not_inherit},{.nothing}
             #
             # @raise ArgumentError if the key and value are not valid
             #   selection (see above)
@@ -240,7 +240,9 @@ module Syskit
 
             def direct_selection_for(obj)
                 if defaults.empty?
-                    self.explicit[obj]
+                    if (sel = self.explicit[obj]) && sel != DependencyInjection.do_not_inherit
+                        sel
+                    end
                 else
                     @resolved ||= resolve
                     return @resolved.direct_selection_for(obj)
@@ -274,9 +276,11 @@ module Syskit
                 used_keys = Set.new
                 selected_services = Hash.new
                 selections = Set.new
-                if name && selection.has_key?(name)
+                if name && (sel = selection[name]) && (sel != DependencyInjection.do_not_inherit)
                     used_keys << name
-                    sel = selection[name] || requirements
+                    if sel == DependencyInjection.nothing
+                        sel = requirements
+                    end
                     selections << sel
                     selection.each do |key, value|
                         next if !value.respond_to?(:component_model) || value.component_model != sel
@@ -289,10 +293,12 @@ module Syskit
                     end
                 else
                     requirements.each_required_model do |required_m|
-                        if selected = selection[required_m]
+                        if sel = direct_selection_for(required_m)
+                            selections << [sel, required_m]
                             used_keys << required_m
+                        else
+                            selections << [required_m, required_m]
                         end
-                        selections << [(selected || required_m), required_m]
                     end
                 end
 
@@ -467,6 +473,20 @@ module Syskit
                 explicit.each_key(&block)
             end
 
+            class SpecialDIValue
+                def initialize(name); @name = name end
+                def to_s; "DependencyInjection.#{@name}" end
+                def inspect; to_s end
+            end
+
+            def self.do_not_inherit
+                @do_not_inherit ||= SpecialDIValue.new('do_not_inherit')
+            end
+
+            def self.nothing
+                @nothing ||= SpecialDIValue.new('nothing')
+            end
+
             # Helper method that resolves recursive selections in a dependency
             # injection mapping
             def self.resolve_recursive_selection_mapping(spec)
@@ -477,7 +497,7 @@ module Syskit
 
             # Helper method that resolves one single object recursively
             def self.resolve_selection_recursively(value, spec)
-                while !value.respond_to?(:to_str)
+                while value && !value.respond_to?(:to_str)
                     case value
                     when Models::BoundDataService
                         return value if !value.component_model.kind_of?(Class)
@@ -502,14 +522,17 @@ module Syskit
             ROOT_MODELS = [TaskContext, Component, Composition]
 
             def self.normalize_selected_object(value, key = nil)
-                return if !value
+                if !value
+                    raise ArgumentError, "found nil as selection for #{key}, but it is not accepted anymore"
+                end
 
                 if value.kind_of?(InstanceSelection)
                     value = value.component || value.selected
                 end
 
-                # 'value' must be one of String,Model<Component>,Component,DataService,Model<BoundDataService>,BoundDataService or nil
+                # 'value' must be one of String,Model<Component>,Component,DataService,Model<BoundDataService>,BoundDataService
                 if !value.respond_to?(:to_str) &&
+                    !value.kind_of?(SpecialDIValue) &&
                     !value.kind_of?(Component) &&
                     !value.kind_of?(BoundDataService) &&
                     !value.kind_of?(Models::BoundDataService) &&
@@ -520,9 +543,9 @@ module Syskit
                         value = value.to_instance_requirements
                     else
                         if key
-                            raise ArgumentError, "found #{value}(of class #{value.class}) as a selection for #{key}, but only nil,name,component models,components,data service models and bound data services are allowed"
+                            raise ArgumentError, "found #{value}(of class #{value.class}) as a selection for #{key}, but only name,component models,components,data service models and bound data services are allowed"
                         else
-                            raise ArgumentError, "found #{value}(of class #{value.class}) as a selection, but only nil,name,component models,components,data service models and bound data services are allowed"
+                            raise ArgumentError, "found #{value}(of class #{value.class}) as a selection, but only name,component models,components,data service models and bound data services are allowed"
                         end
                     end
                 end

--- a/lib/syskit/instance_requirements.rb
+++ b/lib/syskit/instance_requirements.rb
@@ -644,11 +644,9 @@ module Syskit
                     # Add a barrier for the names that our models expect. This is
                     # required to avoid recursively reusing names (which was once
                     # upon a time, and is a very confusing feature)
-                    barrier = Hash.new
-                    self.proxy_task_model.dependency_injection_names.each do |n|
-                        barrier[n] = nil
-                    end
-                    context.push(Syskit::DependencyInjection.new(barrier))
+                    barrier = Syskit::DependencyInjection.new
+                    barrier.add_mask(self.proxy_task_model.dependency_injection_names)
+                    context.push(barrier)
                     context.push(pushed_selections)
                     context.push(selections)
                     @di = context.current_state

--- a/test/models/test_composition.rb
+++ b/test/models/test_composition.rb
@@ -471,6 +471,21 @@ describe Syskit::Models::Composition do
             refute_kind_of cmp_m, task.test_child.test_child
         end
 
+        it "instanciates using the child's plain model if the child has been explicitely selected to nil" do
+            srv_m = Syskit::DataService.new_submodel
+            task_m = Syskit::TaskContext.new_submodel
+            task_m.provides srv_m, as: 'test'
+            cmp_m = Syskit::Composition.new_submodel
+            cmp_m.add srv_m, as: 'test'
+            cmp_m.add srv_m, as: 'control'
+
+            context = Syskit::DependencyInjectionContext.new(
+                Syskit::DependencyInjection.new('test' => nil, srv_m => task_m))
+            task = cmp_m.instanciate(plan, context)
+            assert_kind_of Syskit.proxy_task_model_for([srv_m]), task.test_child
+            assert_kind_of task_m, task.control_child
+        end
+
         describe "dependency relation definition based on information in the child definition" do
             attr_reader :composition_m, :srv_child
             before do

--- a/test/models/test_composition.rb
+++ b/test/models/test_composition.rb
@@ -480,7 +480,7 @@ describe Syskit::Models::Composition do
             cmp_m.add srv_m, as: 'control'
 
             context = Syskit::DependencyInjectionContext.new(
-                Syskit::DependencyInjection.new('test' => nil, srv_m => task_m))
+                Syskit::DependencyInjection.new('test' => Syskit::DependencyInjection.nothing, srv_m => task_m))
             task = cmp_m.instanciate(plan, context)
             assert_kind_of Syskit.proxy_task_model_for([srv_m]), task.test_child
             assert_kind_of task_m, task.control_child

--- a/test/test_dependency_injection.rb
+++ b/test/test_dependency_injection.rb
@@ -58,6 +58,14 @@ describe Syskit::DependencyInjection do
             _, _, service_selections = di.selection_for('child', Syskit::InstanceRequirements.new([base_srv_m]))
             assert_equal task_m.test_srv, service_selections[base_srv_m]
         end
+        it "will accept nil as a selection, thus overriding more general selections" do
+            srv_m  = Syskit::DataService.new_submodel
+            task_m = Syskit::TaskContext.new_submodel
+            task_m.provides srv_m, as: 'test'
+            di = Syskit::DependencyInjection.new('child' => nil, srv_m => task_m)
+            _, requirements, _ = di.selection_for('child', srv_m.to_instance_requirements)
+            assert_equal Syskit.proxy_task_model_for([srv_m]), requirements.model
+        end
     end
 
     describe "#add" do

--- a/test/test_dependency_injection_context.rb
+++ b/test/test_dependency_injection_context.rb
@@ -1,6 +1,6 @@
 require 'syskit/test/self'
 
-describe Syskit::DependencyInjection do
+describe Syskit::DependencyInjectionContext do
     describe "#push" do
         it "applies explicit choices recursively layer-by-layer" do
             srv0 = Syskit::DataService.new_submodel
@@ -28,6 +28,24 @@ describe Syskit::DependencyInjection do
             context.push di0
             context.push di1
             assert_equal task0.test_srv, context.current_state.explicit[srv0]
+        end
+
+        it "allows to add barriers on name-to-selection mapping to avoid recursive name-based selection" do
+            srv0 = Syskit::DataService.new_submodel
+            task0 = Syskit::TaskContext.new_submodel(name: 'T0') { provides srv0, as: 'test' }
+            task1 = Syskit::TaskContext.new_submodel(name: 'T1') { provides srv0, as: 'test' }
+            di0 = Syskit::DependencyInjection.new
+            di0.add('child' => task1, srv0 => task0)
+            di1 = Syskit::DependencyInjection.new
+            di1.add_mask(['child'])
+
+            context = Syskit::DependencyInjectionContext.new
+            context.push di0
+            context.push di1
+
+            _, component_model, service_selection, used_objects =
+                context.selection_for('child', srv0.to_instance_requirements)
+            assert_equal task0, component_model.model
         end
     end
 end


### PR DESCRIPTION
Closes https://github.com/rock-core/tools-syskit/issues/23

Interestingly, the profile-level API really does what the issue was asking: one can now choose 'nothing'

~~~
define 'bla', Bla.use('child' => nothing)
~~~