### PR TITLE
configure com busses to handle all their devices (even unattached ones) by default

### DIFF
--- a/lib/syskit/robot/communication_bus.rb
+++ b/lib/syskit/robot/communication_bus.rb
@@ -11,6 +11,20 @@ module Syskit
                 @attached_devices = Set.new
             end
 
+            def instanciate(plan, context = DependencyInjectionContext.new, **options)
+                service = super
+                task = service.to_task
+                if !device_model.lazy_dispatch?
+                    messages_direction = device_model.messages_direction
+                    each_attached_device do |dev|
+                        task.require_dynamic_service(
+                            device_model.dynamic_service_name,
+                            as: dev.name, direction: messages_direction)
+                    end
+                end
+                service
+            end
+
             def through(&block)
                 instance_eval(&block)
             end


### PR DESCRIPTION
Reconfiguring a com bus is really something that should be avoided at
all costs. The current policy would cause a reconfiguration each time
a device on the bus would be activated for the first time, which would
disrupt the already running devices.

The default policy, after this commit, is to create all dynamic
services on the bus that are required for all declared devices. One can
get the earlier behaviour by adding lazy_dispatch: true to the com bus
declaration.