### PR TITLE
Refactor connection management

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,13 +1,7 @@
-if ENV['SYSKIT_ENABLE_COVERAGE'] == '1'
-    SimpleCov.command_name 'syskit'
-    SimpleCov.start do
-        add_filter "/test/"
-        add_filter "/gui/"
-        add_filter "/scripts/"
-    end
-
-    require 'syskit'
-    Syskit.logger = Logger.new(File.open("/dev/null", 'w'))
-    Syskit.logger.level = Logger::DEBUG
+SimpleCov.command_name 'syskit'
+SimpleCov.start do
+  add_filter "/test/"
+  add_filter "/gui/"
+  add_filter "/scripts/"
 end
 

--- a/lib/syskit/connection_graphs.rb
+++ b/lib/syskit/connection_graphs.rb
@@ -118,6 +118,8 @@ module Syskit
                 end
                 if current_mappings.empty?
                     unlink(source_task, sink_task)
+                    remove(source_task) if leaf?(source_task) && root?(source_task)
+                    remove(sink_task)   if leaf?(sink_task)   && root?(sink_task)
                 else
                     # To make the relation system call #update_info
                     source_task[sink_task, self] = current_mappings

--- a/lib/syskit/deployment.rb
+++ b/lib/syskit/deployment.rb
@@ -3,6 +3,18 @@ module Deployments
 end
 
 module Syskit
+    module TaskContextPeekStateInterdiction
+        def peek_current_state
+            Syskit.fatal "#peek_current_state called on #{self}"
+            caller.each do |line|
+                Syskit.fatal "  #{line}"
+            end
+            super
+        end
+    end
+
+    Orocos::TaskContext.prepend TaskContextPeekStateInterdiction
+
         class << self
             # (see RobyApp::Configuration#register_process_server)
             def register_process_server(name, client, log_dir = nil)

--- a/lib/syskit/models/component.rb
+++ b/lib/syskit/models/component.rb
@@ -701,6 +701,13 @@ module Syskit
                 super
             end
 
+            # Test if the given port is a port of self
+            #
+            # @param [Port] port
+            def self_port?(port)
+                port.component_model == self
+            end
+
             # If true, this model is used internally as specialization of
             # another component model (as e.g. to represent dynamic service
             # instantiation). Otherwise, it is an actual component model.

--- a/lib/syskit/models/composition.rb
+++ b/lib/syskit/models/composition.rb
@@ -386,6 +386,14 @@ module Syskit
                 result
             end
 
+            # Tests whether the given port is a port of one of this
+            # composition's children
+            def child_port?(port)
+                port_component_model = port.to_component_port.component_model
+                port_component_model.respond_to?(:composition_model) &&
+                        port_component_model.composition_model == self
+            end
+
             # Export the given port to the boundary of the composition (it
             # becomes a composition port). By default, the composition port has
             # the same name than the exported port. This name can be overriden
@@ -418,13 +426,8 @@ module Syskit
                     return
                 end
 
-                if !port.respond_to?(:to_component_port)
-                    raise TypeError, "#{port} does not seem to be a port (#{port.class})"
-                end
-
-                port_component_model = port.to_component_port.component_model
-                if !port_component_model.respond_to?(:composition_model) || port_component_model.composition_model != self
-                    raise ArgumentError, "one can only export of this composition's children"
+                if !child_port?(port)
+                    raise ArgumentError, "#{port} is not a port of one of #{self}'s children"
                 end
 
                 case port

--- a/lib/syskit/models/composition_child.rb
+++ b/lib/syskit/models/composition_child.rb
@@ -83,20 +83,29 @@ module Syskit
                 Syskit.connect(self, sink, policy)
             end
 
-            # Tests whether the two ports are connected
+            # Test whether the given port object is a port of self
+            #
+            # @param [Port] port
+            def self_port?(port)
+                port.component_model == self
+            end
+
+            # @api private
+            #
+            # Tests whether two ports are connected
             #
             # This is a delegated call from Port#connected_to?. Always use the
             # former unless you know what you are doing
-            def connected?(in_port, out_port)
-                if !out_port.component_model.respond_to?(:composition_model)
-                    return false
-                elsif composition_model != out_port.component_model.composition_model
+            def connected?(source_port, sink_port)
+                if !self_port?(source_port)
+                    raise ArgumentError, "source port #{source_port} in connected? is not a port of #{self}"
+                elsif !composition_model.child_port?(sink_port)
                     return false
                 end
 
                 cmp_connections = composition_model.
-                    explicit_connections[[child_name, out_port.component_model.child_name]]
-                cmp_connections.has_key?([in_port.name,out_port.name])
+                    explicit_connections[[child_name, sink_port.component_model.child_name]]
+                cmp_connections.has_key?([source_port.name,sink_port.name])
             end
 
             # (see Component#connect_ports)

--- a/lib/syskit/models/port.rb
+++ b/lib/syskit/models/port.rb
@@ -7,15 +7,15 @@ module Syskit
         # be used to represent a port on a subclass of TaskContext while
         # Syskit::Port would represent it for an object of that subclass.
         class Port
-            # [ComponentModel] The component model this port is part of
+            # @return [ComponentModel] The component model this port is part of
             attr_reader :component_model
-            # [Orocos::Spec::Port] The port model
+            # @return [Orocos::Spec::Port] The port model
             attr_reader :orogen_model
-            # [String] The port name on +component_model+. It can be
-            # different from orogen_model.name, as the port could be imported from
-            # another component
+            # @return [String] The port name on +component_model+. It can be
+            #   different from orogen_model.name, as the port could be imported
+            #   from another component
             attr_accessor :name
-            # [Model<Typelib::Type>] the typelib type of this port
+            # @return [Model<Typelib::Type>] the typelib type of this port
             attr_reader :type
 
             # @param [#instanciate] component_model the component model
@@ -33,18 +33,22 @@ module Syskit
                 end
             end
 
+            # Whether this port and the argument represent the same port
             def same_port?(other)
                 other.kind_of?(Port) && (other.component_model <=> component_model) &&
                     other.orogen_model == orogen_model
             end
 
+            # Whether this port and the argument are the same port
             def ==(other)
                 other.kind_of?(self.class) && other.component_model == component_model &&
                 other.orogen_model == orogen_model &&
                 other.name == name
             end
 
-            # Change the component model
+            # Return a new port attached to another component model
+            #
+            # @return [Port]
             def attach(model)
                 new_model = dup
                 new_model.instance_variable_set(:@component_model, model)
@@ -70,6 +74,8 @@ module Syskit
             # of Component and not a data service)
             #
             # @return [Port]
+            # @raise [ArgumentError] if self cannot be resolved into a component
+            #   port
             def to_component_port
                 if component_model.respond_to?(:self_port_to_component_port)
                     component_model.self_port_to_component_port(self)
@@ -78,6 +84,10 @@ module Syskit
             end
 
             # Connects this port to the other given port, using the given policy
+            #
+            # @raise [WrongPortConnectionTypes]
+            # @raise [WrongPortConnectionDirection]
+            # @raise [SelfConnection]
             def connect_to(in_port, policy = Hash.new)
                 out_port = self.to_component_port
                 if out_port == self

--- a/lib/syskit/models/port.rb
+++ b/lib/syskit/models/port.rb
@@ -114,26 +114,25 @@ module Syskit
             end
 
             # Tests whether self is connected to the provided port
-            def connected_to?(in_port)
-                out_port = self.try_to_component_port
-                if out_port == self
-                    in_port = in_port.try_to_component_port
-                    component_model.connected?(out_port, in_port)
+            def connected_to?(sink_port)
+                source_port = self.try_to_component_port
+                if source_port == self
+                    sink_port = sink_port.try_to_component_port
+                    component_model.connected?(source_port, sink_port)
                 else
-                    out_port.connected_to?(in_port)
+                    source_port.connected_to?(sink_port)
                 end
             end
 
             # Tests whether this port can be connceted to the provided input
             # port
-            def can_connect_to?(in_port)
-                out_port = try_to_component_port
-                in_port  = in_port.try_to_component_port
-
-                if out_port != self
-                    return out_port.can_connect_to?(in_port)
+            def can_connect_to?(sink_port)
+                source_port = self.try_to_component_port
+                if source_port == self
+                    sink_port  = sink_port.try_to_component_port
+                    output? && sink_port.input? && type == sink_port.type
                 else
-                    output? && in_port.input? && type == in_port.type
+                    source_port.can_connect_to?(sink_port)
                 end
             end
 

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -412,7 +412,7 @@ module Syskit
                         com_bus_task = com_bus_task.component
                         com_bus_task.attach(task)
                         task.depends_on com_bus_task
-                        task.should_start_after com_bus_task.start_event
+                        task.should_configure_after com_bus_task.start_event
                     end
                 end
                 nil

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -1029,6 +1029,8 @@ module Syskit
                 already_setup_tasks.each do |t|
                     next if !t.transaction_proxy?
                     if t.transaction_modifies_static_ports?
+                        debug { "#{t} was selected as deployment, but it would require modifications on static ports, spawning a new deployment" }
+                        
                         new_task = t.execution_agent.task(t.orocos_name, t.concrete_model)
                         merge_solver.merge(t, new_task, remove: false)
                         new_task.should_configure_after t.stop_event

--- a/lib/syskit/runtime/runtime_connection_management.rb
+++ b/lib/syskit/runtime/runtime_connection_management.rb
@@ -322,18 +322,14 @@ module Syskit
                                             rescue Orocos::ComError
                                             end
 
-                    if (states[source_task] == :RUNNING) || (states[sink_task] == :RUNNING)
-                        debug { "early #{kind} connections from #{source_task} to #{sink_task}" }
-                        true
-                    else
-                        debug do
-                            debug "late #{kind} connections from #{source_task} to #{sink_task}"
-                            debug "  source state: #{states[source_task]}"
-                            debug "  sink state: #{states[sink_task]}"
-                            break
-                        end
-                        false
+                    early = (states[source_task] != :RUNNING) || (states[sink_task] != :RUNNING)
+                    debug do
+                        debug "#{early ? 'early' : 'late'} #{kind} connections from #{source_task} to #{sink_task}"
+                        debug "  source state: #{states[source_task]}"
+                        debug "  sink state: #{states[sink_task]}"
+                        break
                     end
+                    early
                 end
             end
 

--- a/lib/syskit/runtime/runtime_connection_management.rb
+++ b/lib/syskit/runtime/runtime_connection_management.rb
@@ -313,21 +313,31 @@ module Syskit
                 end
             end
 
-            # Apply all connection changes on the system. The principle is to
-            # use a transaction-based approach: i.e. either we apply everything
-            # or nothing.
-            #
-            # See #compute_connection_changes for the format of +new+ and
-            # +removed+
-            #
-            # Returns a false value if it could not apply the changes and a true
-            # value otherwise.
-            def apply_connection_changes(new, removed)
-                if removed_connections_require_network_update?(removed)
-                    plan.syskit_engine.force_update!
-                    return new, removed
-                end
+            def partition_early_late(connections, states, kind, mapping)
+                connections.partition do |(source_task, sink_task), _|
+                    states[source_task] ||= begin mapping[source_task].rtt_state
+                                            rescue Orocos::ComError
+                                            end
+                    states[sink_task]   ||= begin mapping[sink_task].rtt_state
+                                            rescue Orocos::ComError
+                                            end
 
+                    if (states[source_task] == :RUNNING) || (states[sink_task] == :RUNNING)
+                        debug { "early #{kind} connections from #{source_task} to #{sink_task}" }
+                        true
+                    else
+                        debug do
+                            debug "late #{kind} connections from #{source_task} to #{sink_task}"
+                            debug "  source state: #{states[source_task]}"
+                            debug "  sink state: #{states[sink_task]}"
+                            break
+                        end
+                        false
+                    end
+                end
+            end
+
+            def new_connections_partition_held_ready(new)
                 additions_held, additions_ready = Hash.new, Hash.new
                 new.each do |(from_task, to_task), mappings|
                     hold, ready = mappings.partition do |(from_port, to_port), policy|
@@ -367,36 +377,31 @@ module Syskit
                         additions_ready[[from_task, to_task]] = Hash[ready]
                     end
                 end
+                return additions_held, additions_ready
+            end
 
-                early_removal, late_removal = removed.partition do |(source_task, sink_task), _|
-                    source_running = begin source_task.rtt_state == :RUNNING
-                                     rescue Orocos::ComError
-                                     end
-                    sink_running   = begin sink_task.rtt_state == :RUNNING
-                                     rescue Orocos::ComError
-                                     end
-                    !source_running || !sink_running
+            # Apply all connection changes on the system. The principle is to
+            # use a transaction-based approach: i.e. either we apply everything
+            # or nothing.
+            #
+            # See #compute_connection_changes for the format of +new+ and
+            # +removed+
+            #
+            # Returns a false value if it could not apply the changes and a true
+            # value otherwise.
+            def apply_connection_changes(new, removed)
+                if removed_connections_require_network_update?(removed)
+                    plan.syskit_engine.force_update!
+                    return new, removed
                 end
-                early_additions, late_additions = additions_ready.partition do |(source_task, sink_task), _|
-                    source_running = begin source_task.orocos_task.rtt_state == :RUNNING
-                                     rescue Orocos::ComError
-                                     end
-                    sink_running   = begin sink_task.orocos_task.rtt_state == :RUNNING
-                                     rescue Orocos::ComError
-                                     end
-                    if !source_running || !sink_running
-                        debug { "early adding connections from #{source_task} to #{sink_task}" }
-                        true
-                    else
-                        debug do
-                            debug "late adding connections from #{source_task} to #{sink_task}"
-                            debug "  #{source_task.orocos_task} running: #{source_task.orocos_task.running?}"
-                            debug "  #{sink_task.orocos_task} running: #{sink_task.orocos_task.running?}"
-                            break
-                        end
-                        false
-                    end
-                end
+
+                additions_held, additions_ready = new_connections_partition_held_ready(new)
+
+                task_states = Hash.new
+                early_removal, late_removal     =
+                    partition_early_late(removed, task_states, 'disconnection', proc { |v| v })
+                early_additions, late_additions =
+                    partition_early_late(additions_ready, task_states, 'connection', proc(&:orocos_task))
 
                 modified_tasks = apply_connection_removal(early_removal)
                 modified_tasks |= apply_connection_additions(early_additions)

--- a/lib/syskit/runtime/runtime_connection_management.rb
+++ b/lib/syskit/runtime/runtime_connection_management.rb
@@ -145,8 +145,6 @@ module Syskit
                 handle_modified_task = lambda do |orocos_task|
                     if !(syskit_task = find_setup_syskit_task_context_from_orocos_task(orocos_task))
                         return false
-                    elsif !syskit_task.setup?
-                        return false
                     end
 
                     unneeded_tasks ||= plan.unneeded_tasks

--- a/lib/syskit/runtime/runtime_connection_management.rb
+++ b/lib/syskit/runtime/runtime_connection_management.rb
@@ -234,22 +234,6 @@ module Syskit
                         if syskit_sink_task && !syskit_sink_task.executable?
                             modified << syskit_sink_task
                         end
-
-                        # The following test is meant to make sure that we
-                        # cleanup input ports after crashes. CORBA connections
-                        # will properly cleanup the output port-to-corba part
-                        # automatically, but never the corba-to-input port
-                        #
-                        # It will break code that connects to input ports
-                        # externally. This is not a common case however.
-                        # begin
-                        #     if !ActualDataFlow.has_in_connections?(sink_task, sink_port)
-                        #         debug { "calling #disconnect_all on the input port #{sink_task.name}:#{sink_port} since it has no input connections anymore" }
-                        #         sink.disconnect_all
-                        #     end
-                        # rescue Orocos::NotFound
-                        # rescue CORBA::ComError
-                        # end
                     end
                 end
                 modified

--- a/lib/syskit/runtime/runtime_connection_management.rb
+++ b/lib/syskit/runtime/runtime_connection_management.rb
@@ -369,19 +369,19 @@ module Syskit
                 end
 
                 early_removal, late_removal = removed.partition do |(source_task, sink_task), _|
-                    source_running = begin source_task.running?
+                    source_running = begin source_task.rtt_state == :RUNNING
                                      rescue Orocos::ComError
                                      end
-                    sink_running   = begin sink_task.running?
+                    sink_running   = begin sink_task.rtt_state == :RUNNING
                                      rescue Orocos::ComError
                                      end
                     !source_running || !sink_running
                 end
                 early_additions, late_additions = additions_ready.partition do |(source_task, sink_task), _|
-                    source_running = begin source_task.orocos_task.running?
+                    source_running = begin source_task.orocos_task.rtt_state == :RUNNING
                                      rescue Orocos::ComError
                                      end
-                    sink_running   = begin sink_task.orocos_task.running?
+                    sink_running   = begin sink_task.orocos_task.rtt_state == :RUNNING
                                      rescue Orocos::ComError
                                      end
                     if !source_running || !sink_running

--- a/lib/syskit/runtime/runtime_connection_management.rb
+++ b/lib/syskit/runtime/runtime_connection_management.rb
@@ -7,7 +7,6 @@ module Syskit
 
             attr_reader :plan
 
-            attr_predicate :dry_run?, true
 
             def scheduler
                 plan.execution_engine.scheduler
@@ -17,9 +16,8 @@ module Syskit
                 @plan = plan
             end
 
-            def self.update(plan, dry_run = false)
+            def self.update(plan)
                 manager = ConnectionManagement.new(plan)
-                manager.dry_run = dry_run
                 manager.update
             end
 
@@ -73,10 +71,6 @@ module Syskit
             # +to_port+ are the names of the ports that have to be disconnected
             # (i.e. strings)
             def compute_connection_changes(tasks)
-                if dry_run?
-                    return [], []
-                end
-
                 not_running = tasks.find_all { |t| !t.orocos_task }
                 if !not_running.empty?
                     debug do

--- a/lib/syskit/runtime/runtime_connection_management.rb
+++ b/lib/syskit/runtime/runtime_connection_management.rb
@@ -413,6 +413,42 @@ module Syskit
                 return Hash.new, Hash.new
             end
 
+            # @api private
+            #
+            # Compute the set of connections we should remove to account for
+            # orocos tasks whose supporting syskit task has been removed, but
+            # are still connected
+            #
+            # The result is formatted as the rest of the connection hashes, that
+            # is keys are (source_task, sink_task) and values are Array<(source_port,
+            # task_port)>. Note that source_task and sink_task are
+            # Orocos::TaskContext, and it is guaranteed that one of them has no
+            # equivalent in the Syskit graphs (meaning that no keys in the
+            # return value can be found in the return value of
+            # {#compute_connection_changes})
+            #
+            # @return [Hash]
+            def dangling_task_cleanup
+                removed = Hash.new
+
+                present_tasks = plan.find_tasks(TaskContext).map(&:orocos_task).to_set
+                dangling_tasks = ActualDataFlow.enum_for(:each_vertex).find_all do |orocos_task|
+                    !present_tasks.include?(orocos_task)
+                end
+                dangling_tasks.each do |parent_t|
+                    parent_t.each_child_vertex(ActualDataFlow) do |child_t|
+                        if !present_tasks.include?(child_t)
+                            # NOTE: since the two tasks have been removed,
+                            # they cannot be within the 'removed' set
+                            # already
+                            mappings = parent_t[child_t, ActualDataFlow]
+                            removed[[parent_t, child_t]] = mappings.keys.to_set
+                        end
+                    end
+                end
+                removed
+            end
+
             def update
                 tasks = Flows::DataFlow.modified_tasks
 
@@ -454,53 +490,21 @@ module Syskit
                     end
 
                     new, removed = compute_connection_changes(main_tasks)
-                    # Make also sure we have no dangling orocos_task within the
-                    # ActualDataFlow graph
-                    present_tasks = plan.find_tasks(TaskContext).map(&:orocos_task).to_set
-                    dangling_tasks = ActualDataFlow.enum_for(:each_vertex).find_all do |orocos_task|
-                        !present_tasks.include?(orocos_task)
-                    end
-                    dangling_tasks.each do |parent_t|
-                        parent_t.each_child_vertex(ActualDataFlow) do |child_t|
-                            if !present_tasks.include?(child_t)
-                                # NOTE: since the two tasks have been removed,
-                                # they cannot be within the 'removed' set
-                                # already
-                                mappings = parent_t[child_t, ActualDataFlow]
-                                removed[[parent_t, child_t]] = mappings.keys.to_set
-                            end
-                        end
-                    end
-
                     if new
-                        debug do
-                            debug "  new connections:"
-                            new.each do |(from_task, to_task), mappings|
-                                debug "    #{from_task} (#{from_task.running? ? 'running' : 'stopped'}) =>"
-                                debug "       #{to_task} (#{to_task.running? ? 'running' : 'stopped'})"
-                                mappings.each do |(from_port, to_port), policy|
-                                    debug "      #{from_port}:#{to_port} #{policy}"
-                                end
-                            end
-                            debug "  removed connections:"
-                            debug "  disable debug display because it is unstable in case of process crashes"
-                            #removed.each do |(from_task, to_task), mappings|
-                            #    Engine.info "    #{from_task} (#{from_task.running? ? 'running' : 'stopped'}) =>"
-                            #    Engine.info "       #{to_task} (#{to_task.running? ? 'running' : 'stopped'})"
-                            #    mappings.each do |from_port, to_port|
-                            #        Engine.info "      #{from_port}:#{to_port}"
-                            #    end
-                            #end
-                                
-                            break
-                        end
-
                         Flows::DataFlow.pending_changes = [main_tasks, new, removed]
                         Flows::DataFlow.modified_tasks.clear
                         Flows::DataFlow.modified_tasks.merge(proxy_tasks.to_set)
                     else
                         debug "cannot compute changes, keeping the tasks queued"
                     end
+                end
+
+                # Yes, we can do that. See documentation of
+                # {#dangling_task_cleanup}
+                dangling = dangling_task_cleanup
+                if !dangling.empty?
+                    Flows::DataFlow.pending_changes ||= [[], Hash.new, Hash.new]
+                    Flows::DataFlow.pending_changes[2].merge!(dangling)
                 end
 
                 if Flows::DataFlow.pending_changes

--- a/lib/syskit/runtime/runtime_connection_management.rb
+++ b/lib/syskit/runtime/runtime_connection_management.rb
@@ -146,51 +146,43 @@ module Syskit
                     find { |t| t.setup? && (t.orocos_task == orocos_task) }
             end
 
-            def new_connections_require_network_update?(connections)
-                connections.each do |(source_task, sink_task), mappings|
-                    if source_task.running?
-                        mappings.each_key do |source_port, _|
-                            if port = source_task.model.find_output_port(source_port)
-                                return true if !port || port.static?
-                            end
-                        end
-                    end
-                    if sink_task.running?
-                        mappings.each_key do |_, sink_port|
-                            if port = sink_task.model.find_input_port(sink_port)
-                                return true if !port || port.static?
-                            end
-                        end
-                    end
-                end
-                false
-            end
-
             def removed_connections_require_network_update?(connections)
                 unneeded_tasks = nil
                 handle_modified_task = lambda do |orocos_task|
-                    if syskit_task = find_setup_syskit_task_context_from_orocos_task(orocos_task)
-                        unneeded_tasks ||= plan.unneeded_tasks
-                        if !unneeded_tasks.include?(syskit_task)
-                            return true
-                        end
+                    if !(syskit_task = find_setup_syskit_task_context_from_orocos_task(orocos_task))
+                        return false
+                    elsif !syskit_task.setup?
+                        return false
+                    end
+
+                    unneeded_tasks ||= plan.unneeded_tasks
+                    if !unneeded_tasks.include?(syskit_task)
+                        return true
                     end
                 end
 
                 connections.each do |(source_task, sink_task), mappings|
                     source_task_modified = mappings.any? do |source_port, sink_port|
                         port = source_task.model.find_output_port(source_port)
-                        (!port || port.static?)
+                        if port && port.static?
+                            ConnectionManagement.debug { "#{source_task} has an outgoing connection removed from #{source_port} and the port is static" }
+                            true 
+                        end
                     end
                     if source_task_modified && handle_modified_task[source_task]
+                        ConnectionManagement.debug { "#{source_task} has connection modifications that require a deployment and it is not going to be garbage collected, redeploying" }
                         return true
                     end
 
                     sink_task_modified = mappings.any? do |_, sink_port|
                         port = sink_task.model.find_input_port(sink_port)
-                        (!port || port.static?)
+                        if port && port.static?
+                            ConnectionManagement.debug { "#{sink_task} has a connection removed from #{sink_port} and the port is static" }
+                            true 
+                        end
                     end
                     if sink_task_modified && handle_modified_task[sink_task]
+                        ConnectionManagement.debug { "#{sink_task} has connection modifications that require a deployment and it is not going to be garbage collected, redeploying" }
                         return true
                     end
                 end
@@ -239,7 +231,7 @@ module Syskit
                     end
                 end
 
-                if new_connections_require_network_update?(new) || removed_connections_require_network_update?(removed)
+                if removed_connections_require_network_update?(removed)
                     plan.syskit_engine.force_update!
                     throw :cancelled
                 end

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -367,6 +367,8 @@ module Syskit
             def ready_for_setup?(state = nil)
                 if !super()
                     return false
+                elsif !all_inputs_connected?(only_static: true)
+                    return false
                 elsif !orogen_model || !orocos_task
                     return false
                 end
@@ -409,7 +411,11 @@ module Syskit
             # If true, #configure must be called on this task before it is
             # started. This flag is reset after #configure has been called
             def needs_reconfiguration?
-                TaskContext.needs_reconfiguration.include?(orocos_name)
+                TaskContext.needs_reconfiguration?(orocos_name)
+            end
+
+            def self.needs_reconfiguration?(orocos_name)
+                needs_reconfiguration.include?(orocos_name)
             end
 
             # Make sure that #configure will be called on this task before it

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -853,25 +853,17 @@ module Syskit
 
                 def transaction_modifies_static_ports?
                     new_connections_to_static = Hash.new
-                    each_source do |source_task|
-                        connections = source_task[self, Flows::DataFlow]
-                        connections.each_key do |source_port, sink_port|
-                            if find_input_port(sink_port).static?
-                                return true if !source_task.transaction_proxy?
-                                sources = (new_connections_to_static[sink_port] ||= Set.new)
-                                sources << [source_task.orocos_name, source_port]
-                            end
+                    each_concrete_input_connection do |source_task, source_port, sink_port, policy|
+                        if find_input_port(sink_port).static?
+                            sources = (new_connections_to_static[sink_port] ||= Set.new)
+                            sources << [source_task.orocos_name, source_port]
                         end
                     end
 
-                    each_sink do |sink_task|
-                        connections = self[sink_task, Flows::DataFlow]
-                        connections.each_key do |source_port, sink_port|
-                            if find_output_port(source_port).static?
-                                return true if !sink_task.transaction_proxy?
-                                sinks = (new_connections_to_static[source_port] ||= Set.new)
-                                sinks << [sink_task.orocos_name, sink_port]
-                            end
+                    each_concrete_output_connection do |source_port, sink_port, sink_task, policy|
+                        if find_output_port(source_port).static?
+                            sinks = (new_connections_to_static[source_port] ||= Set.new)
+                            sinks << [sink_task.orocos_name, sink_port]
                         end
                     end
 

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -876,13 +876,13 @@ module Syskit
                     end
 
                     current_connections_to_static = Hash.new
-                    orocos_task.each_parent_vertex(Syskit::ActualDataFlow) do |source_task|
+                    orocos_task.each_parent_vertex(ActualDataFlow) do |source_task|
                         # Transactions neither touch ActualDataFlow nor the
                         # task-to-orocos_task mapping. It's safe to check it
                         # straight.
-                        connections = source_task[orocos_task, Syskit::ActualDataFlow]
+                        connections = source_task[orocos_task, ActualDataFlow]
                         connections.each_key do |source_port, sink_port|
-                            if find_input_port(sink_port).static?
+                            if ActualDataFlow.static?(orocos_task, sink_port)
                                 sources = (current_connections_to_static[sink_port] ||= Set.new)
                                 sources << [source_task.name, source_port]
                             end
@@ -894,7 +894,7 @@ module Syskit
                         # straight.
                         connections = orocos_task[sink_task, Syskit::ActualDataFlow]
                         connections.each_key do |source_port, sink_port|
-                            if find_output_port(source_port).static?
+                            if ActualDataFlow.static?(orocos_task, source_port)
                                 sinks = (current_connections_to_static[source_port] ||= Set.new)
                                 sinks << [sink_task.name, sink_port]
                             end

--- a/lib/syskit/test/base.rb
+++ b/lib/syskit/test/base.rb
@@ -1,51 +1,8 @@
-require 'minitest/spec'
-require 'flexmock/minitest'
-
-# simplecov must be loaded FIRST. Only the files required after it gets loaded
-# will be profiled !!!
-if ENV['SYSKIT_ENABLE_COVERAGE'] == '1' || ENV['SYSKIT_ENABLE_COVERAGE'] == '2'
-    begin
-        require 'simplecov'
-        SimpleCov.start
-        if ENV['SYSKIT_ENABLE_COVERAGE'] == '2'
-            require 'syskit'
-            Syskit.warn "coverage has been automatically enabled, which has a noticeable effect on runtime"
-            Syskit.warn "Set SYSKIT_ENABLE_COVERAGE=0 in your shell to disable"
-        end
-
-    rescue LoadError
-        require 'syskit'
-        Syskit.warn "coverage is disabled because the 'simplecov' gem cannot be loaded"
-    rescue Exception => e
-        require 'syskit'
-        Syskit.warn "coverage is disabled: #{e.message}"
-    end
-end
+require 'roby/test/common'
 
 require 'syskit'
-require 'roby'
-require 'roby/test/common'
 require 'roby/schedulers/temporal'
 require 'orocos/ruby_process_server'
-
-if ENV['SYSKIT_ENABLE_PRY'] != '0'
-    begin
-        require 'pry'
-    rescue Exception
-        Syskit.warn "debugging is disabled because the 'pry' gem cannot be loaded"
-    end
-end
-
-if ENV['SYSKIT_ENABLE_PROFILING'] && ENV['SYSKIT_ENABLE_PROFILING'] != '1'
-    require 'stackprof'
-    StackProf.start
-    Minitest.after_run do
-        Syskit.info "dumping profiling results in syskit-tests.dump"
-        StackProf.stop
-        StackProf.results('syskit-tests.dump')
-    end
-end
-
 
 module Syskit
     module Test

--- a/lib/syskit/test/network_manipulation.rb
+++ b/lib/syskit/test/network_manipulation.rb
@@ -495,6 +495,7 @@ module Syskit
 
                 pending = tasks.dup
                 while !pending.empty?
+                    Syskit::Runtime::ConnectionManagement.update(component.plan)
                     current_state = pending.size
                     pending.delete_if do |t|
                         if !t.setup? && t.ready_for_setup?

--- a/lib/syskit/test/self.rb
+++ b/lib/syskit/test/self.rb
@@ -32,6 +32,9 @@ module Syskit
             Syskit.conf.export_types = false
             Syskit.conf.disables_local_process_server = true
             Syskit.conf.only_load_models = true
+            null_io = File.open('/dev/null', 'w')
+            Syskit.logger = Logger.new(null_io)
+            Syskit.logger.level = Logger::DEBUG
 
             super
 

--- a/lib/syskit/test/self.rb
+++ b/lib/syskit/test/self.rb
@@ -1,5 +1,5 @@
-require 'roby/test/self'
 require 'syskit/test/base'
+require 'roby/test/self'
 require 'syskit/test/network_manipulation'
 
 module Syskit
@@ -32,9 +32,6 @@ module Syskit
             Syskit.conf.export_types = false
             Syskit.conf.disables_local_process_server = true
             Syskit.conf.only_load_models = true
-            null_io = File.open('/dev/null', 'w')
-            Syskit.logger = Logger.new(null_io)
-            Syskit.logger.level = Logger::DEBUG
 
             super
 

--- a/test/models/test_composition.rb
+++ b/test/models/test_composition.rb
@@ -211,6 +211,13 @@ describe Syskit::Models::Composition do
                         as: 'srv_in'
                 end
             end
+            it "raises ArgumentError if given a port that is not a port of a child of the composition" do
+                task_m = Syskit::TaskContext.new_submodel { output_port 'out', '/double' }
+                cmp_m  = Syskit::Composition.new_submodel
+                assert_raises(ArgumentError) do
+                    cmp_m.export task_m.out_port, as: 'test'
+                end
+            end
         end
 
         describe "#find_exported_output" do

--- a/test/models/test_composition.rb
+++ b/test/models/test_composition.rb
@@ -963,5 +963,32 @@ describe Syskit::Models::Composition do
             assert_equal Hash[bla: 10], cmp_m.test_child.arguments
         end
     end
+
+    describe "#child_port?" do
+        attr_reader :cmp_m, :task_m
+        before do
+            srv_m = Syskit::DataService.new_submodel { output_port 'out', '/double' }
+            @task_m = Syskit::TaskContext.new_submodel { output_port 'out', '/double' }
+            task_m.provides srv_m, as: 'test'
+            @cmp_m = Syskit::Composition.new_submodel
+            cmp_m.add task_m, as: 'test'
+        end
+        it "returns true for a port that is a port of one of this composition's children" do
+            assert cmp_m.child_port?(cmp_m.test_child.out_port)
+        end
+        it "returns true for a port that is a port of one of this composition's children's services" do
+            assert cmp_m.child_port?(cmp_m.test_child.test_srv.out_port)
+        end
+        it "returns false for a port of a standalone task model" do
+            task_m = Syskit::TaskContext.new_submodel { output_port 'out', '/double' }
+            assert !cmp_m.child_port?(task_m.out_port)
+        end
+        it "returns false for a port of a different composition's child" do
+            cmp2_m = Syskit::Composition.new_submodel
+            cmp2_m.add task_m, as: 'test'
+            assert !cmp_m.child_port?(cmp2_m.test_child.out_port)
+            assert !cmp_m.child_port?(cmp2_m.test_child.test_srv.out_port)
+        end
+    end
 end
 

--- a/test/models/test_composition_child.rb
+++ b/test/models/test_composition_child.rb
@@ -28,6 +28,25 @@ describe Syskit::Models::CompositionChild do
         end
     end
 
+    describe "#resolve" do
+        let(:child_m) do
+            task_m = Syskit::Component.new_submodel
+            cmp_m = Syskit::Composition.new_submodel
+            cmp_m.add task_m, as: 'task'
+        end
+
+        it "resolves the task with try_resolve" do
+            flexmock(child_m).should_receive(:try_resolve).
+                with(root = flexmock).and_return(result = flexmock)
+            assert_equal result, child_m.resolve(root)
+        end
+        it "raises ArgumentError if the task cannot be resolved" do
+            flexmock(child_m).should_receive(:try_resolve).
+                with(root = flexmock).and_return(nil)
+            assert_raises(ArgumentError) { child_m.resolve(root) }
+        end
+    end
+
     describe "#connect_ports" do
         it "refuses to connect ports from different models" do
             srv_m = Syskit::DataService.new_submodel

--- a/test/models/test_port.rb
+++ b/test/models/test_port.rb
@@ -96,15 +96,17 @@ describe Syskit::Models::Port do
         it "returns true even if the types differ" do
             assert !srv_out.int_port.can_connect_to?(srv_in.dbl_port)
         end
-        it "tries to resolve the ports to component ports" do
-            component_in_port  = flexmock
+        it "resolves self to component port and delegate to the resolved port's can_connect_to? method" do
             component_out_port = flexmock
-            component_out_port.should_receive(:can_connect_to?).with(component_in_port).once.
+            component_out_port.should_receive(:can_connect_to?).with(srv_in.int_port).once.
                 and_return(true)
             flexmock(srv_out.int_port).should_receive(:try_to_component_port).and_return(component_out_port)
-            flexmock(srv_in.int_port).should_receive(:try_to_component_port).and_return(component_in_port)
 
             assert srv_out.int_port.can_connect_to?(srv_in.int_port)
+        end
+        it "resolves the sink to component port before testing for compatibility" do
+            flexmock(srv_in.dbl_port).should_receive(:try_to_component_port).and_return(srv_in.int_port)
+            assert srv_out.int_port.can_connect_to?(srv_in.dbl_port)
         end
     end
 end

--- a/test/runtime/test_connection_management.rb
+++ b/test/runtime/test_connection_management.rb
@@ -130,13 +130,11 @@ describe Syskit::Runtime::ConnectionManagement do
 
             describe "handling of static ports" do
                 it "triggers a redeployment if #removed_connections_require_network_update? returns true" do
-                    expected =
-                        Syskit::Flows::DataFlow.pending_changes = 
+                    expected = Syskit::Flows::DataFlow.pending_changes = 
                         [flexmock, flexmock(:empty? => false), flexmock(:empty? => false)]
 
                     manager = Syskit::Runtime::ConnectionManagement.new(plan)
-                    flexmock(manager).
-                        should_receive(:removed_connections_require_network_update?).
+                    flexmock(manager).should_receive(:removed_connections_require_network_update?).
                         and_return(true)
                     manager.update
                     assert plan.syskit_engine.forced_update?
@@ -360,8 +358,7 @@ describe Syskit::Runtime::ConnectionManagement do
 
         it "triggers a deployment if a connection to a static port is removed on an already setup task" do
             task_m = Syskit::TaskContext.new_submodel do
-                input_port('in', '/double').
-                    static
+                input_port('in', '/double').static
                 output_port 'out', '/double'
             end
             source = syskit_stub_and_deploy(task_m.with_conf('source'))
@@ -399,6 +396,37 @@ describe Syskit::Runtime::ConnectionManagement do
             source.dispose if source
             sink.dispose if sink
         end
+    end
+    
+    it "raises if an expected input port is not present on a configured task" do
+        source_m  = Syskit::TaskContext.new_submodel { output_port('out', '/double') }
+        sink_m    = Syskit::TaskContext.new_submodel
+        source = syskit_stub_deploy_and_configure(source_m)
+        sink   = syskit_stub_deploy_and_configure(sink_m)
+        sink.specialize
+        sink.model.orogen_model.input_port 'in', '/double'
+        source.out_port.connect_to sink.in_port
+        e = assert_adds_roby_localized_error(Syskit::PortNotFound) do
+            Syskit::Runtime::ConnectionManagement.update(plan)
+        end
+        assert_equal sink, e.failed_task
+        assert_equal 'in', e.port_name
+        assert_equal :input, e.port_kind
+    end
+    it "raises if an expected output port is not present on a configured task" do
+        source_m  = Syskit::TaskContext.new_submodel
+        sink_m    = Syskit::TaskContext.new_submodel { input_port('in', '/double') }
+        source = syskit_stub_deploy_and_configure(source_m)
+        sink   = syskit_stub_deploy_and_configure(sink_m)
+        source.specialize
+        source.model.orogen_model.output_port 'out', '/double'
+        source.out_port.connect_to sink.in_port
+        e = assert_adds_roby_localized_error(Syskit::PortNotFound) do
+            Syskit::Runtime::ConnectionManagement.update(plan)
+        end
+        assert_equal source, e.failed_task
+        assert_equal 'out', e.port_name
+        assert_equal :output, e.port_kind
     end
 end
 

--- a/test/runtime/test_connection_management.rb
+++ b/test/runtime/test_connection_management.rb
@@ -23,6 +23,84 @@ describe Syskit::Runtime::ConnectionManagement do
         end
     end
 
+    describe "#removed_connections_require_network_update?" do
+        let(:management) { Syskit::Runtime::ConnectionManagement.new(plan) }
+        attr_reader :source_task, :sink_task
+        before do
+            @source_task = syskit_stub_and_deploy("source") do
+                output_port 'out', '/double'
+                output_port 'state', '/int'
+            end
+            @sink_task = syskit_stub_and_deploy("sink") do
+                output_port 'state', '/int'
+                input_port 'in', '/double'
+            end
+            syskit_start_execution_agents(source_task)
+            syskit_start_execution_agents(sink_task)
+        end
+
+        it "returns false if the ports are not static" do
+            flexmock(Syskit::ActualDataFlow, :static? => false)
+            assert !management.removed_connections_require_network_update?(
+                Hash[[source_task, sink_task] => ['out', 'in']])
+        end
+
+        describe "static source port" do
+            before do
+                flexmock(Syskit::ActualDataFlow).should_receive(:static?).
+                    with(source_task.orocos_task, 'out').and_return(true)
+                flexmock(Syskit::ActualDataFlow).should_receive(:static?).
+                    with(sink_task.orocos_task, 'in').and_return(false)
+             end
+
+            it "returns false if the modified task is not represented in the plan" do
+                assert !management.removed_connections_require_network_update?(
+                    Hash[[source_task.orocos_task, sink_task.orocos_task] => [['out', 'in']]])
+            end
+            it "returns false if the modified task is to be garbage-collected" do
+                flexmock(management).should_receive(:find_setup_syskit_task_context_from_orocos_task).
+                    and_return(source_task)
+                plan.unmark_mission(source_task)
+                assert !management.removed_connections_require_network_update?(
+                    Hash[[source_task.orocos_task, sink_task.orocos_task] => [['out', 'in']]])
+            end
+            it "returns true if the task is already configured" do
+                flexmock(management).should_receive(:find_setup_syskit_task_context_from_orocos_task).
+                    and_return(source_task)
+                assert management.removed_connections_require_network_update?(
+                    Hash[[source_task.orocos_task, sink_task.orocos_task] => [['out', 'in']]])
+            end
+        end
+
+        describe "static sink port" do
+            before do
+                flexmock(Syskit::ActualDataFlow).should_receive(:static?).
+                    with(source_task.orocos_task, 'out').and_return(false)
+                flexmock(Syskit::ActualDataFlow).should_receive(:static?).
+                    with(sink_task.orocos_task, 'in').and_return(true)
+             end
+
+            it "returns false if the modified task is not represented in the plan" do
+                assert !management.removed_connections_require_network_update?(
+                    Hash[[source_task.orocos_task, sink_task.orocos_task] => [['out', 'in']]])
+            end
+            it "returns false if the modified task is to be garbage-collected" do
+                flexmock(management).should_receive(:find_setup_syskit_task_context_from_orocos_task).
+                    and_return(sink_task)
+                plan.unmark_mission(sink_task)
+                assert !management.removed_connections_require_network_update?(
+                    Hash[[source_task.orocos_task, sink_task.orocos_task] => [['out', 'in']]])
+            end
+            it "returns true if the task is already configured" do
+                flexmock(management).should_receive(:find_setup_syskit_task_context_from_orocos_task).
+                    and_return(sink_task)
+                assert management.removed_connections_require_network_update?(
+                    Hash[[source_task.orocos_task, sink_task.orocos_task] => [['out', 'in']]])
+            end
+        end
+    end
+
+
     describe "#update" do
         describe "interaction between connections and task states" do
             attr_reader :source_task, :sink_task
@@ -39,18 +117,218 @@ describe Syskit::Runtime::ConnectionManagement do
                 syskit_start_execution_agents(sink_task)
             end
 
-            it "should connect tasks only once they have been set up" do
+            it "connects input static ports before the task gets set up" do
+                flexmock(source_task.orocos_task.port('out')).should_receive(:connect_to).once.ordered
+                flexmock(sink_task.orocos_task).should_receive(:configure).once.ordered.pass_thru
                 source_task.connect_to(sink_task)
-                FlexMock.use(source_task.orocos_task.port('out')) do |mock|
-                    mock.should_receive(:connect_to).never
-                    Syskit::Runtime::ConnectionManagement.update(plan)
+                assert !sink_task.ready_for_setup?, "#{sink_task} is ready_for_setup? but its inputs are not connected yet"
+                process_events
+                Syskit::Runtime::ConnectionManagement.update(plan)
+                assert sink_task.ready_for_setup?
+                process_events
+            end
+
+            describe "handling of static ports" do
+                it "triggers a redeployment if #removed_connections_require_network_update? returns true" do
+                    expected =
+                        Syskit::Flows::DataFlow.pending_changes = 
+                        [flexmock, flexmock(:empty? => false), flexmock(:empty? => false)]
+
+                    manager = Syskit::Runtime::ConnectionManagement.new(plan)
+                    flexmock(manager).
+                        should_receive(:removed_connections_require_network_update?).
+                        and_return(true)
+                    manager.update
+                    assert plan.syskit_engine.forced_update?
+                    assert_equal expected, Syskit::Flows::DataFlow.pending_changes
+                    Syskit::Flows::DataFlow.pending_changes = nil
                 end
 
-                FlexMock.use(source_task.orocos_task.port('out')) do |mock|
-                    mock.should_receive(:connect_to).once
-                    syskit_configure(source_task)
-                    syskit_configure(sink_task)
-                    Syskit::Runtime::ConnectionManagement.update(plan)
+                describe "stopped tasks" do
+                    def self.common
+                        it "disconnects a static source port and marks the task for reconfiguration" do
+                            prepare(true, false)
+                            assert Syskit::TaskContext.needs_reconfiguration?(source_task.orocos_name)
+                            assert !Syskit::TaskContext.needs_reconfiguration?(sink_task.orocos_name)
+                        end
+
+                        it "disconnects a static sink port and marks the task for reconfiguration" do
+                            prepare(false, true)
+                            Syskit::Runtime::ConnectionManagement.update(plan)
+                            assert !Syskit::TaskContext.needs_reconfiguration?(source_task.orocos_name)
+                            assert Syskit::TaskContext.needs_reconfiguration?(sink_task.orocos_name)
+                        end
+                    end
+
+                    describe "orocos tasks with non-static half without syskit tasks" do
+                        def prepare(source_static, sink_static)
+                            flexmock(source_task.orocos_task.out).should_receive(:disconnect_from).once
+                            Syskit::ActualDataFlow.add_connections(
+                                source_task.orocos_task,
+                                sink_task.orocos_task,
+                                ['out', 'in'] => [Hash.new, source_static, sink_static])
+                            if source_static
+                                plan.remove_object(sink_task)
+                            else
+                                plan.remove_object(source_task)
+                            end
+                            Syskit::Flows::DataFlow.modified_tasks << source_task << sink_task
+                            Syskit::Runtime::ConnectionManagement.update(plan)
+                        end
+
+                        common
+                    end
+
+                    describe "orocos tasks with static half without syskit tasks" do
+                        def prepare(source_static, sink_static)
+                            flexmock(source_task.orocos_task.out).should_receive(:disconnect_from).once
+                            Syskit::ActualDataFlow.add_connections(
+                                source_task.orocos_task,
+                                sink_task.orocos_task,
+                                ['out', 'in'] => [Hash.new, source_static, sink_static])
+                            if source_static
+                                plan.remove_object(source_task)
+                            else
+                                plan.remove_object(sink_task)
+                            end
+                            Syskit::Flows::DataFlow.modified_tasks << source_task << sink_task
+                            Syskit::Runtime::ConnectionManagement.update(plan)
+                        end
+
+                        common
+                    end
+
+                    describe "orocos tasks without syskit tasks" do
+                        def prepare(source_static, sink_static)
+                            flexmock(source_task.orocos_task.out).should_receive(:disconnect_from).once
+                            Syskit::ActualDataFlow.add_connections(
+                                source_task.orocos_task,
+                                sink_task.orocos_task,
+                                ['out', 'in'] => [Hash.new, source_static, sink_static])
+                            plan.remove_object(source_task)
+                            plan.remove_object(sink_task)
+                            Syskit::Flows::DataFlow.modified_tasks << source_task << sink_task
+                            Syskit::Runtime::ConnectionManagement.update(plan)
+                        end
+
+                        common
+                    end
+                end
+            end
+
+            describe "handling of dynamic ports" do
+                it "waits for the tasks to be set up to connect dynamic ports" do
+                    source_task.specialize
+                    def source_task.configure
+                        orocos_task.create_output_port 'out2', '/double'
+                    end
+                    source_task.model.orogen_model.output_port 'out2', '/double'
+                    source_task.out2_port.connect_to sink_task.in_port
+                    flexmock(source_task.orocos_task).
+                        should_receive(:configure).
+                        once.globally.ordered.
+                        pass_thru.
+                        and_return do
+                            flexmock(source_task.orocos_task.out2).
+                                should_receive(:connect_to).
+                                with(sink_task.orocos_task.in).
+                                once.globally.ordered
+                            true
+                        end
+                    assert_event_emission source_task.start_event
+                end
+
+                it "only connects ports to/from non-running tasks until the tasks are set up" do
+                    sink_task.specialize
+                    def sink_task.configure
+                        orocos_task.create_input_port 'in2', '/double'
+                    end
+                    sink_task.model.orogen_model.input_port 'in2', '/double'
+                    source_task.out_port.connect_to sink_task.in_port
+                    source_task.out_port.connect_to sink_task.in2_port
+                    flexmock(source_task.orocos_task.out).
+                        should_receive(:connect_to).
+                        with(sink_task.orocos_task.in, any).
+                        once.globally.ordered
+                    flexmock(sink_task.orocos_task, 'task').
+                        should_receive(:configure).
+                        once.globally.ordered.
+                        pass_thru
+                    flexmock(source_task.orocos_task.out).
+                        should_receive(:connect_to).
+                        with(->(p) { p.name == "in2" }, any).once.globally.ordered
+
+                    assert_event_emission source_task.start_event
+                end
+            end
+
+            describe "policy update of existing connections" do
+                # These check a situation where the deployer would have spawned
+                # a new task (for reconfiguration) that would have a different
+                # policy than the existing policy. It might happen that the Roby
+                # GC would not have removed the old task and the connection
+                # management would create the new connection
+            
+                describe "source tasks" do
+                    before do
+                        source_task.out_port.connect_to sink_task.in_port, type: :buffer
+                        Syskit::Runtime::ConnectionManagement.update(plan)
+                        assert_equal Hash[['out', 'in'] => Hash[type: :buffer]], source_task.orocos_task[sink_task.orocos_task, Syskit::ActualDataFlow]
+                    end
+
+                    it "handles an old task still present in the plan while the new task's connection is added, both tasks not setup" do
+                        plan.unmark_mission(source_task)
+                        plan.add_task(new_source_task = source_task.execution_agent.task(source_task.orocos_name))
+                        new_source_task.out_port.connect_to sink_task.in_port, type: :data
+                        Syskit::Runtime::ConnectionManagement.update(plan)
+                        assert source_task.out_port.connected_to?(sink_task.in_port)
+                        assert_equal Hash[['out', 'in'] => Hash[type: :data]], new_source_task.orocos_task[sink_task.orocos_task, Syskit::ActualDataFlow]
+                    end
+
+                    it "handles an old task still present in the plan while the new task's connection is added, the old task being running" do
+                        syskit_configure_and_start(source_task)
+                        plan.unmark_mission(source_task)
+                        plan.add_mission(new_source_task = source_task.execution_agent.task(source_task.orocos_name))
+                        new_source_task.conf = ['default']
+                        new_source_task.should_configure_after(source_task.stop_event)
+                        new_source_task.out_port.connect_to sink_task.in_port, type: :data
+                        flexmock(source_task.orocos_task.out).should_receive(:disconnect_from).with(sink_task.orocos_task.in).once.globally.ordered
+                        flexmock(source_task.orocos_task.out).should_receive(:connect_to).with(sink_task.orocos_task.in, Hash[type: :data]).once.globally.ordered
+                        Syskit::Runtime::ConnectionManagement.update(plan)
+                        assert_event_emission(new_source_task.start_event)
+                        assert_equal Hash[['out', 'in'] => Hash[type: :data]], new_source_task.orocos_task[sink_task.orocos_task, Syskit::ActualDataFlow]
+                    end
+                end
+            
+                describe "sink tasks" do
+                    before do
+                        source_task.out_port.connect_to sink_task.in_port, type: :buffer
+                        Syskit::Runtime::ConnectionManagement.update(plan)
+                        assert_equal Hash[['out', 'in'] => Hash[type: :buffer]], source_task.orocos_task[sink_task.orocos_task, Syskit::ActualDataFlow]
+                    end
+
+                    it "handles an old task still present in the plan while the new task's connection is added, both tasks not setup" do
+                        plan.unmark_mission(sink_task)
+                        plan.add_task(new_sink_task = sink_task.execution_agent.task(sink_task.orocos_name))
+                        source_task.out_port.connect_to new_sink_task.in_port, type: :data
+                        Syskit::Runtime::ConnectionManagement.update(plan)
+                        assert source_task.out_port.connected_to?(sink_task.in_port)
+                        assert_equal Hash[['out', 'in'] => Hash[type: :data]], source_task.orocos_task[new_sink_task.orocos_task, Syskit::ActualDataFlow]
+                    end
+
+                    it "handles an old task still present in the plan while the new task's connection is added, the old task being running" do
+                        syskit_configure_and_start(sink_task)
+                        plan.unmark_mission(sink_task)
+                        plan.add_mission(new_sink_task = sink_task.execution_agent.task(sink_task.orocos_name))
+                        new_sink_task.conf = ['default']
+                        new_sink_task.should_configure_after(sink_task.stop_event)
+                        source_task.out_port.connect_to new_sink_task.in_port, type: :data
+                        flexmock(source_task.orocos_task.out).should_receive(:disconnect_from).with(sink_task.orocos_task.in).once.globally.ordered
+                        flexmock(source_task.orocos_task.out).should_receive(:connect_to).with(sink_task.orocos_task.in, Hash[type: :data]).once.globally.ordered
+                        Syskit::Runtime::ConnectionManagement.update(plan)
+                        assert_event_emission(new_sink_task.start_event)
+                        assert_equal Hash[['out', 'in'] => Hash[type: :data]], source_task.orocos_task[new_sink_task.orocos_task, Syskit::ActualDataFlow]
+                    end
                 end
             end
 
@@ -58,7 +336,7 @@ describe Syskit::Runtime::ConnectionManagement do
             # removed connections that are queued because some tasks are not set up,
             # and then kill the tasks involved. The resulting operation should work
             # fine (i.e. not creating the dead connections)
-            it "should ignore pending new connections that involve a dead task" do
+            it "handles pending new connections that involve a dead task" do
                 source_task.connect_to(sink_task)
                 Syskit::Runtime::ConnectionManagement.update(plan)
                 source_task.execution_agent.stop!
@@ -67,20 +345,15 @@ describe Syskit::Runtime::ConnectionManagement do
                 Syskit::Runtime::ConnectionManagement.update(plan)
             end
 
-            it "should ignore pending removed connections that involve a dead task" do
+            it "handles pending removed connections that involve a dead task" do
                 source_task.connect_to(sink_task)
                 syskit_configure(source_task)
                 syskit_configure(sink_task)
                 Syskit::Runtime::ConnectionManagement.update(plan)
 
                 source_task.disconnect_ports(sink_task, [['out', 'in']])
-                FlexMock.use(Syskit::Runtime::ConnectionManagement) do |mock|
-                    mock.new_instances.should_receive(:apply_connection_changes).at_least.once.and_throw(:cancelled)
-                    Syskit::Runtime::ConnectionManagement.update(plan)
-                    source_task.execution_agent.stop!
-                    # This is normally done by Runtime.update_deployment_states
-                    source_task.execution_agent.cleanup_dead_connections
-                end
+                source_task.execution_agent.stop!
+                source_task.execution_agent.cleanup_dead_connections
                 Syskit::Runtime::ConnectionManagement.update(plan)
             end
         end

--- a/test/runtime/test_connection_management.rb
+++ b/test/runtime/test_connection_management.rb
@@ -24,63 +24,86 @@ describe Syskit::Runtime::ConnectionManagement do
     end
 
     describe "#update" do
-        attr_reader :source_task, :sink_task
-        before do
-            @source_task = syskit_stub_and_deploy("source") do
-                output_port 'out', '/double'
-                output_port 'state', '/int'
-            end
-            @sink_task = syskit_stub_and_deploy("sink") do
-                output_port 'state', '/int'
-                input_port 'in', '/double'
-            end
-            syskit_start_execution_agents(source_task)
-            syskit_start_execution_agents(sink_task)
-        end
-
-        it "should connect tasks only once they have been set up" do
-            source_task.connect_to(sink_task)
-            FlexMock.use(source_task.orocos_task.port('out')) do |mock|
-                mock.should_receive(:connect_to).never
-                Syskit::Runtime::ConnectionManagement.update(plan)
+        describe "interaction between connections and task states" do
+            attr_reader :source_task, :sink_task
+            before do
+                @source_task = syskit_stub_and_deploy("source") do
+                    output_port 'out', '/double'
+                    output_port 'state', '/int'
+                end
+                @sink_task = syskit_stub_and_deploy("sink") do
+                    output_port 'state', '/int'
+                    input_port 'in', '/double'
+                end
+                syskit_start_execution_agents(source_task)
+                syskit_start_execution_agents(sink_task)
             end
 
-            FlexMock.use(source_task.orocos_task.port('out')) do |mock|
-                mock.should_receive(:connect_to).once
-                syskit_configure(source_task)
-                syskit_configure(sink_task)
-                Syskit::Runtime::ConnectionManagement.update(plan)
+            it "should connect tasks only once they have been set up" do
+                source_task.connect_to(sink_task)
+                FlexMock.use(source_task.orocos_task.port('out')) do |mock|
+                    mock.should_receive(:connect_to).never
+                    Syskit::Runtime::ConnectionManagement.update(plan)
+                end
+
+                FlexMock.use(source_task.orocos_task.port('out')) do |mock|
+                    mock.should_receive(:connect_to).once
+                    syskit_configure(source_task)
+                    syskit_configure(sink_task)
+                    Syskit::Runtime::ConnectionManagement.update(plan)
+                end
             end
-        end
 
-        # This is really a system test. We simulate having pending new and
-        # removed connections that are queued because some tasks are not set up,
-        # and then kill the tasks involved. The resulting operation should work
-        # fine (i.e. not creating the dead connections)
-        it "should ignore pending new connections that involve a dead task" do
-            source_task.connect_to(sink_task)
-            Syskit::Runtime::ConnectionManagement.update(plan)
-            source_task.execution_agent.stop!
-            # This is normally done by Runtime.update_deployment_states
-            source_task.execution_agent.cleanup_dead_connections
-            Syskit::Runtime::ConnectionManagement.update(plan)
-        end
-
-        it "should ignore pending removed connections that involve a dead task" do
-            source_task.connect_to(sink_task)
-            syskit_configure(source_task)
-            syskit_configure(sink_task)
-            Syskit::Runtime::ConnectionManagement.update(plan)
-
-            source_task.disconnect_ports(sink_task, [['out', 'in']])
-            FlexMock.use(Syskit::Runtime::ConnectionManagement) do |mock|
-                mock.new_instances.should_receive(:apply_connection_changes).at_least.once.and_throw(:cancelled)
+            # This is really a system test. We simulate having pending new and
+            # removed connections that are queued because some tasks are not set up,
+            # and then kill the tasks involved. The resulting operation should work
+            # fine (i.e. not creating the dead connections)
+            it "should ignore pending new connections that involve a dead task" do
+                source_task.connect_to(sink_task)
                 Syskit::Runtime::ConnectionManagement.update(plan)
                 source_task.execution_agent.stop!
                 # This is normally done by Runtime.update_deployment_states
                 source_task.execution_agent.cleanup_dead_connections
+                Syskit::Runtime::ConnectionManagement.update(plan)
             end
+
+            it "should ignore pending removed connections that involve a dead task" do
+                source_task.connect_to(sink_task)
+                syskit_configure(source_task)
+                syskit_configure(sink_task)
+                Syskit::Runtime::ConnectionManagement.update(plan)
+
+                source_task.disconnect_ports(sink_task, [['out', 'in']])
+                FlexMock.use(Syskit::Runtime::ConnectionManagement) do |mock|
+                    mock.new_instances.should_receive(:apply_connection_changes).at_least.once.and_throw(:cancelled)
+                    Syskit::Runtime::ConnectionManagement.update(plan)
+                    source_task.execution_agent.stop!
+                    # This is normally done by Runtime.update_deployment_states
+                    source_task.execution_agent.cleanup_dead_connections
+                end
+                Syskit::Runtime::ConnectionManagement.update(plan)
+            end
+        end
+
+        it "triggers a deployment if a connection to a static port is removed on an already setup task" do
+            task_m = Syskit::TaskContext.new_submodel do
+                input_port('in', '/double').
+                    static
+                output_port 'out', '/double'
+            end
+            source = syskit_stub_and_deploy(task_m.with_conf('source'))
+            sink   = syskit_stub_and_deploy(task_m.with_conf('sink'))
+            source.out_port.connect_to sink.in_port
+            syskit_configure_and_start(source)
+            syskit_configure_and_start(sink)
+            source.out_port.disconnect_from sink.in_port
+
+            sink_srv = sink.as_service
             Syskit::Runtime::ConnectionManagement.update(plan)
+            assert plan.syskit_engine.forced_update?
+            plan.syskit_engine.resolve
+            refute_equal sink, sink_srv.to_task
         end
     end
 end
+

--- a/test/runtime/test_connection_management.rb
+++ b/test/runtime/test_connection_management.rb
@@ -378,5 +378,27 @@ describe Syskit::Runtime::ConnectionManagement do
             refute_equal sink, sink_srv.to_task
         end
     end
+
+    it "removes dangling connections" do
+        begin
+            task_m = Syskit::TaskContext.new_submodel do
+                input_port('in', '/double').static
+                output_port 'out', '/double'
+            end
+            source = Orocos::RubyTasks::TaskContext.from_orogen_model 'source', task_m.orogen_model
+            sink   = Orocos::RubyTasks::TaskContext.from_orogen_model 'sink', task_m.orogen_model
+
+            source.out.connect_to sink.in
+            Syskit::ActualDataFlow.add_connections(source, sink, Hash[['out', 'in'] => [Hash.new, false, false]])
+            Syskit::Runtime::ConnectionManagement.update(plan)
+            assert !source.out.connected?
+            assert !source.in.connected?
+            assert !Syskit::ActualDataFlow.include?(source)
+            assert !Syskit::ActualDataFlow.include?(sink)
+        ensure
+            source.dispose if source
+            sink.dispose if sink
+        end
+    end
 end
 

--- a/test/suite.rb
+++ b/test/suite.rb
@@ -1,8 +1,16 @@
-ENV['SYSKIT_ENABLE_COVERAGE'] = '0'
-if !ENV['SYSKIT_ENABLE_COVERAGE']
-    ENV['SYSKIT_ENABLE_COVERAGE'] = '2'
-end
 require 'syskit/test/self'
+
+if ENV['TEST_ENABLE_COVERAGE'] == '1' || rand > 0.5
+    null_io = File.open('/dev/null', 'w')
+    current_formatter = Syskit.logger.formatter
+    Syskit.warn "running tests with logger in DEBUG mode"
+    Syskit.logger = Logger.new(null_io)
+    Syskit.logger.level = Logger::DEBUG
+    Syskit.logger.formatter = current_formatter
+else
+    Syskit.warn "running tests with logger in FATAL mode"
+    Syskit.logger.level = Logger::FATAL + 1
+end
 
 require './test/suite_models'
 require './test/suite_robot'
@@ -29,13 +37,3 @@ require './test/test_instance_requirements_task'
 require './test/test_typelib_marshalling'
 
 require './test/test_exceptions'
-
-Syskit.logger = Logger.new(File.open("/dev/null", 'w'))
-Syskit.logger.level = Logger::DEBUG
-
-# OK Coverage for now:
-#   models/base
-#   base
-#   models/data_service
-#   models/deployment
-#   models/component

--- a/test/suite_actions.rb
+++ b/test/suite_actions.rb
@@ -1,7 +1,3 @@
-if !ENV['SYSKIT_ENABLE_COVERAGE']
-    ENV['SYSKIT_ENABLE_COVERAGE'] = '1'
-end
-
 require 'syskit/test/self'
 require './test/actions/test_interface_model_extension'
 require './test/actions/test_profile'

--- a/test/suite_coordination.rb
+++ b/test/suite_coordination.rb
@@ -1,6 +1,3 @@
-if !ENV['SYSKIT_ENABLE_COVERAGE']
-    ENV['SYSKIT_ENABLE_COVERAGE'] = '2'
-end
 require 'syskit/test/self'
 
 require './test/coordination/test_data_monitoring_error'

--- a/test/suite_models.rb
+++ b/test/suite_models.rb
@@ -1,6 +1,3 @@
-if !ENV['SYSKIT_ENABLE_COVERAGE']
-    ENV['SYSKIT_ENABLE_COVERAGE'] = '1'
-end
 require 'syskit/test/self'
 
 require './test/models/test_configured_deployment'

--- a/test/suite_network_generation.rb
+++ b/test/suite_network_generation.rb
@@ -1,6 +1,3 @@
-if !ENV['SYSKIT_ENABLE_COVERAGE']
-    ENV['SYSKIT_ENABLE_COVERAGE'] = '1'
-end
 require 'syskit/test/self'
 
 require './test/network_generation/test_engine'

--- a/test/suite_roby_app.rb
+++ b/test/suite_roby_app.rb
@@ -1,6 +1,3 @@
-if !ENV['SYSKIT_ENABLE_COVERAGE']
-    ENV['SYSKIT_ENABLE_COVERAGE'] = '1'
-end
 require 'syskit/test/self'
 
 require './test/roby_app/test_plugin'

--- a/test/suite_ros.rb
+++ b/test/suite_ros.rb
@@ -1,7 +1,3 @@
-if !ENV['SYSKIT_ENABLE_COVERAGE']
-    ENV['SYSKIT_ENABLE_COVERAGE'] = '1'
-end
-
 require 'syskit/test/self'
 require './test/ros/test_task_context'
 

--- a/test/suite_runtime.rb
+++ b/test/suite_runtime.rb
@@ -1,6 +1,3 @@
-if !ENV['SYSKIT_ENABLE_COVERAGE']
-    ENV['SYSKIT_ENABLE_COVERAGE'] = '1'
-end
 require 'syskit/test/self'
 
 require './test/runtime/test_connection_management'

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -730,26 +730,58 @@ describe Syskit::TaskContext do
                 source_task_p.out_port.disconnect_from sink_task_p.in_port
                 assert task_p.transaction_modifies_static_ports?
             end
+
         end
+
 
         describe "handling of static input ports" do
             handling_of_static_ports(input: true)
 
             it "returns true if a static input port is connected to new tasks" do
+                configure_tasks
                 transaction.add(new_task = source_task.model.new)
-                task_p = transaction[sink_task]
-                new_task.out_port.connect_to task_p.in_port
-                assert task_p.transaction_modifies_static_ports?
+                new_task.out_port.connect_to sink_task_p.in_port
+                assert sink_task_p.transaction_modifies_static_ports?
+            end
+
+            it "uses concrete input connections to determine the new connections" do
+                cmp_m = Syskit::Composition.new_submodel
+                cmp_m.add source_task.model, as: 'test'
+                cmp_m.export cmp_m.test_child.out_port, as: 'out'
+                cmp = syskit_stub_and_deploy(cmp_m.use('test' => source_task))
+
+                cmp.out_port.connect_to sink_task.in_port
+                configure_tasks
+                new_cmp = cmp_m.use('test' => source_task_p).instanciate(transaction)
+                cmp_p = transaction[cmp]
+                cmp_p.out_port.disconnect_from sink_task_p.in_port
+                new_cmp.out_port.connect_to sink_task_p.in_port
+                assert !sink_task_p.transaction_modifies_static_ports?
             end
         end
         describe "handling of static output ports" do
             handling_of_static_ports(input: false)
 
             it "returns true if a static output port is connected to new tasks" do
+                configure_tasks
                 transaction.add(new_task = sink_task.model.new)
-                task_p = transaction[source_task]
-                task_p.out_port.connect_to new_task.in_port
-                assert task_p.transaction_modifies_static_ports?
+                source_task_p.out_port.connect_to new_task.in_port
+                assert source_task_p.transaction_modifies_static_ports?
+            end
+
+            it "uses concrete output connections to determine the new connections" do
+                cmp_m = Syskit::Composition.new_submodel
+                cmp_m.add sink_task.model, as: 'test'
+                cmp_m.export cmp_m.test_child.in_port, as: 'in'
+                cmp = syskit_stub_and_deploy(cmp_m.use('test' => sink_task))
+
+                source_task.out_port.connect_to cmp.in_port
+                configure_tasks
+                new_cmp = cmp_m.use('test' => sink_task_p).instanciate(transaction)
+                cmp_p = transaction[cmp]
+                source_task.out_port.disconnect_from cmp.in_port
+                source_task_p.out_port.connect_to new_cmp.in_port
+                assert !source_task_p.transaction_modifies_static_ports?
             end
         end
     end

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -502,7 +502,7 @@ describe Syskit::TaskContext do
                 end
                 orocos_tasks = [source_task.orocos_task, task.orocos_task]
 
-                Syskit::ActualDataFlow.add_connections(*orocos_tasks, Hash[['dynamic', 'dynamic'] => Hash.new])
+                Syskit::ActualDataFlow.add_connections(*orocos_tasks, Hash[['dynamic', 'dynamic'] => [Hash.new, false, false]])
                 assert Syskit::ActualDataFlow.linked?(*orocos_tasks)
 
                 Syskit::TaskContext.configured['task'] = nil
@@ -528,7 +528,7 @@ describe Syskit::TaskContext do
                 end
                 orocos_tasks = [task.orocos_task, sink_task.orocos_task]
 
-                Syskit::ActualDataFlow.add_connections(*orocos_tasks, Hash[['dynamic', 'dynamic'] => Hash.new])
+                Syskit::ActualDataFlow.add_connections(*orocos_tasks, Hash[['dynamic', 'dynamic'] => [Hash.new, false, false]])
                 assert Syskit::ActualDataFlow.linked?(*orocos_tasks)
 
                 Syskit::TaskContext.configured['task'] = nil


### PR DESCRIPTION
This cleans up connection management, and changes the overall connection policy. The
policy is now to be eager in connecting, i.e. to connect tasks as soon as possible without changing
the overall behaviour.

In practice, it means that it is now possible to have a client.should_configure_after(server.start_event)
even if client and server are connected, as e.g. for com busses. In other words, it's possible to configure
a com bus client in #configure instead of having to do it in the start.