### PR TITLE
Deployment: fix calling private method prepend (ruby 2.0)

### DIFF
--- a/lib/syskit/deployment.rb
+++ b/lib/syskit/deployment.rb
@@ -13,7 +13,7 @@ module Syskit
         end
     end
 
-    Orocos::TaskContext.prepend TaskContextPeekStateInterdiction
+    Orocos::TaskContext.send :prepend, TaskContextPeekStateInterdiction
 
         class << self
             # (see RobyApp::Configuration#register_process_server)


### PR DESCRIPTION
At the moment syskit no longer runs on ruby2.0 (Ubuntu 14.04) because of  private method call. This was changed in ruby 2.1. 