### PR TITLE
Fix merge corner cases

### DIFF
--- a/lib/syskit/models/composition.rb
+++ b/lib/syskit/models/composition.rb
@@ -561,12 +561,16 @@ module Syskit
                 result
             end
 
+            def children_names
+                each_child.map { |name, _| name }
+            end
+
             # The list of names that will be used by this model as keys in a
             # DependencyInjection object,
             #
             # For compositions, this is the list of children names
             def dependency_injection_names
-                each_child.map { |name, _| name }
+                children_names
             end
 
             def find_child_model_and_task(child_name, context)

--- a/lib/syskit/network_generation/merge_solver.rb
+++ b/lib/syskit/network_generation/merge_solver.rb
@@ -181,6 +181,34 @@ module Syskit
                         info "rejected: compositions still have unresolved children"
                         return false
                     end
+
+                    # Now verify that the exported ports are the same
+                    task_exports = Set.new
+                    task.each_input_connection do |source_task, source_port, sink_port, _|
+                        if task.find_output_port(sink_port)
+                            task_exports << [source_task, source_port, sink_port]
+                        end
+                    end
+                    task.each_output_connection do |source_port, sink_task, sink_port, _|
+                        if task.find_input_port(source_port)
+                            task_exports << [source_port, sink_task, sink_port]
+                        end
+                    end
+                    target_task_exports = Set.new
+                    target_task.each_input_connection do |source_task, source_port, sink_port, _|
+                        if target_task.find_output_port(sink_port)
+                            target_task_exports << [source_task, source_port, sink_port]
+                        end
+                    end
+                    target_task.each_output_connection do |source_port, sink_task, sink_port, _|
+                        if target_task.find_input_port(source_port)
+                            target_task_exports << [source_port, sink_task, sink_port]
+                        end
+                    end
+                    if task_exports != target_task_exports
+                        info "rejected: compositions with different exports"
+                        return false
+                    end
                 end
 
                 # Finally, check if the inputs match

--- a/lib/syskit/network_generation/merge_solver.rb
+++ b/lib/syskit/network_generation/merge_solver.rb
@@ -241,7 +241,7 @@ module Syskit
                     # for task
                     (source_task, source_port), policy = inputs[sink_port].first
                     if source_port != target_source_port
-                        debug { "rejected: sink #{sink_port} is connected to a port named #{target_source_port} resp. #{source_port}" }
+                        debug { "rejected: sink #{sink_port} is connected to a port named #{source_port} resp. #{target_source_port}" }
                         return
                     end
                     if !policy.empty? && !target_policy.empty? && (Syskit.update_connection_policy(policy, target_policy) != target_policy)

--- a/lib/syskit/test/self.rb
+++ b/lib/syskit/test/self.rb
@@ -67,7 +67,7 @@ module Syskit
             super
 
         ensure
-            if @syskit_handler_ids
+            if @syskit_handler_ids && engine
                 Syskit::RobyApp::Plugin.unplug_engine_from_roby(@syskit_handler_ids, engine)
             end
 

--- a/test/network_generation/test_engine.rb
+++ b/test/network_generation/test_engine.rb
@@ -758,6 +758,30 @@ describe Syskit::NetworkGeneration::Engine do
                 cmp2 = syskit_deploy(cmp_m.use(task_m.out2_srv))
                 refute_same cmp1, cmp2
             end
+
+            it "does merge compositions regardless of the existence of an externally added dependency relation" do
+                srv_m = Syskit::DataService.new_submodel do
+                    output_port 'out', '/double'
+                end
+                task_m = Syskit::TaskContext.new_submodel do
+                    output_port 'out1', '/double'
+                    output_port 'out2', '/double'
+                end
+                task_m.provides srv_m, 'out' => 'out1', as: 'out1'
+                task_m.provides srv_m, 'out' => 'out2', as: 'out2'
+                cmp_m = Syskit::Composition.new_submodel
+                cmp_m.add srv_m, as: 'test'
+                cmp_m.export cmp_m.test_child.out_port
+
+                syskit_stub_deployment_model(task_m, 'deployed-task')
+                cmp1 = syskit_deploy(cmp_m.use(task_m.out1_srv))
+                cmp2 = cmp_m.use(task_m.out2_srv).as_plan
+                cmp1.depends_on cmp2
+                cmp2_srv = cmp2.as_service
+                cmp2.planning_task.start!
+                syskit_deploy
+                assert_equal Set[cmp1, cmp2, cmp2_srv.task], plan.find_tasks(cmp_m).to_set
+            end
         end
     end
 

--- a/test/network_generation/test_merge_solver.rb
+++ b/test/network_generation/test_merge_solver.rb
@@ -62,42 +62,98 @@ describe Syskit::NetworkGeneration::MergeSolver do
             flexmock(solver).should_receive(:resolve_input_matching).with(task, target_task).and_return([]).once
             assert_same true, solver.resolve_single_merge(task, target_task)
         end
-        it "returns true for compositions without children" do
-            plan.add(c0 = simple_composition_model.new)
-            plan.add(c1 = simple_composition_model.new)
-            assert solver.resolve_single_merge(c0, c1)
-        end
-        it "returns true for compositions that have the same children" do
-            plan.add(t = simple_component_model.new)
-            plan.add(c0 = simple_composition_model.new)
-            c0.depends_on(t)
-            plan.add(c1 = simple_composition_model.new)
-            c1.depends_on(t)
-            assert solver.resolve_single_merge(c0, c1)
-        end
-        it "returns false for compositions that have different children" do
-            plan.add(t0 = simple_component_model.new)
-            plan.add(c0 = simple_composition_model.new)
-            plan.add(t1 = simple_component_model.new)
-            plan.add(c1 = simple_composition_model.new)
-            c0.depends_on(t0, role: 'child')
-            c1.depends_on(t1, role: 'child')
-            assert_same false, solver.resolve_single_merge(c0, c1)
-        end
-        it "returns false for compositions that have the same child task but in different roles" do
-            plan.add(t = simple_component_model.new)
-            plan.add(c0 = simple_composition_model.new)
-            c0.depends_on(t, role: 'child0')
-            plan.add(c1 = simple_composition_model.new)
-            c1.depends_on(t, role: 'child1')
-            assert_same false, solver.resolve_single_merge(c0, c1)
-        end
         it "returns false for tasks that have execution agents" do
             plan.add(t1 = simple_component_model.new)
             plan.add(t2 = simple_composition_model.new)
             flexmock(t1).should_receive(:execution_agent).and_return(true)
             assert_same false, solver.resolve_single_merge(t1, t2)
             assert_same false, solver.resolve_single_merge(t2, t1)
+        end
+        describe "compositions" do
+            attr_reader :task_m, :cmp_m
+            before do
+                @task_m = Syskit::TaskContext.new_submodel
+                @cmp_m  = Syskit::Composition.new_submodel
+                cmp_m.add task_m, as: 'child'
+            end
+
+            it "returns true for compositions without children" do
+                plan.add(c0 = cmp_m.new)
+                plan.add(c1 = cmp_m.new)
+                assert solver.resolve_single_merge(c0, c1)
+            end
+            it "returns true for compositions that have the same children" do
+                plan.add(t = task_m.new)
+                plan.add(c0 = cmp_m.new)
+                c0.depends_on(t, role: 'child')
+                plan.add(c1 = cmp_m.new)
+                c1.depends_on(t, role: 'child')
+                assert solver.resolve_single_merge(c0, c1)
+            end
+            it "returns false for compositions that have different children" do
+                plan.add(t0 = task_m.new)
+                plan.add(c0 = cmp_m.new)
+                plan.add(t1 = task_m.new)
+                plan.add(c1 = cmp_m.new)
+                c0.depends_on(t0, role: 'child')
+                c1.depends_on(t1, role: 'child')
+                assert_same false, solver.resolve_single_merge(c0, c1)
+            end
+            it "returns false for compositions that have the same children but the exported output ports differ" do
+                srv_m = Syskit::DataService.new_submodel do
+                    output_port 'out', '/double'
+                end
+                task_m = Syskit::TaskContext.new_submodel do
+                    output_port 'out1', '/double'
+                    provides srv_m, as: 'test1', 'out' => 'out1'
+                    output_port 'out2', '/double'
+                    provides srv_m, as: 'test2', 'out' => 'out2'
+                end
+                cmp_m  = Syskit::Composition.new_submodel do
+                    add srv_m, as: 'test'
+                    export test_child.out_port
+                end
+
+                plan.add(child = task_m.new)
+                cmp1 = cmp_m.use('test' => child.test1_srv).instanciate(plan)
+                cmp2 = cmp_m.use('test' => child.test2_srv).instanciate(plan)
+
+                assert_same false, solver.resolve_single_merge(cmp1, cmp2)
+                assert_same false, solver.resolve_single_merge(cmp2, cmp1)
+            end
+            it "returns false for compositions that have the same children but the exported input ports differ" do
+                srv_m = Syskit::DataService.new_submodel do
+                    input_port 'in', '/double'
+                end
+                task_m = Syskit::TaskContext.new_submodel do
+                    input_port 'in1', '/double'
+                    provides srv_m, as: 'test1', 'in' => 'in1'
+                    input_port 'in2', '/double'
+                    provides srv_m, as: 'test2', 'in' => 'in2'
+                end
+                cmp_m  = Syskit::Composition.new_submodel do
+                    add srv_m, as: 'test'
+                    export test_child.in_port
+                end
+
+                plan.add(child = task_m.new)
+                cmp1 = cmp_m.use('test' => child.test1_srv).instanciate(plan)
+                cmp2 = cmp_m.use('test' => child.test2_srv).instanciate(plan)
+
+                assert_same false, solver.resolve_single_merge(cmp1, cmp2)
+                assert_same false, solver.resolve_single_merge(cmp2, cmp1)
+            end
+            it "returns true for compositions that differ only on children whose role is not part of the model" do
+                plan.add(child = task_m.new)
+                plan.add(task  = task_m.new)
+                plan.add(c0 = cmp_m.new)
+                plan.add(c1 = cmp_m.new)
+                c0.depends_on(child, role: 'child')
+                c1.depends_on(child, role: 'child')
+                c0.depends_on task
+                assert_same true, solver.resolve_single_merge(c0, c1)
+                assert_same true, solver.resolve_single_merge(c1, c0)
+            end
         end
     end
     


### PR DESCRIPTION
This fixes a few corner cases when deploying compositions. They were hit (but not caught) by the data monitor / fault table tests, in which it is common to monitor different outputs of the same network - one for monitoring and one for real usage.