### PR TITLE
fix NoMethodError when reloading configuration in the shell

### DIFF
--- a/lib/syskit/shell_interface.rb
+++ b/lib/syskit/shell_interface.rb
@@ -38,7 +38,7 @@ module Syskit
         # Helper method that makes sure that changed configuration files will
         # cause the relevant tasks to be reconfigured in the next re-deployment
         def mark_changed_configuration_as_not_reusable(changed)
-            TaskContext.configured.each do |task_name, (syskit_model, current_conf, _)|
+            TaskContext.needs_reconfiguration.each do |task_name, (syskit_model, current_conf, _)|
                 changed_conf = changed[syskit_model.concrete_model]
 
                 if changed_conf && current_conf.any? { |section_name| changed_conf.include?(section_name) }

--- a/test/suite.rb
+++ b/test/suite.rb
@@ -37,6 +37,7 @@ require './test/test_data_flow'
 require './test/test_dependency_injection'
 require './test/test_dependency_injection_context'
 require './test/test_instance_requirements_task'
+require './test/test_shell_interface'
 
 require './test/test_exceptions'
 


### PR DESCRIPTION
The syskit.reload_config() was reporting "unknown configured method". This fix the error message, anything else need to be done?