### PR TITLE
actions: pass more information when droby-marshalling/demarshalling an action

### DIFF
--- a/lib/syskit/instance_requirements.rb
+++ b/lib/syskit/instance_requirements.rb
@@ -916,7 +916,7 @@ module Syskit
                     result << ".use#{use_suffix}(#{selections})"
                 end
                 if !arguments.empty?
-                    result << ".with_arguments(#{arguments.map { |k, v| "#{k} => #{v}" }})"
+                    result << ".with_arguments(#{arguments.map { |k, v| "#{k}: #{v}" }.join(", ")})"
                 end
                 result
             end

--- a/test/actions/test_action_model.rb
+++ b/test/actions/test_action_model.rb
@@ -50,6 +50,18 @@ describe Syskit::Actions::Models::Action do
             assert_raises(TypeError) { Marshal.dump(requirements) }
             assert_droby_compatible(action_m)
         end
+        it "passes along the requirements name, model and arguments" do
+            requirements.name = "bla_def"
+            requirements.with_arguments(test: 10, other: flexmock(droby_dump: 20))
+
+            remote_marshaller = Roby::DRoby::Marshal.new
+            reloaded = assert_droby_compatible(action_m, remote_marshaller: remote_marshaller)
+            reloaded_task_m = remote_marshaller.object_manager.find_model_by_name('Test')
+            assert_equal reloaded_task_m, reloaded.returned_type
+            assert_equal reloaded_task_m, reloaded.requirements.model
+            assert_equal "bla_def", reloaded.requirements.name
+            assert_equal Hash[test: 10, other: 20], reloaded.requirements.arguments
+        end
         it "passes along the returned type" do
             remote_marshaller = Roby::DRoby::Marshal.new
             reloaded = assert_droby_compatible(action_m, remote_marshaller: remote_marshaller)


### PR DESCRIPTION
On the user-visible side, this fixes displaying Syskit actions in the
roby shell.

Depends on:
- [ ] https://github.com/rock-core/tools-roby/pull/61