### PR TITLE
new orogen model syntax

### DIFF
--- a/generators/orogen/orogen_generator.rb
+++ b/generators/orogen/orogen_generator.rb
@@ -3,18 +3,13 @@ require 'roby/app/gen'
 class OrogenGenerator < Roby::App::GenBase
     attr_reader :project_name
     attr_reader :project
-    attr_reader :classes
-    attr_reader :orogen_project_module_name
+    attr_reader :orogen_models
 
     def initialize(runtime_args, runtime_options = Hash.new)
         super
         @project_name = runtime_args.shift
         @project = Roby.app.using_task_library(project_name)
-        @classes = Array.new
-        project.self_tasks.each_value do |orogen_task|
-            classes << Syskit::TaskContext.syskit_names_from_orogen_name(orogen_task.name)
-        end
-        @orogen_project_module_name = project_name.camelcase(:upper)
+        @orogen_models = project.self_tasks.values
     end
     
     def manifest
@@ -23,9 +18,8 @@ class OrogenGenerator < Roby::App::GenBase
             m.directory "models/#{subdir}"
             m.directory "test/#{subdir}"
             local_vars = Hash[
-                'classes' => classes,
-                'orogen_project_name' => project_name,
-                'orogen_project_module_name' => orogen_project_module_name]
+                'orogen_models' => orogen_models,
+                'orogen_project_name' => project_name]
             m.template 'class.rb', "models/#{subdir}/#{project_name}.rb", :assigns => local_vars
             m.template 'test.rb', "test/#{subdir}/test_#{project_name}.rb", :assigns => local_vars
         end

--- a/generators/orogen/templates/class.rb
+++ b/generators/orogen/templates/class.rb
@@ -1,4 +1,4 @@
-<% classes.each do |class_name| %>class OroGen::<%= class_name.join("::") %>
+<% orogen_models.each do |model| %>Syskit.extend_model OroGen.<%= model.name.gsub("::", ".") %> do
     # Customizes the configuration step.
     #
     # The orocos task is available from orocos_task

--- a/generators/orogen/templates/test.rb
+++ b/generators/orogen/templates/test.rb
@@ -1,8 +1,8 @@
 using_task_library '<%= orogen_project_name %>'
-<% indent, open, close = ::Roby::App::GenBase.in_module("OroGen", orogen_project_module_name) %>
+<% indent, open, close = ::Roby::App::GenBase.in_module("OroGen") %>
 <%= open %>
-<% classes.each do |class_name| %>
-<%= indent %>describe <%= class_name.last %> do
+<% orogen_models.each do |model| %>
+<%= indent %>describe OroGen.<%= model.name.gsub("::", ".") %> do
 <%= indent %>    it { is_configurable }
 <%= indent %>end
 <% end %>

--- a/lib/syskit.rb
+++ b/lib/syskit.rb
@@ -17,6 +17,7 @@ require 'syskit/base'
 
 require 'syskit/instance_requirements'
 
+require 'syskit/orogen_namespace'
 require 'syskit/roby_app'
 
 # Models

--- a/lib/syskit/actions/profile.rb
+++ b/lib/syskit/actions/profile.rb
@@ -348,6 +348,20 @@ module Syskit
                 definitions.has_key?(name)
             end
 
+            # Enumerate the definitions
+            #
+            # @yieldparam [Definition] definition
+            # @return [void]
+            def each_definition
+                return enum_for(__method__) if !block_given?
+
+                definitions.each do |name, definition|
+                    definition = definition.dup
+                    definition.name = name
+                    yield(definition)
+                end
+            end
+
             # Returns the instance requirement object that represents the given
             # definition
             #

--- a/lib/syskit/droby/enable.rb
+++ b/lib/syskit/droby/enable.rb
@@ -7,7 +7,9 @@ Typelib::Type.include Syskit::DRoby::V5::TypelibTypeDumper
 Typelib::Type.extend Syskit::DRoby::V5::TypelibTypeModelDumper
 
 Roby::DRoby::ObjectManager.include Syskit::DRoby::V5::ObjectManagerExtension
+Roby::DRoby::Marshal.include Syskit::DRoby::V5::MarshalExtension
 
 Syskit::InstanceRequirements.include Syskit::DRoby::V5::InstanceRequirementsDumper
 Syskit::Models::ComBusModel.include Syskit::DRoby::V5::ComBusDumper
 Syskit::Actions::Profile.include Syskit::DRoby::V5::ProfileDumper
+Syskit::TaskContext.extend Syskit::DRoby::V5::Models::TaskContextDumper

--- a/lib/syskit/droby/v5/droby_dump.rb
+++ b/lib/syskit/droby/v5/droby_dump.rb
@@ -274,6 +274,14 @@ module Syskit
 
                             local_model
                         end
+
+                        def update(peer, local_object, fresh_proxy: false)
+                            @types.each do |type|
+                                peer.register_typelib_model(
+                                    peer.local_object(type))
+                            end
+                            super
+                        end
                     end
 
                     def droby_dump(peer)

--- a/lib/syskit/droby/v5/droby_dump.rb
+++ b/lib/syskit/droby/v5/droby_dump.rb
@@ -235,8 +235,6 @@ module Syskit
                         end
 
                         def create_new_proxy_model(peer)
-                            supermodel = peer.local_model(self.supermodel)
-
                             @types.each do |type|
                                 peer.register_typelib_model(
                                     peer.local_object(type))
@@ -274,18 +272,14 @@ module Syskit
                                 peer.register_orogen_model(local_model, remote_siblings)
                             end
 
-
-                            # This looks useless, but it actually does ensure
-                            # that the peer-local info gets registered, thus
-                            # allowing further unmarshalling that would depend
-                            # on it
-                            @provided_models.each { |m| peer.local_object(m) }
                             local_model
                         end
                     end
 
                     def droby_dump(peer)
                         supermodel = Roby::DRoby::V5::DRobyModel.dump_supermodel(peer, self)
+                        provided_models = Roby::DRoby::V5::DRobyModel.
+                            dump_provided_models_of(peer, self)
 
                         types = orogen_model.each_interface_type.
                             map { |t| peer.dump(t) }
@@ -309,7 +303,7 @@ module Syskit
                             peer.known_siblings_for(self),
                             arguments,
                             supermodel,
-                            Roby::DRoby::V5::DRobyModel.dump_provided_models_of(peer, self),
+                            provided_models,
                             each_event.map { |_, ev| [ev.symbol, ev.controlable?, ev.terminal?] },
                             orogen_name, orogen_superclass_name, project_name, project_text, types)
                     end

--- a/lib/syskit/droby/v5/droby_dump.rb
+++ b/lib/syskit/droby/v5/droby_dump.rb
@@ -1,6 +1,64 @@
 module Syskit
     module DRoby
         module V5
+            module MarshalExtension
+                def has_orogen_project?(project_name)
+                    object_manager.has_orogen_project?(project_name)
+                end
+
+                def add_orogen_project(project_name, project_text)
+                    object_manager.add_orogen_project(project_name, project_text)
+                end
+
+                def orogen_task_context_model_from_name(name)
+                    object_manager.orogen_task_context_model_from_name(name)
+                end
+
+                def register_orogen_model(local_model, remote_siblings)
+                    object_manager.register_orogen_model(local_model, remote_siblings)
+                end
+
+                def register_typelib_model(type)
+                    object_manager.register_typelib_model(type)
+                end
+
+                def find_local_orogen_model(droby)
+                    find_local_model(droby, name: "orogen::" + droby.orogen_name)
+                end
+            end
+
+            module ObjectManagerExtension
+                # The typelib registry on which we define types transmitted by
+                # our peer
+                attribute(:typelib_registry) { Typelib::Registry.new }
+
+                # The loader used to register models transmitted by our peer
+                def orogen_loader
+                    Roby.app.default_loader
+                end
+
+                def has_orogen_project?(project_name)
+                    orogen_loader.has_project?(project_name)
+                end
+
+                def add_orogen_project(project_name, project_text)
+                    orogen_loader.project_model_from_text(project_text, name: project_name)
+                end
+
+                def orogen_task_context_model_from_name(name)
+                    orogen_loader.task_model_from_name(name)
+                end
+
+                def register_orogen_model(local_model, remote_siblings)
+                    orogen_loader.register_task_context_model(local_model.orogen_model)
+                    register_model(local_model, remote_siblings, name: 'orogen::' + local_model.orogen_model.name)
+                end
+
+                def register_typelib_model(type)
+                    orogen_loader.register_type_model(type)
+                end
+            end
+
             module ComBusDumper
                 # Must include this, Roby uses it to know which models can be
                 # dumped and which not
@@ -68,10 +126,6 @@ module Syskit
                 def droby_dump(peer)
                     DRoby.new(to_byte_array, peer.dump(self.class))
                 end
-            end
-
-            module ObjectManagerExtension
-                attribute(:typelib_registry) { Typelib::Registry.new }
             end
 
             # Module used to allow droby-marshalling of Typelib types
@@ -156,6 +210,87 @@ module Syskit
                 end
 
                 def clear_owners
+                end
+            end
+
+            module Models
+                module TaskContextDumper
+                    include Roby::DRoby::V5::Models::TaskDumper
+
+                    class DRoby < Roby::DRoby::V5::Models::TaskDumper::DRoby
+                        attr_reader :orogen_name
+
+                        def initialize(name, remote_siblings, arguments, supermodel, provided_models, events,
+                            orogen_name, orogen_superclass_name, project_name, project_text, types)
+                            super(name, remote_siblings, arguments, supermodel, provided_models, events)
+                            @orogen_name, @orogen_superclass_name, @project_name, @project_text, @types =
+                                orogen_name, orogen_superclass_name, project_name, project_text, types
+                        end
+
+                        def create_new_proxy_model(peer)
+                            supermodel = peer.local_model(self.supermodel)
+
+                            @types.each do |type|
+                                peer.register_typelib_model(
+                                    peer.local_object(type))
+                            end
+
+                            if @project_text && !peer.has_orogen_project?(@project_name)
+                                peer.add_orogen_project(
+                                    @project_name, @project_text)
+                            end
+
+                            begin
+                                orogen_model = peer.
+                                    orogen_task_context_model_from_name(@orogen_name)
+                                local_model = Syskit::TaskContext.
+                                    define_from_orogen(orogen_model, register: false)
+                            rescue OroGen::TaskModelNotFound
+                                orogen_model = OroGen::Spec::TaskContext.new(
+                                    Roby.app.default_orogen_project, @orogen_name)
+                                if @orogen_superclass_name
+                                    orogen_model.subclasses @orogen_superclass_name
+                                end
+                                local_model = Syskit::TaskContext.
+                                    define_from_orogen(orogen_model, register: false)
+                                peer.register_orogen_model(local_model, remote_siblings)
+                            end
+
+                            # This looks useless, but it actually does ensure
+                            # that the peer-local info gets registered, thus
+                            # allowing further unmarshalling that would depend
+                            # on it
+                            @provided_models.each { |m| peer.local_object(m) }
+                            local_model
+                        end
+                    end
+
+                    def droby_dump(peer)
+                        orogen_name = orogen_model.name
+                        if orogen_model.name && (project_name = orogen_model.project.name)
+                            begin
+                                project_text, _ = orogen_model.project.loader.
+                                    project_model_text_from_name(project_name)
+                            rescue OroGen::ProjectNotFound
+                            end
+                        end
+                        types = orogen_model.each_interface_type.
+                            map { |t| peer.dump(t) }
+
+                        if orogen_model.superclass
+                            orogen_superclass_name = orogen_model.superclass.name
+                        end
+
+                        peer.register_model(self)
+                        DRoby.new(
+                            name,
+                            peer.known_siblings_for(self),
+                            arguments,
+                            Roby::DRoby::V5::DRobyModel.dump_supermodel(peer, self),
+                            Roby::DRoby::V5::DRobyModel.dump_provided_models_of(peer, self),
+                            each_event.map { |_, ev| [ev.symbol, ev.controlable?, ev.terminal?] },
+                            orogen_name, orogen_superclass_name, project_name, project_text, types)
+                    end
                 end
             end
         end

--- a/lib/syskit/droby/v5/droby_dump.rb
+++ b/lib/syskit/droby/v5/droby_dump.rb
@@ -285,6 +285,11 @@ module Syskit
                     end
 
                     def droby_dump(peer)
+                        supermodel = Roby::DRoby::V5::DRobyModel.dump_supermodel(peer, self)
+
+                        types = orogen_model.each_interface_type.
+                            map { |t| peer.dump(t) }
+
                         orogen_name = orogen_model.name
                         if orogen_model.name && (project_name = orogen_model.project.name)
                             begin
@@ -293,8 +298,6 @@ module Syskit
                             rescue OroGen::ProjectNotFound
                             end
                         end
-                        types = orogen_model.each_interface_type.
-                            map { |t| peer.dump(t) }
 
                         if orogen_model.superclass
                             orogen_superclass_name = orogen_model.superclass.name
@@ -305,7 +308,7 @@ module Syskit
                             name,
                             peer.known_siblings_for(self),
                             arguments,
-                            Roby::DRoby::V5::DRobyModel.dump_supermodel(peer, self),
+                            supermodel,
                             Roby::DRoby::V5::DRobyModel.dump_provided_models_of(peer, self),
                             each_event.map { |_, ev| [ev.symbol, ev.controlable?, ev.terminal?] },
                             orogen_name, orogen_superclass_name, project_name, project_text, types)

--- a/lib/syskit/graphviz.rb
+++ b/lib/syskit/graphviz.rb
@@ -89,13 +89,18 @@ module Syskit
             end
 
             def uri_for(type)
-                "link://metaruby/" + @typelib_resolver.split_name(type).join("/")
+                "link://metaruby/" + escape_dot_uri(@typelib_resolver.split_name(type).join("/"))
+            end
+
+
+            def escape_dot_uri(string)
+                string.
+                    gsub(/</, "&lt;").
+                    gsub(/>/, "&gt;")
             end
 
             def escape_dot(string)
-                string.
-                    gsub(/</, "&lt;").
-                    gsub(/>/, "&gt;").
+                escape_dot_uri(string).
                     gsub(/[^\[\]&;:\w\. ]/, "_")
             end
 

--- a/lib/syskit/graphviz.rb
+++ b/lib/syskit/graphviz.rb
@@ -77,12 +77,17 @@ module Syskit
                 @plan = plan
                 @page = page
                 @make_links = true
+                @typelib_resolver = GUI::ModelBrowser::TypelibResolver.new
 
                 @task_annotations = Hash.new { |h, k| h[k] = Hash.new { |a, b| a[b] = Array.new } }
                 @port_annotations = Hash.new { |h, k| h[k] = Hash.new { |a, b| a[b] = Array.new } }
                 @conn_annotations = Hash.new { |h, k| h[k] = Array.new }
                 @additional_vertices = Hash.new { |h, k| h[k] = Array.new }
                 @additional_edges    = Array.new
+            end
+
+            def uri_for(type)
+                "link://metaruby/" + @typelib_resolver.split_name(type).join("/")
             end
 
             def escape_dot(string)
@@ -635,7 +640,7 @@ module Syskit
                         port_id = dot_id(p.name)
                         ann = format_annotations(port_annotations, [task, p.name])
                         doc = escape_dot(p.model.doc || '<no documentation for this port>')
-                        input_port_label << "<TR><TD HREF=\"syskit://types/#{p.type.object_id}\" TITLE=\"#{doc}\"><TABLE BORDER=\"0\" CELLBORDER=\"0\"><TR><TD PORT=\"#{port_id}\" COLSPAN=\"2\">#{p.name}</TD></TR>#{ann}</TABLE></TD></TR>"
+                        input_port_label << "<TR><TD HREF=\"#{uri_for(p.type)}\" TITLE=\"#{doc}\"><TABLE BORDER=\"0\" CELLBORDER=\"0\"><TR><TD PORT=\"#{port_id}\" COLSPAN=\"2\">#{p.name}</TD></TR>#{ann}</TABLE></TD></TR>"
                     end
                     input_port_label << "\n</TABLE>"
                     result << "    inputs#{task.dot_id} [label=< #{input_port_label} >,shape=none];"
@@ -648,7 +653,7 @@ module Syskit
                         port_id = dot_id(p.name)
                         ann = format_annotations(port_annotations, [task, p.name])
                         doc = escape_dot(p.model.doc || '<no documentation for this port>')
-                        output_port_label << "<TR><TD HREF=\"syskit://types/#{p.type.object_id}\" TITLE=\"#{doc}\"><TABLE BORDER=\"0\" CELLBORDER=\"0\"><TR><TD PORT=\"#{port_id}\" COLSPAN=\"2\">#{p.name}</TD></TR>#{ann}</TABLE></TD></TR>"
+                        output_port_label << "<TR><TD HREF=\"#{uri_for(p.type)}\" TITLE=\"#{doc}\"><TABLE BORDER=\"0\" CELLBORDER=\"0\"><TR><TD PORT=\"#{port_id}\" COLSPAN=\"2\">#{p.name}</TD></TR>#{ann}</TABLE></TD></TR>"
                     end
                     output_port_label << "\n</TABLE>"
                     result << "    outputs#{task.dot_id} [label=< #{output_port_label} >,shape=none];"

--- a/lib/syskit/graphviz.rb
+++ b/lib/syskit/graphviz.rb
@@ -94,7 +94,7 @@ module Syskit
                 string.
                     gsub(/</, "&lt;").
                     gsub(/>/, "&gt;").
-                    gsub(/[^\[\]&;:\w ]/, "_")
+                    gsub(/[^\[\]&;:\w\. ]/, "_")
             end
 
             def annotate_tasks(annotations)
@@ -681,7 +681,6 @@ module Syskit
 
                     values = values.map { |v| v.tr("<>", "[]") }
                     values = values.map { |v| v.tr("{}", "[]") }
-                    values = values.map { |v| v.tr(":", "_") }
 
                    "<TR><TD ROWSPAN=\"#{values.size()}\" VALIGN=\"TOP\" ALIGN=\"RIGHT\">#{category}</TD><TD ALIGN=\"LEFT\">#{values.first}</TD></TR>\n" +
                    values[1..-1].map { |v| "<TR><TD ALIGN=\"LEFT\">#{v}</TD></TR>" }.join("\n")

--- a/lib/syskit/gui/browse.rb
+++ b/lib/syskit/gui/browse.rb
@@ -38,8 +38,8 @@ module Syskit
             end
 
             # Select the current model using its module
-            def select_by_module(mod)
-                model_browser.select_by_module(mod)
+            def select_by_model(mod)
+                model_browser.select_by_model(mod)
             end
         end
     end

--- a/lib/syskit/gui/model_browser.rb
+++ b/lib/syskit/gui/model_browser.rb
@@ -40,7 +40,8 @@ module Syskit
                 def each_submodel(model)
                     if model == Syskit::TaskContext
                         model.each_submodel do |m|
-                        yield(m) if !m.private_specialization?
+                            excluded = (!m.name || m.private_specialization?)
+                            yield(m, excluded)
                         end
                     end
                 end

--- a/lib/syskit/gui/model_browser.rb
+++ b/lib/syskit/gui/model_browser.rb
@@ -38,8 +38,10 @@ module Syskit
                 end
 
                 def each_submodel(model)
-                    model.each_submodel do |m|
+                    if model == Syskit::TaskContext
+                        model.each_submodel do |m|
                         yield(m) if !m.private_specialization?
+                        end
                     end
                 end
             end
@@ -67,7 +69,7 @@ module Syskit
 
                 page.load_javascript File.expand_path("composer_buttons.js", File.dirname(__FILE__))
                 AVAILABLE_VIEWS.each do |view|
-                    register_type(view.root_model, view.renderer, view.name, view.priority, categories: [view.name], resolver: view.resolver || MetaRuby::GUI::ModelHierarchy::Resolver.new)
+                    register_type(view.root_model, view.renderer, view.name, view.priority, categories: [view.name], resolver: view.resolver || MetaRuby::GUI::ModelHierarchy::Resolver.new(view.root_model))
                 end
                 update_model_selector
             end

--- a/lib/syskit/gui/model_browser.rb
+++ b/lib/syskit/gui/model_browser.rb
@@ -60,6 +60,7 @@ module Syskit
 
             def initialize(parent = nil)
                 super(parent, exception_view: Roby::GUI::ExceptionView.new)
+                self.page = Page.new(@model_selector, display.page)
 
                 if ENV['SYSKIT_GUI_DEBUG_HTML']
                     display.page.settings.setAttribute(Qt::WebSettings::DeveloperExtrasEnabled, true)

--- a/lib/syskit/gui/model_views/type.rb
+++ b/lib/syskit/gui/model_views/type.rb
@@ -34,10 +34,11 @@ module Syskit::GUI
             def render(type, options = Hash.new)
                 type_rendering.render(type)
 
-                producers, consumers = [], []
+                producers, consumers = Set.new, Set.new
                 [Syskit::Component,Syskit::DataService].each do |base_model|
                     base_model.each_submodel do |submodel|
                         next if submodel.respond_to?(:proxied_data_services)
+                        next if (submodel.respond_to?(:private_specialization?) && submodel.private_specialization?) || !submodel.name
                         submodel.each_output_port do |port|
                             if port.type.name == type.name
                                 producers << [page.link_to(submodel), port.name]
@@ -51,9 +52,9 @@ module Syskit::GUI
                     end
                 end
 
-                fragment = render_port_list(producers.sort)
+                fragment = render_port_list(producers.to_a.sort)
                 page.push('Producers', fragment)
-                fragment = render_port_list(consumers.sort)
+                fragment = render_port_list(consumers.to_a.sort)
                 page.push('Consumers', fragment)
             end
 

--- a/lib/syskit/gui/page.rb
+++ b/lib/syskit/gui/page.rb
@@ -4,7 +4,23 @@ require 'metaruby/gui/html/page'
 require 'metaruby/gui/html/button'
 module Syskit
     module GUI
-        module PageExtension
+        class Page < MetaRuby::GUI::ModelBrowser::Page
+            # Returns the path part of the URI to an object
+            #
+            # Overloaded from MetaRuby to handle task contexts properly in the
+            # oroGen HTML templates. In these templates, the models are
+            # OroGen::Spec::TaskContext, but the model browser only knows about
+            # Syskit::TaskContext
+            def uri_for(object)
+                if object.kind_of?(OroGen::Spec::TaskContext)
+                    if syskit_model = Syskit::TaskContext.find_model_by_orogen(object)
+                        super(syskit_model)
+                    end
+                else
+                    super
+                end
+            end
+
             # Adds a plan representation on the page
             #
             # @param [String] title the title that should be added to the
@@ -56,6 +72,5 @@ module Syskit
                 emit :updated
             end
         end
-        MetaRuby::GUI::HTML::Page.include PageExtension
     end
 end

--- a/lib/syskit/models/task_context.rb
+++ b/lib/syskit/models/task_context.rb
@@ -118,7 +118,7 @@ module Syskit
                 if register && orogen_model.name
                     OroGen.syskit_model_toplevel_constant_registration =
                         Roby.app.backward_compatible_naming?
-                    OroGen.register_syskit_model(klass)
+                    klass.name = OroGen.register_syskit_model(klass)
                 end
 
                 klass

--- a/lib/syskit/models/task_context.rb
+++ b/lib/syskit/models/task_context.rb
@@ -6,6 +6,22 @@ module OroGen
 end
 
 module Syskit
+    # Extend an auto-generated with custom code
+    #
+    # This is used mainly for Syskit models generated from oroGen models, in
+    # extension files within models/orogen/:
+    #
+    #     Syskit.extend_model OroGen.test.Task do
+    #       def configure
+    #         super
+    #         ...
+    #       end
+    #     end
+    #
+    def self.extend_model(model, &block)
+        model.class_eval(&block)
+    end
+
     module Models
         # This module contains the model-level API for the task context models
         #

--- a/lib/syskit/orogen_namespace.rb
+++ b/lib/syskit/orogen_namespace.rb
@@ -1,0 +1,151 @@
+module Syskit
+    # Implementation of the model access as available through the OroGen
+    # toplevel constant
+    #
+    # Assuming a test project that has a test::Task component, one can
+    # access it through OroGen.test.Task
+    #
+    # It replaces the now-deprecated access through constants
+    # (OroGen::Test::Task)
+    module OroGenNamespace
+        class ProjectNamespace < BasicObject
+            # The name of the underlying oroGen project
+            attr_reader :project_name
+
+            def initialize(name)
+                @project_name = name
+                @registered_models = ::Hash.new
+                super()
+            end
+
+            def register_syskit_model(model)
+                orogen_name = model.orogen_model.name
+                prefix = "#{project_name}::"
+                if !orogen_name.start_with?(prefix)
+                    ::Kernel.raise ::ArgumentError, "#{model} does not seem to be part of the #{project_name} project"
+                end
+
+                @registered_models[orogen_name[prefix.size..-1].to_sym] = model
+            end
+
+            def respond_to_missing?(m, include_private = false)
+                @registered_models.has_key?(m)
+            end
+
+            def method_missing(m, *args, &block)
+                if model = @registered_models[m]
+                    if args.empty?
+                        return model
+                    else
+                        raise ArgumentError, "expected 0 arguments, got #{args.size}"
+                    end
+                end
+                super
+            end
+        end
+
+        attr_predicate :syskit_model_constant_registration?, true
+        attr_predicate :syskit_model_toplevel_constant_registration?, true
+
+        def self.extend_object(m)
+            super
+            m.instance_variable_set :@project_namespaces, Hash.new
+            m.instance_variable_set :@registered_models, Hash.new
+        end
+
+        def clear
+            @project_namespaces = Hash.new
+            @registered_models = Hash.new
+        end
+
+        # Resolve the registered syskit model that has the given orogen name
+        def syskit_model_by_orogen_name(name)
+            if model = @registered_models[name]
+                model
+            else raise ArgumentError, "#{name} is not registered on #{self}"
+            end
+        end
+
+        def respond_to_missing?(m, include_private = false)
+            @project_namespaces.has_key?(m)
+        end
+
+        def method_missing(m, *args, &block)
+            if project = @project_namespaces[m]
+                if args.empty?
+                    return project
+                else
+                    raise ArgumentError, "expected 0 arguments, got #{args.size}"
+                end
+            end
+            super
+        end
+
+        def register_syskit_model(model)
+            if syskit_model_constant_registration?
+                register_syskit_model_as_constant(model)
+            end
+
+            project_name = model.orogen_model.project.name
+            if !project_name
+                raise ArgumentError, "cannot register a project with no name"
+            end
+            project_ns =
+                (@project_namespaces[project_name.to_sym] ||= ProjectNamespace.new(project_name))
+
+            project_ns.register_syskit_model(model)
+            @registered_models[model.orogen_model.name] = model
+        end
+
+        # @api private
+        #
+        # Translates an orogen task context model name into the syskit
+        # equivalent
+        #
+        # @return [(String,String)] the namespace and class names
+        def syskit_names_from_orogen_name(orogen_name)
+            namespace, basename = orogen_name.split '::'
+            return namespace.camelcase(:upper), basename.camelcase(:upper)
+        end
+
+        # @api private
+        #
+        # Registers the given syskit model on the class hierarchy, using the
+        # (camelized) orogen name as a basis
+        #
+        # If there is a constant clash, the model will not be registered but
+        # its #name method will return the "right" value enclosed in <>
+        #
+        # @return [Boolean] true if the model could be registered and false
+        # otherwise
+        def register_syskit_model_as_constant(model)
+            orogen_model = model.orogen_model
+
+            namespace, basename = syskit_names_from_orogen_name(orogen_model.name)
+            if syskit_model_toplevel_constant_registration?
+                OroGenNamespace.register_syskit_model_as_constant(
+                    Object, namespace, basename, model)
+            end
+            OroGenNamespace.register_syskit_model_as_constant(
+                self, namespace, basename, model)
+        end
+
+        def self.register_syskit_model_as_constant(mod, namespace, basename, model)
+            namespace =
+                if mod.const_defined_here?(namespace)
+                    mod.const_get(namespace)
+                else 
+                    mod.const_set(namespace, Module.new)
+                end
+
+            if namespace.const_defined_here?(basename)
+                warn "there is already a constant with the name #{namespace.name}::#{basename}, I am not registering the model for #{orogen_model.name} there"
+                false
+            else
+                namespace.const_set(basename, model)
+                true
+            end
+        end
+
+    end
+end

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -638,6 +638,8 @@ module Syskit
             end
 
             def self.clear_models(app)
+                OroGen.clear
+
                 app.loaded_orogen_projects.clear
                 app.default_loader.clear
 

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -350,7 +350,7 @@ module Syskit
                 end
 
                 rtt_core_model = app.default_loader.task_model_from_name("RTT::TaskContext")
-                Syskit::TaskContext.define_from_orogen(rtt_core_model, :register => true)
+                Syskit::TaskContext.define_from_orogen(rtt_core_model, register: true)
             end
 
             # Called by the main Roby application to clear all before redoing a

--- a/lib/syskit/scripts/browse.rb
+++ b/lib/syskit/scripts/browse.rb
@@ -47,7 +47,7 @@ Scripts.run do
                     Syskit.warn "cannot find a model named #{remaining.first}"
                 end
         if model
-            main.select_by_module(model)
+            main.select_by_model(model)
         end
     end
 

--- a/lib/syskit/test/network_manipulation.rb
+++ b/lib/syskit/test/network_manipulation.rb
@@ -631,7 +631,7 @@ module Syskit
                 if guard
                     expect_execution do
                         plan.remove_free_event(guard)
-                    end.validate_unexpected_errors(false).to_run
+                    end.to_run
                 end
             end
 
@@ -661,7 +661,7 @@ module Syskit
                 if guard
                     expect_execution do
                         plan.remove_free_event(guard)
-                    end.validate_unexpected_errors(false).to_run
+                    end.to_run
                 end
             end
 
@@ -796,7 +796,7 @@ module Syskit
                 if guard
                     expect_execution do
                         plan.remove_free_event(guard)
-                    end.validate_unexpected_errors(false).to_run
+                    end.to_run
                 end
             end
             
@@ -918,7 +918,7 @@ module Syskit
                 if guard
                     expect_execution do
                         plan.remove_free_event(guard)
-                    end.validate_unexpected_errors(false).to_run
+                    end.to_run
                 end
             end
 

--- a/lib/syskit/test/self.rb
+++ b/lib/syskit/test/self.rb
@@ -62,7 +62,7 @@ module Syskit
             end
 
             Syskit.conf.register_process_server(
-                'stubs', Orocos::RubyTasks::ProcessManager.new(Roby.app.default_loader), "", host_id: 'syskit')
+                'stubs', Orocos::RubyTasks::ProcessManager.new(Roby.app.default_loader, task_context_class: Orocos::RubyTasks::StubTaskContext), "", host_id: 'syskit')
             Syskit.conf.logs.create_configuration_log(File.join(app.log_dir, 'properties'))
 
             Orocos.forbid_blocking_calls

--- a/test/actions/test_profile.rb
+++ b/test/actions/test_profile.rb
@@ -327,5 +327,14 @@ describe Syskit::Actions::Profile do
             assert test_task_1.can_merge?(test_task_2)
         end
     end
+
+    describe "#each_definition" do
+        it 'enumerates the definitions' do
+            profile = Syskit::Actions::Profile.new("name")
+            profile.define 'test1', Syskit::TaskContext
+            profile.define 'test2', Syskit::TaskContext
+            assert_equal ['test1', 'test2'], profile.each_definition.map(&:name)
+        end
+    end
 end
 

--- a/test/coordination/test_data_monitoring_table.rb
+++ b/test/coordination/test_data_monitoring_table.rb
@@ -145,13 +145,14 @@ describe Syskit::Coordination::DataMonitoringTable do
                 sample > 10
             end
 
-        recorder.should_receive(:called).with(2).once.ordered
-        recorder.should_receive(:called).with(12).once.ordered
+        recorder.should_receive(:called).with(2).ordered
+        recorder.should_receive(:called).with(12).ordered
 
         component = syskit_stub_deploy_configure_and_start(component_m)
         ruby_task = component.orocos_task.local_ruby_task
         composition = composition_m.use('test' => component.test2_srv).instanciate(plan)
         composition.depends_on composition.test_child, success: :success, remove_when_done: true
+        component.success_event.forward_to composition.success_event
         plan.add_permanent_task(composition)
 
         table = table_m.new(composition)
@@ -166,9 +167,8 @@ describe Syskit::Coordination::DataMonitoringTable do
             have_error_matching Syskit::Coordination::DataMonitoringError.match.
                 with_origin(composition)
             emit component.success_event
+            emit composition.success_event
         end
-        assert component.success?
-        composition.success_event.emit
     end
 
     it "can use whole component networks as data sources" do

--- a/test/coordination/test_models_task_extension.rb
+++ b/test/coordination/test_models_task_extension.rb
@@ -72,7 +72,7 @@ describe Syskit::Coordination::Models::TaskExtension do
         task = action_m.test_machine(arg: 0).instanciate(plan)
         recorder.should_receive(:called).with(0).once
         plan.add_mission_task(task)
-        task.start!
+        execute { task.start! }
         syskit_deploy_configure_and_start(task.current_task_child)
         task.current_task_child.orocos_task.local_ruby_task.out.write(20)
         execute_one_cycle

--- a/test/droby/test_droby_dump.rb
+++ b/test/droby/test_droby_dump.rb
@@ -217,6 +217,20 @@ module Syskit
                 assert_same unmarshalled.supermodel.orogen_model,
                     unmarshalled.orogen_model.superclass
             end
+
+            it "deals with types shared between the superclass and the subclass" do
+                parent_model = OroGen::Spec::TaskContext.new(app.default_orogen_project, 'parent::Task')
+                parent_model.output_port 'out', stub_type('/test')
+                parent_m = Syskit::TaskContext.new_submodel(orogen_model: parent_model)
+
+                child_model = OroGen::Spec::TaskContext.new(app.default_orogen_project, 'child::Task')
+                child_model.subclasses parent_model
+                child_model.output_port 'out2', stub_type('/test')
+                child_m = parent_m.new_submodel(orogen_model: child_model)
+
+                droby_transfer child_m
+                assert droby_remote_marshaller.object_manager.typelib_registry.include?('/test')
+            end
         end
     end
 end

--- a/test/models/test_task_context.rb
+++ b/test/models/test_task_context.rb
@@ -207,6 +207,15 @@ describe Syskit::Models::TaskContext do
             assert_same model, Syskit::TaskContext.define_from_orogen(orogen)
         end
 
+        it "registers the model by CamelCasing it" do
+            model = Syskit::TaskContext.new_submodel
+            project = OroGen::Spec::Project.new(app.default_orogen_project.loader)
+            project.name 'test'
+            orogen = OroGen::Spec::TaskContext.new(project, 'test::Task')
+            Syskit::TaskContext.define_from_orogen(orogen, register: true)
+            assert_same orogen, OroGen::Test::Task.orogen_model
+        end
+
         it "creates the model from the superclass if it does not exist" do
             orogen_parent = OroGen::Spec::TaskContext.new(app.default_orogen_project)
             orogen = OroGen::Spec::TaskContext.new(app.default_orogen_project)

--- a/test/network_generation/test_engine.rb
+++ b/test/network_generation/test_engine.rb
@@ -44,16 +44,18 @@ module Syskit
                 end
 
                 it "returns running InstanceRequirementsTask tasks" do
-                    planning_task.start!
+                    execute { planning_task.start! }
                     assert_equal [planning_task], Engine.discover_requirement_tasks_from_plan(plan)
                 end
                 it "returns InstanceRequirementsTask tasks that successfully finished" do
-                    planning_task.start!
-                    planning_task.success_event.emit
+                    execute do
+                        planning_task.start!
+                        planning_task.success_event.emit
+                    end
                     assert_equal [planning_task], Engine.discover_requirement_tasks_from_plan(plan)
                 end
                 it "ignores InstanceRequirementsTask tasks that failed" do
-                    planning_task.start!
+                    execute { planning_task.start! }
                     
                     expect_execution { planning_task.failed_event.emit }.to do
                         have_error_matching Roby::PlanningFailedError.match.
@@ -174,7 +176,8 @@ module Syskit
                         # Should have of course created a new task
                         refute_equal new_cmp.test_child, cmp.test_child
                         # And the old tasks should be ready to garbage-collect
-                        assert_equal [cmp, original_task].to_set, plan.static_garbage_collect.to_set
+                        assert_equal [cmp, original_task].to_set,
+                            execute { plan.static_garbage_collect.to_set }
                     end
                 end
 
@@ -203,7 +206,8 @@ module Syskit
                         assert_equal new_parent, parent
                         refute_equal new_child, child
                         # And the old tasks should be ready to garbage-collect
-                        assert_equal [child].to_set, plan.static_garbage_collect.to_set
+                        assert_equal [child].to_set,
+                            execute { plan.static_garbage_collect.to_set }
                     end
                 end
             end
@@ -322,7 +326,7 @@ module Syskit
                     flexmock(task0).should_receive(can_finalize?: false)
                     plan.add(task1 = component_m.new)
                     task1.should_configure_after(task0.stop_event)
-                    plan.garbage_task(task0)
+                    execute { plan.garbage_task(task0) }
                     task0 = syskit_engine.work_plan[task0]
                     task1 = syskit_engine.work_plan[task1]
                     assert_equal task1, syskit_engine.find_current_deployed_task([task0, task1])
@@ -368,7 +372,7 @@ module Syskit
                     deployed = syskit_deploy(composition_model)
                     # This deregisters the task from the list of requirements in the
                     # syskit engine
-                    plan.remove_task(deployed.planning_task)
+                    execute { plan.remove_task(deployed.planning_task) }
 
                     new_deployed = syskit_deploy(
                         composition_model.use('child' => task_model.with_conf('non_default')))
@@ -391,7 +395,8 @@ module Syskit
                     assert_equal [deployed_task.stop_event],
                         deployed_reconf.start_event.parent_objects(Roby::EventStructure::SyskitConfigurationPrecedence).to_a
                     plan.useful_tasks
-                    assert_equal([planning_task, deployed_task].to_set, plan.static_garbage_collect.to_set)
+                    assert_equal([planning_task, deployed_task].to_set,
+                                 execute { plan.static_garbage_collect.to_set })
                     assert(['non_default'], deployed_reconf.conf)
                 end
 
@@ -405,7 +410,7 @@ module Syskit
                     cmp, original_cmp = syskit_deploy(composition_model.use('child' => task_model))
                     child = cmp.child_child.to_task
                     child.do_not_reuse
-                    plan.remove_task(cmp.planning_task)
+                    execute { plan.remove_task(cmp.planning_task) }
 
                     new_cmp, original_new = syskit_deploy(composition_model.use('child' => task_model))
                     new_child = new_cmp.child_child
@@ -567,7 +572,7 @@ module Syskit
                         cmp2 = cmp_m.use(task_m.out2_srv).as_plan
                         cmp1.depends_on cmp2
                         cmp2_srv = cmp2.as_service
-                        cmp2.planning_task.start!
+                        execute { cmp2.planning_task.start! }
                         syskit_deploy
                         assert_equal Set[cmp1, cmp2, cmp2_srv.task], plan.find_tasks(cmp_m).to_set
                     end

--- a/test/network_generation/test_engine.rb
+++ b/test/network_generation/test_engine.rb
@@ -510,12 +510,12 @@ module Syskit
                     it "synchronizes the startup of communication busses and their supported devices" do
                         dev_driver, bus_driver = deploy_dev_and_bus
 
-                        syskit_configure(bus_driver)
-
                         bus_driver.orocos_task.local_ruby_task.create_output_port 'dev', '/int'
                         flexmock(bus_driver.orocos_task, "bus").should_receive(:start).once.globally.ordered(:bus_startup).pass_thru
                         mock_raw_port(bus_driver, 'dev').should_receive(:connect_to).once.globally.ordered(:bus_startup).pass_thru
                         flexmock(dev_driver.orocos_task, "dev").should_receive(:configure).once.globally.ordered.pass_thru
+
+                        syskit_configure(bus_driver)
                         capture_log(bus_driver, :info) do
                             capture_log(dev_driver, :info) do
                                 expect_execution.scheduler(true).to do

--- a/test/network_generation/test_logger.rb
+++ b/test/network_generation/test_logger.rb
@@ -107,14 +107,19 @@ describe Syskit::NetworkGeneration::LoggerConfigurationSupport do
                 add_logging_to_network(syskit_engine, plan)
 
             flexmock(logger).should_receive(:create_logging_port).
-                with('task.out1', task, task.out1_port).once
+                with('task.out1', task, task.out1_port).once.and_return(true)
             flexmock(logger).should_receive(:create_logging_port).
-                with('task.out2', task, task.out2_port).once
+                with('task.out2', task, task.out2_port).once.and_return(true)
             flexmock(logger).should_receive(:create_logging_port).
-                with('task.state', task, task.state_port).once
+                with('task.state', task, task.state_port).once.and_return(true)
             flexmock(Orocos.conf).should_receive(:apply)
             syskit_start_execution_agents(logger)
-            syskit_configure(logger)
+            Orocos.allow_blocking_calls do
+                logger.orocos_task.create_input_port 'task.out1', '/double'
+                logger.orocos_task.create_input_port 'task.out2', '/int32_t'
+                logger.orocos_task.create_input_port 'task.state', '/int32_t'
+                syskit_configure(logger)
+            end
         end
     end
 end

--- a/test/network_generation/test_system_network_deployer.rb
+++ b/test/network_generation/test_system_network_deployer.rb
@@ -117,7 +117,7 @@ module Syskit
                         with(on: 'machine').
                         and_return(deployment_task = flexmock(Roby::Task.new))
                     # Add it to the work plan
-                    flexmock(plan).should_receive(:add).once.with(deployment_task).ordered.pass_thru
+                    flexmock(plan).should_receive(:add).once.with([deployment_task]).ordered.pass_thru
                     # Create the task
                     deployment_task.should_receive(:task).explicitly.
                         with('task').and_return(deployed_task = flexmock).ordered

--- a/test/network_generation/test_system_network_generator.rb
+++ b/test/network_generation/test_system_network_generator.rb
@@ -113,7 +113,7 @@ module Syskit
 
                     def compute_system_network(*requirements)
                         requirements = requirements.map(&:to_instance_requirements)
-                        subject.compute_system_network(requirements, validate_generated_network: false)
+                        execute { subject.compute_system_network(requirements, validate_generated_network: false) }
                         cmp = subject.plan.find_tasks(cmp_m).to_a
                         assert_equal 1, cmp.size
                         cmp.first
@@ -135,7 +135,7 @@ module Syskit
                     it "enables the use of the abstract flag in InstanceRequirements to use an optional dep only if it is instanciated by other means" do
                         cmp = compute_system_network(cmp_m.use('test' => task_m.to_instance_requirements.abstract))
                         assert !cmp.has_role?('test')
-                        plan.remove_task(cmp)
+                        execute { plan.remove_task(cmp) }
                         cmp = compute_system_network(cmp_m.use('test' => task_m.to_instance_requirements.abstract), task_m)
                         assert cmp.has_role?('test')
                     end

--- a/test/roby_app/test_unmanaged_tasks.rb
+++ b/test/roby_app/test_unmanaged_tasks.rb
@@ -11,7 +11,7 @@ module Syskit
                 Syskit.conf.use_unmanaged_task task_model => 'unmanaged_deployment_test'
                 task = syskit_deploy(task_model)
                 @deployment_task = task.execution_agent
-                plan.remove_task(task)
+                execute { plan.remove_task(task) }
             end
 
             after do
@@ -88,8 +88,8 @@ module Syskit
 
             it "allows to kill a deployment that is ready" do
                 make_deployment_ready
-                expect_execution { deployment_task.stop_event }.
-                    to { deployment_task.stop! }
+                expect_execution { deployment_task.stop! }.
+                    to { emit deployment_task.stop_event }
             end
 
             it "aborts the execution agent if the monitor thread fails in unexpected ways" do

--- a/test/runtime/test_connection_management.rb
+++ b/test/runtime/test_connection_management.rb
@@ -252,10 +252,12 @@ module Syskit
                             describe "orocos tasks with non-static half without syskit tasks" do
                                 def prepare(source_static, sink_static)
                                     super
-                                    if source_static
-                                        plan.remove_task(sink_task)
-                                    else
-                                        plan.remove_task(source_task)
+                                    execute do
+                                        if source_static
+                                            plan.remove_task(sink_task)
+                                        else
+                                            plan.remove_task(source_task)
+                                        end
                                     end
                                     dataflow_graph.modified_tasks << source_task << sink_task
                                     ConnectionManagement.update(plan)
@@ -267,10 +269,12 @@ module Syskit
                             describe "orocos tasks with static half without syskit tasks" do
                                 def prepare(source_static, sink_static)
                                     super
-                                    if source_static
-                                        plan.remove_task(source_task)
-                                    else
-                                        plan.remove_task(sink_task)
+                                    execute do
+                                        if source_static
+                                            plan.remove_task(source_task)
+                                        else
+                                            plan.remove_task(sink_task)
+                                        end
                                     end
                                     dataflow_graph.modified_tasks << source_task << sink_task
                                     ConnectionManagement.update(plan)
@@ -282,8 +286,10 @@ module Syskit
                             describe "orocos tasks without syskit tasks" do
                                 def prepare(source_static, sink_static)
                                     super
-                                    plan.remove_task(source_task)
-                                    plan.remove_task(sink_task)
+                                    execute do
+                                        plan.remove_task(source_task)
+                                        plan.remove_task(sink_task)
+                                    end
                                     dataflow_graph.modified_tasks << source_task << sink_task
                                     ConnectionManagement.update(plan)
                                 end
@@ -854,7 +860,7 @@ _                   end
                             with(source_orocos, 'out', 'in').once.globally.ordered
                         flexmock(sink_task).should_receive(:removed_input_port_connection).
                             with(source_orocos, 'out', 'in').once.globally.ordered
-                        source_agent.stop!
+                        execute { source_agent.stop! }
                         Syskit::Runtime::ConnectionManagement.update(plan)
                     end
 
@@ -865,7 +871,7 @@ _                   end
                             with('out', sink_orocos, 'in').once.globally.ordered
                         flexmock(source_task).should_receive(:removed_output_port_connection).
                             with('out', sink_orocos, 'in').once.globally.ordered
-                        sink_agent.stop!
+                        execute { sink_agent.stop! }
                         Syskit::Runtime::ConnectionManagement.update(plan)
                     end
                 end

--- a/test/runtime/test_update_task_states.rb
+++ b/test/runtime/test_update_task_states.rb
@@ -29,11 +29,12 @@ module Syskit
 
                 it "attempts to kill it and does nothing further if that succeeds" do
                     task.should_receive(:kill_execution_agent_if_alone).pass_thru
-                    expect_execution.to { achieve { task.execution_agent.finishing? } }
+                    expect_execution.scheduler(true).to { achieve { task.execution_agent.finishing? } }
                 end
                 it "marks the task as failed-to-start if the execution agent cannot be killed" do
                     task.should_receive(:kill_execution_agent_if_alone).and_return(false)
                     failure_reason = expect_execution { Runtime.update_task_states(plan) }.
+                        scheduler(true).
                         to { fail_to_start task }
                     assert_equal "#{task} reports that it cannot be configured (FATAL_ERROR ?)",
                         failure_reason.original_exception.message

--- a/test/test_component.rb
+++ b/test/test_component.rb
@@ -441,15 +441,15 @@ describe Syskit::Component do
             component.should_configure_after(event = Roby::EventGenerator.new)
             assert !component.ready_for_setup?
             component.should_configure_after(Roby::EventGenerator.new)
-            event.emit
+            execute { event.emit }
             assert !component.ready_for_setup?
         end
         it "returns true if all the parent events in a syskit configuration precedence links are either emitted or unreachable" do
             plan.add(component = Syskit::Component.new)
             component.should_configure_after(event = Roby::EventGenerator.new)
-            event.emit
+            execute { event.emit }
             component.should_configure_after(event = Roby::EventGenerator.new)
-            event.unreachable!
+            execute { event.unreachable! }
             assert component.ready_for_setup?
         end
     end

--- a/test/test_instance_requirements_task.rb
+++ b/test/test_instance_requirements_task.rb
@@ -17,7 +17,7 @@ describe Syskit::InstanceRequirementsTask do
 
     it "triggers a network resolution when started" do
         task = plan.add_permanent_task(cmp_m.as_plan)
-        task.planning_task.start!
+        execute { task.planning_task.start! }
         assert plan.syskit_current_resolution
     end
 

--- a/test/test_orogen_namespace.rb
+++ b/test/test_orogen_namespace.rb
@@ -1,0 +1,58 @@
+require 'syskit/test/self'
+
+module Syskit
+    describe OroGenNamespace do
+        before do
+            @object = Module.new
+            @object.extend OroGenNamespace
+        end
+
+        it "gives access to a registered model by method calls" do
+            obj = flexmock(
+                orogen_model: flexmock(
+                    project: flexmock(name: 'project'),
+                    name: 'project::Task'))
+            @object.register_syskit_model(obj)
+            assert_same obj, @object.project.Task
+        end
+
+        it "raises if attempting to register a model whose project name does not match" do
+            obj = flexmock(
+                orogen_model: flexmock(
+                    project: flexmock(name: 'test'),
+                    name: 'project::Task'))
+            assert_raises(ArgumentError) do
+                @object.register_syskit_model(obj)
+            end
+        end
+
+        it "allows to resolve a project by its orogen name" do
+            obj = flexmock(
+                orogen_model: flexmock(
+                    project: flexmock(name: 'project'),
+                    name: 'project::Task'))
+            @object.register_syskit_model(obj)
+            assert_same obj, @object.syskit_model_by_orogen_name('project::Task')
+        end
+
+        it "does not register a model by constant by default" do
+            obj = flexmock(
+                orogen_model: flexmock(
+                    project: flexmock(name: 'project'),
+                    name: 'project::Task'))
+            @object.register_syskit_model(obj)
+            refute @object.const_defined?(:Project)
+        end
+
+        it "registers a model by constant by CamelCasing it if enabled" do
+            @object.syskit_model_constant_registration = true
+            obj = flexmock(
+                orogen_model: flexmock(
+                    project: flexmock(name: 'project'),
+                    name: 'project::Task'))
+            @object.register_syskit_model(obj)
+            assert @object.const_defined?(:Project)
+            assert_same obj, @object::Project::Task
+        end
+    end
+end

--- a/test/test_orogen_namespace.rb
+++ b/test/test_orogen_namespace.rb
@@ -16,16 +16,6 @@ module Syskit
             assert_same obj, @object.project.Task
         end
 
-        it "raises if attempting to register a model whose project name does not match" do
-            obj = flexmock(
-                orogen_model: flexmock(
-                    project: flexmock(name: 'test'),
-                    name: 'project::Task'))
-            assert_raises(ArgumentError) do
-                @object.register_syskit_model(obj)
-            end
-        end
-
         it "allows to resolve a project by its orogen name" do
             obj = flexmock(
                 orogen_model: flexmock(
@@ -54,5 +44,15 @@ module Syskit
             assert @object.const_defined?(:Project)
             assert_same obj, @object::Project::Task
         end
+
+        it "returns the call chain that leads to the model" do
+            flexmock(@object, name: 'test')
+            obj = flexmock(
+                orogen_model: flexmock(
+                    project: flexmock(name: 'project'),
+                    name: 'project::Task'))
+            assert_equal 'test.project.Task', @object.register_syskit_model(obj)
+        end
     end
 end
+

--- a/test/test_port.rb
+++ b/test/test_port.rb
@@ -247,7 +247,7 @@ describe Syskit::InputWriter do
             #
             # #start! runs through the synchronous event processing codepath,
             # and therefore does not call any handler
-            expect_execution.join_all_waiting_work(false).to { task.start! }
+            expect_execution { task.start! }.join_all_waiting_work(false).to_run
             expect_execution { writer.disconnect }.to { achieve { !writer.ready? } }
         end
     end
@@ -327,7 +327,7 @@ describe Syskit::OutputReader do
             #
             # #start! runs through the synchronous event processing codepath,
             # and therefore does not call any handler
-            expect_execution.join_all_waiting_work(false).to { task.start! }
+            expect_execution { task.start! }.join_all_waiting_work(false).to_run
             expect_execution { reader.disconnect }.
                 to { achieve { !reader.ready? } }
         end

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -931,7 +931,7 @@ module Syskit
             end
             it "keeps the task in the plan until the asynchronous setup is finished" do
                 plan.unmark_mission_task(task)
-                expect_execution.garbage_collect(true).join_all_waiting_work(false).to do
+                expect_execution.scheduler(true).garbage_collect(true).join_all_waiting_work(false).to do
                     achieve { task.setup? }
                 end
                 expect_execution.garbage_collect(true).to do
@@ -950,7 +950,7 @@ module Syskit
                     end
 
                 plan.unmark_mission_task(task)
-                expect_execution.join_all_waiting_work(false).garbage_collect(true).to do
+                expect_execution.scheduler(true).join_all_waiting_work(false).garbage_collect(true).to do
                     fail_to_start task
                 end
             end
@@ -1740,8 +1740,8 @@ module Syskit
                     barrier.wait(2)
                 end
 
-                def wait_for_synchronization
-                    expect_execution { yield if block_given? }.join_all_waiting_work(false).to do
+                def wait_for_synchronization(scheduler: false)
+                    expect_execution { yield if block_given? }.scheduler(scheduler).join_all_waiting_work(false).to do
                         achieve { barrier.number_waiting == 1 }
                     end
                 end
@@ -1754,7 +1754,7 @@ module Syskit
                     flexmock(task.orocos_task).should_receive(:configure).once.
                         pass_thru { barrier.wait }
                     capture_log(task, :info) do
-                        wait_for_synchronization
+                        wait_for_synchronization(scheduler: true)
                         assert_process_events_does_not_block
                     end
                 end
@@ -1782,7 +1782,7 @@ module Syskit
                     flexmock(task.orocos_task).should_receive(:cleanup).once.
                         pass_thru { barrier.wait }
                     capture_log(task, :info) do
-                        wait_for_synchronization
+                        wait_for_synchronization(scheduler: true)
                         assert_process_events_does_not_block
                     end
                 end
@@ -1791,7 +1791,7 @@ module Syskit
                     flexmock(task.orocos_task).should_receive(:reset_exception).once.
                         pass_thru { barrier.wait }
                     capture_log(task, :info) do
-                        wait_for_synchronization
+                        wait_for_synchronization(scheduler: true)
                         assert_process_events_does_not_block
                     end
                 end


### PR DESCRIPTION
Depends on:
- [x] https://github.com/rock-core/tools-roby/pull/70
- [ ] https://github.com/rock-core/tools-metaruby/pull/17

This commit implements a new syntax for OroGen model access, which does not involve the complex and confusing conversion to CamelCase.

Instead, one accesses an oroGen model with `OroGen.project_name.ModelName`. The old constant registration is still enabled and available for backward compatibility.

When using the new syntax, one cannot do

~~~
class OroGen.project_name.Task
end
~~~

but instead has to do

~~~
Syskit.extend_model OroGen.project_name.Task do
end
~~~

Because of this change, the model browser had to be refactored to handle model names that are not constant paths. This allowed me to finally fix type browsing and hyperlinks between models and types (clicking on a file in a SVG will now redirect to the type page)