### PR TITLE
disable any action-related interactions when Syskit is unreachable (closes #131)

### DIFF
--- a/lib/syskit/gui/runtime_state.rb
+++ b/lib/syskit/gui/runtime_state.rb
@@ -170,8 +170,12 @@ module Syskit
                 end
                 syskit.on_reachable do
                     @syskit_commands = syskit.client.syskit
+                    @job_status_list.each_widget do |w|
+                        w.show_actions = true
+                    end
                     update_log_server_connection(syskit.client.log_server_port)
                     action_combo.clear
+                    action_combo.enabled = true
                     syskit.actions.sort_by(&:name).each do |action|
                         next if action.advanced?
                         action_combo.add_item(action.name, Qt::Variant.new(action.doc))
@@ -184,7 +188,12 @@ module Syskit
                 end
                 syskit.on_unreachable do
                     @syskit_commands = nil
+                    @job_status_list.each_widget do |w|
+                        w.show_actions = false
+                    end
                     @ui_event_widgets.each_value(&:hide)
+                    action_combo.enabled = false
+                    @batch_manager.cancel
                     if remote_name == 'localhost'
                         global_actions[:start].visible = true
                     end
@@ -421,7 +430,7 @@ module Syskit
                 button.flat = true
                 button
             end
-            
+
             def create_ui_event_orogen_config_changed
                 syskit_orogen_config_changed = create_ui_event_frame
                 layout = Qt::HBoxLayout.new(syskit_orogen_config_changed)
@@ -486,6 +495,7 @@ module Syskit
                 label   = Qt::Label.new("New Job", self)
                 label.set_size_policy(Qt::SizePolicy::Minimum, Qt::SizePolicy::Minimum)
                 @action_combo = Qt::ComboBox.new(self)
+                action_combo.enabled = false
                 action_combo.item_delegate = ActionListDelegate.new(self)
                 new_job_layout.add_widget label
                 new_job_layout.add_widget action_combo, 1
@@ -557,4 +567,3 @@ module Syskit
         end
     end
 end
-

--- a/lib/syskit/gui/widget_list.rb
+++ b/lib/syskit/gui/widget_list.rb
@@ -27,7 +27,7 @@ module Syskit
                 end
                 @separators = Hash.new
             end
-            
+
             def add_separator(name, label, permanent: true)
                 add_widget(w = Qt::Label.new(label, self), permanent: permanent)
                 @separators[name] = w
@@ -85,7 +85,15 @@ module Syskit
                 self.size = s
                 event.accept
             end
-            
+
+            # Enumerate the widgets in the list
+            def each_widget
+                return enum_for(__method__) if !block_given?
+                @widgets.each do |item|
+                    yield(item.widget)
+                end
+            end
+
             # Clear widgets for which the given filter returns true
             #
             # It removes all widgets if no filter is given
@@ -112,5 +120,3 @@ module Syskit
         end
     end
 end
-
-


### PR DESCRIPTION
We can't interact with the batch manager while Syskit is unreachable.
Make sure that one cannot create new jobs in any way, and clear the
current batch if there's one.