### PR TITLE
runtime: report on a scheduler when a component is being configured

### DIFF
--- a/lib/syskit/runtime/update_task_states.rb
+++ b/lib/syskit/runtime/update_task_states.rb
@@ -26,8 +26,12 @@ module Syskit
                 # Ignore tasks whose process is terminating to reduce the
                 # likelihood of that happening
                 if execution_agent.finishing? || execution_agent.ready_to_die?
-		    next
-		end
+                    next
+                end
+
+                if t.setting_up?
+                    plan.execution_engine.scheduler.report_holdoff "is being configured", t
+                end
 
                 if schedule && t.pending? && !t.setup? && !t.setting_up?
                     next if !t.meets_configurationg_precedence_constraints?


### PR DESCRIPTION
This ensures that the chronicle view reports that a component is being configured (it was only saying 'not executable' before)

![screenshot_20171115_125753](https://user-images.githubusercontent.com/292/32842703-e633533a-ca04-11e7-88dc-3cb3eeb45172.png)
