### PR TITLE
fix dot's SVG output to not include < > in HREF's

### DIFF
--- a/lib/syskit/gui/page.rb
+++ b/lib/syskit/gui/page.rb
@@ -51,6 +51,10 @@ module Syskit
                     svg = e.message
                 end
 
+                # Fixup a mixup in dot's SVG output. The URIs that contain < and >
+                # are not properly escaped to &lt; and &gt;
+                svg = svg.gsub(/xlink:href="[^"]+"/) { |match| match.gsub("<", "&lt;").gsub(">", "&gt;") }
+
                 begin
                     if match = /svg width=\"(\d+)(\w+)\" height=\"(\d+)(\w+)\"/.match(svg)
                         width, w_unit, height, h_unit = *match.captures


### PR DESCRIPTION
They are properly translated to &lt; and &gt; in the geneated dot, but
then dot converts them back to < and > in the SVG. This breaks SVG
parsing of e.g. inkscape.