### PR TITLE
cli: fix help messages from 'syskit gen'

### DIFF
--- a/lib/syskit/cli/gen_main.rb
+++ b/lib/syskit/cli/gen_main.rb
@@ -4,6 +4,7 @@ require 'roby/cli/exceptions'
 module Syskit
     module CLI
         class GenMain < Roby::CLI::GenMain
+            namespace :gen
             source_paths << File.join(__dir__, 'gen')
 
             def app(dir = nil)


### PR DESCRIPTION
They were using the class name (`gen_main`) by default