### PR TITLE
Support for orogen's master/slave deployments

### DIFF
--- a/lib/syskit/deployment.rb
+++ b/lib/syskit/deployment.rb
@@ -687,9 +687,6 @@ module Syskit
                 end
 
                 Deployment.all_deployments.delete(orocos_process)
-                model.each_orogen_deployed_task_context_model do |act|
-                    name = orocos_process.get_mapped_name(act.name)
-                end
 
                 # do NOT call cleanup_dead_connections here.
                 # Runtime.update_deployment_states will first announce all the

--- a/lib/syskit/deployment.rb
+++ b/lib/syskit/deployment.rb
@@ -105,40 +105,141 @@ module Syskit
                 model.each_orogen_deployed_task_context_model(&block)
             end
 
-            # Returns an task instance that represents the given task in this
-            # deployment.
-            def task(name, model = nil)
-                if finishing? || finished?
-                    raise InvalidState, "#{self} is either finishing or already finished, you cannot call #task"
-                end
-
-                orogen_task_deployment = each_orogen_deployed_task_context_model.
+            # Either find the existing task that matches the given deployment specification,
+            # or creates and adds it.
+            #
+            # @param (see #task)
+            def find_or_create_task(name, syskit_task_model = nil, auto_conf: false)
+                orogen_task_deployment_model = each_orogen_deployed_task_context_model.
                     find { |act| name == name_mappings[act.name] }
-                if !orogen_task_deployment
-                    available = each_orogen_deployed_task_context_model.map { |act| name_mappings[act.name] }.sort.join(", ")
-                    mappings  = name_mappings.map { |k,v| "#{k} => #{v}" }.join(", ")
-                    raise ArgumentError, "no task called #{name} in #{self.class.deployment_name}, available tasks are #{available} using name mappings #{name_mappings}"
+                if orogen_master = orogen_task_deployment_model.master
+                    mapped_master = name_mappings[orogen_master.name]
+                    scheduler_task = find_or_create_task(
+                        mapped_master, auto_conf: true)
+                    candidates = scheduler_task.each_parent_task
+                else
+                    candidates = each_executed_task
                 end
 
-                orogen_task_model = TaskContext.model_for(orogen_task_deployment.task_model)
-                if model
-                    if !(model <= orogen_task_model)
-                        raise ArgumentError, "incompatible explicit selection #{model} for the model of #{name} in #{self}"
+                # I don't know why name_mappings[orogen.name] would not be
+                # equal to 'name' and I couldn't find a reason for this in the
+                # git history when I refactored this.
+                #
+                # I keep it here for now, just in case, but that would need to
+                # be investigated
+                #
+                # TODO
+                mapped_name = name_mappings[orogen_task_deployment_model.name]
+                candidates.each do |task|
+                    return task if task.orocos_name == mapped_name
+                end
+
+                create_deployed_task(
+                    orogen_task_deployment_model,
+                    syskit_task_model,
+                    scheduler_task, auto_conf: auto_conf)
+            end
+
+            # @api private
+            #
+            # Create and add a task model supported by this deployment
+            #
+            # @param [OroGen::Spec::TaskDeployment] orogen_task_deployment_model
+            #   the orogen model that describes this
+            #   deployment
+            # @param [Models::TaskContext,nil] syskit_task_model the expected syskit task model, or nil
+            #   if it is meant to use the basic model. This is useful in specialized models (e.g. dynamic
+            #   services)
+            # @param [Deployment,TaskContext] syskit_execution_agent the task that will be used as an execution agent.
+            #   this is usually self, but may be a task in master/slave relationships.
+            # @param [Boolean] auto_conf if true, the method will attempt to select
+            #   a configuration that matches the task's orocos name (if it exists). This
+            #   is mostly used for scheduling tasks, which are automatically instanciated
+            #   by Syskit.
+            #
+            # @see find_or_create_task task
+            def create_deployed_task(orogen_task_deployment_model,
+                syskit_task_model, scheduler_task, auto_conf: false)
+
+                mapped_name = name_mappings[orogen_task_deployment_model.name]
+                base_syskit_task_model = TaskContext.
+                    model_for(orogen_task_deployment_model.task_model)
+                if syskit_task_model
+                    if !(syskit_task_model <= base_syskit_task_model)
+                        raise ArgumentError, "incompatible explicit selection of task "\
+                            "model #{syskit_task_model} for the model of #{mapped_name} "\
+                            " in #{self}"
                     end
                 else
-                    model = orogen_task_model
+                    syskit_task_model = base_syskit_task_model
                 end
-                plan.add(task = model.new(orocos_name: name_mappings[orogen_task_deployment.name]))
+
+                plan.add(task = syskit_task_model.new(orocos_name: mapped_name))
                 task.executed_by self
-                task.orogen_model = orogen_task_deployment
+                if scheduler_task
+                    task.depends_on scheduler_task, role: 'scheduler'
+                    task.should_configure_after scheduler_task.start_event
+                end
+
+                task.orogen_model = orogen_task_deployment_model
                 if ready?
-                    if remote_task = remote_task_handles[name]
+                    if remote_task = remote_task_handles[mapped_name]
                         task.initialize_remote_handles(remote_task)
                     else
-                        raise InternalError, "no handle under then #{name} in #{self} for #{task} (got #{remote_task_handles.keys.sort.join(", ")})"
+                        raise InternalError, "no remote handle describing #{mapped_name} in #{self} for #{task} (got #{remote_task_handles.keys.sort.join(", ")})"
                     end
                 end
+                auto_select_conf(task) if auto_conf
                 task
+            end
+
+            # Returns an task instance that represents the given task in this
+            # deployment.
+            #
+            # @param [String] name the unmapped name of the task
+            # @param [Models::TaskContext,nil] syskit_task_model the Syskit
+            #   model that should be used to create the task, if it is not the
+            #   same as the base model. This is used for specialized models (e.g.
+            #   dynamic services)
+            def task(name, syskit_task_model = nil)
+                if finishing? || finished?
+                    raise InvalidState, "#{self} is either finishing or already "\
+                        "finished, you cannot call #task"
+                end
+
+                orogen_task_deployment_model = each_orogen_deployed_task_context_model.
+                    find { |act| name == name_mappings[act.name] }
+                if !orogen_task_deployment_model
+                    available = each_orogen_deployed_task_context_model.
+                        map { |act| name_mappings[act.name] }.sort.join(", ")
+                    mappings  = name_mappings.map { |k,v| "#{k} => #{v}" }.join(", ")
+                    raise ArgumentError, "no task called #{name} in "\
+                        "#{self.class.deployment_name}, available tasks are #{available}"\
+                        " using name mappings #{mappings}"
+                end
+
+                if orogen_master = orogen_task_deployment_model.master
+                    scheduler_task = find_or_create_task(
+                        orogen_master.name, auto_conf: true)
+                end
+                create_deployed_task(orogen_task_deployment_model,
+                    syskit_task_model, scheduler_task)
+            end
+
+            # Selects the configuration of a master task
+            #
+            # Master tasks are auto-injected in the network, and as such the
+            # user cannot select their configuration. This picks either
+            # ['default', task.orocos_name] if the master task's has a configuration
+            # section matching the task's name, or ['default'] otherwise.
+            private def auto_select_conf(task)
+                manager = task.model.configuration_manager
+                task.conf =
+                    if manager.has_section?(task.orocos_name)
+                        ['default', task.orocos_name]
+                    else
+                        ['default']
+                    end
             end
 
             ##
@@ -159,7 +260,7 @@ module Syskit
                 end
 
                 spawn_options = spawn_options.merge(
-                    output: "%m-%p.txt", 
+                    output: "%m-%p.txt",
                     wait: false,
                     cmdline_args: options)
 
@@ -195,9 +296,9 @@ module Syskit
                     loader: Roby.app.default_pkgconfig_loader)
 
                 cmdline_args = cmdline_args.dup
-                each_default_run_option do |name, value|
-                    if !cmdline_args.has_key?(name)
-                        cmdline_args[name] = value
+                each_default_run_option do |option_name, option_value|
+                    if !cmdline_args.has_key?(option_name)
+                        cmdline_args[option_name] = option_value
                     end
                 end
 
@@ -487,7 +588,7 @@ module Syskit
                         raise InternalError, "expected #{orocos_process}'s reported tasks to include mapped_task_name, but got handles only for invalid_name"
                     end
                 end
-                
+
                 remote_tasks.each_value do |task|
                     task.handle.process = nil
                 end
@@ -599,7 +700,7 @@ module Syskit
 
             # Returns the deployment object that matches the given process
             # object
-            # 
+            #
             # @param process the deployment's process object. Note that it is
             #   usually not a Ruby Process object, but a process representation
             #   from orocosrb's process server infrastructure
@@ -608,5 +709,3 @@ module Syskit
             end
         end
 end
-
-

--- a/lib/syskit/exceptions.rb
+++ b/lib/syskit/exceptions.rb
@@ -938,23 +938,28 @@ module Syskit
         # been called on a port that is being modified
         class ModifyingFinalizedPortInfo < ArgumentError
             attr_reader :task, :port_name, :done_at
-            def initialize(task, port_name, done_at)
+            def initialize(task, port_name, done_at, propagation_class_name)
                 @task = task
                 @port_name = port_name
                 @done_at = done_at
+                @propagation_class_name = propagation_class_name
             end
 
             def pretty_print(pp)
-                pp.text "trying to change port information for #{task}.#{port_name} after done_port_info has been called"
+                pp.text "trying to change port information in #{@propagation_class_name} for #{task}.#{port_name} after done_port_info has been called"
                 pp.breakable
                 if done_at
-                    pp.text "done_port_info called at"
+                    pp.text "== START done_port_info called at"
                     done_at.each do |line|
-                        pp.breakable
-                        pp.text "  #{line}"
+                        pp.nest(4) do
+                            pp.breakable
+                            pp.text line
+                        end
                     end
+                    pp.breakable
+                    pp.text "== END done_port_info called at"
                 else
-                    pp.text "turn on debugging to get a full backtrace of where done_port_info was called"
+                    pp.text "set the logger for #{@propagation_class_name.gsub('::', '/')} to DEBUG to get a full backtrace of where done_port_info was called"
                 end
             end
         end

--- a/lib/syskit/graphviz.rb
+++ b/lib/syskit/graphviz.rb
@@ -744,6 +744,7 @@ module Syskit
                         name = task.concrete_model.name || ""
                     end
 
+                    name = name.dup
                     if task.execution_agent && task.respond_to?(:orocos_name)
                         name << "[#{task.orocos_name}]"
                     end

--- a/lib/syskit/models/component.rb
+++ b/lib/syskit/models/component.rb
@@ -75,7 +75,7 @@ module Syskit
             # Generic data service selection method, based on a service type
             # and an optional service name. It implements the following
             # algorithm:
-            #  
+            #
             #  * only services that match +target_model+ are considered
             #  * if there is only one service of that type and no pattern is
             #    given, that service is returned
@@ -119,7 +119,7 @@ module Syskit
             def stub(&block)
                 stub_modules.first.class_eval(&block)
             end
-            
+
             # Apply what's necessary for this component (from the underlying
             # component implementation) to be a proper component stub
             def prepare_stub(component)
@@ -160,7 +160,7 @@ module Syskit
                 end
             end
 
-            # Generic instanciation of a component. 
+            # Generic instanciation of a component.
             #
             # It creates a new task from the component model using
             # Component.new, adds it to the plan and returns it.
@@ -249,7 +249,7 @@ module Syskit
 
 	    # Defined to be compatible, in port mapping code, with the data services
             def port_mappings_for(model)
-                if model.kind_of?(Class) 
+                if model.kind_of?(Class)
                     if fullfills?(model)
                         mappings = Hash.new
                         model.each_port do |port|
@@ -329,7 +329,7 @@ module Syskit
                     elsif !to.respond_to?(:to_str)
                         raise ArgumentError, "unexpected value given in port mapping: #{to}, expected a string"
                     else
-                        normalized_mappings[from] = to 
+                        normalized_mappings[from] = to
                     end
                 end
 
@@ -424,7 +424,7 @@ module Syskit
             # ports that are not mapped to the task are automatically created
             # (provided a corresponding dynamic_input_port or
             # dynamic_output_port declaration exists on the oroGen model).
-            # 
+            #
             # @param [Syskit::DataService] service_model the service model
             # @param [Hash] port_mappings explicit port mappings needed to
             #   resolve the service's ports  to the task's ports
@@ -510,7 +510,7 @@ module Syskit
                 return enum_for(:each_required_dynamic_service) if !block_given?
                 each_data_service do |_, srv|
                     if srv.dynamic?
-                        yield(srv) 
+                        yield(srv)
                     end
                 end
             end
@@ -910,7 +910,7 @@ module Syskit
             end
 
             # Adds a new port to this model based on a known dynamic port
-            # 
+            #
             # @param [String] name the new port's name
             # @param [Orocos::Spec::DynamicInputPort] port the port model, as
             #   returned for instance by Orocos::Spec::TaskContext#find_dynamic_input_ports
@@ -923,7 +923,7 @@ module Syskit
             end
 
             # Adds a new port to this model based on a known dynamic port
-            # 
+            #
             # @param [String] name the new port's name
             # @param [Orocos::Spec::DynamicOutputPort] port the port model, as
             #   returned for instance by Orocos::Spec::TaskContext#find_dynamic_output_ports
@@ -1327,11 +1327,10 @@ module Syskit
             else
                 task_model.proxy_task_model(service_models)
             end
-        
+
         if service
             service.attach(task_model)
         else task_model
         end
     end
 end
-

--- a/lib/syskit/models/composition_child.rb
+++ b/lib/syskit/models/composition_child.rb
@@ -10,7 +10,7 @@ module Syskit
             attr_reader :child_name
             # The set of models that this child should fullfill. It is a
             # Set which contains at most one Component model and any number
-            # of data service models 
+            # of data service models
             attr_accessor :dependency_options
             # [InstanceSelection] information needed to update the composition's
             # parent models about the child (mainly port mappings)

--- a/lib/syskit/network_generation/dataflow_computation.rb
+++ b/lib/syskit/network_generation/dataflow_computation.rb
@@ -32,6 +32,10 @@ module Syskit
             extend Logger::Hierarchy
             include Logger::Hierarchy
 
+            def initialize
+                reset
+            end
+
             def has_information_for_port?(task, port_name)
                 result.has_key?(task) &&
                     result[task].has_key?(port_name)
@@ -153,12 +157,7 @@ module Syskit
                 end
             end
 
-            def propagate(tasks)
-                # Get the periods from the activities themselves directly (i.e.
-                # not taking into account the port-driven behaviour)
-                #
-                # We also precompute relevant connections, as they won't change
-                # during the computation
+            def reset(tasks = Array.new)
                 @result = Hash.new { |h, k| h[k] = Hash.new }
                 # Internal variable that is used to detect whether an iteration
                 # added information
@@ -166,6 +165,11 @@ module Syskit
                 @done_ports = Hash.new { |h, k| h[k] = Set.new }
                 @triggering_connections  = Hash.new { |h, k| h[k] = Hash.new }
                 @triggering_dependencies = Hash.new { |h, k| h[k] = Set.new }
+                @missing_ports = Hash.new
+            end
+
+            def propagate(tasks)
+                reset(tasks)
 
                 debug do
                     debug "#{self.class}: computing on #{tasks.size} tasks"

--- a/lib/syskit/network_generation/dataflow_computation.rb
+++ b/lib/syskit/network_generation/dataflow_computation.rb
@@ -309,7 +309,7 @@ module Syskit
             def add_port_info(task, port_name, info)
                 if done_ports[task].include?(port_name)
                     done_at = @done_at[[task, port_name]] if @done_at
-                    raise ModifyingFinalizedPortInfo.new(task, port_name, done_at), "trying to change port information for #{task}.#{port_name} after done_port_info has been called"
+                    raise ModifyingFinalizedPortInfo.new(task, port_name, done_at, self.class.name), "trying to change port information for #{task}.#{port_name} after done_port_info has been called"
                 end
 
                 if !has_information_for_port?(task, port_name)

--- a/lib/syskit/network_generation/dataflow_computation.rb
+++ b/lib/syskit/network_generation/dataflow_computation.rb
@@ -108,13 +108,6 @@ module Syskit
                         return [], false 
                     end
 
-                    predicate =
-                        if mode == USE_PARTIAL
-                            state.method(:has_information_for_port?)
-                        else
-                            state.method(:has_final_information_for_port?)
-                        end
-
                     complete = false
                     candidates = []
                     ports.each do |args|

--- a/lib/syskit/network_generation/merge_solver.rb
+++ b/lib/syskit/network_generation/merge_solver.rb
@@ -138,6 +138,14 @@ module Syskit
                     end
                     register_replacement(merged_task, task)
                 end
+
+                if MergeSolver.tracing_directory
+                    Engine.autosave_plan_to_dot(plan,
+                        MergeSolver.tracing_directory,
+                        MergeSolver.tracing_options.merge(
+                            highlights: merged_task_to_task.to_a.flatten.to_set,
+                            suffix: "0"))
+                end
             end
 
             # Create a new solver on the given plan and perform

--- a/lib/syskit/network_generation/system_network_deployer.rb
+++ b/lib/syskit/network_generation/system_network_deployer.rb
@@ -134,8 +134,15 @@ module Syskit
                     end
                     deployed_task = deployment_task.task(task_name)
                     debug { "deploying #{task} with #{task_name} of #{configured_deployment.short_name} (#{deployed_task})" }
+                    # We MUST merge one-by-one here. Calling apply_merge_group
+                    # on all the merges at once would NOT copy the connections
+                    # that exist between the tasks of the "from" group to the
+                    # "to" group, which is really not what we want
+                    #
+                    # Calling with all the mappings would be useful if what
+                    # we wanted is replace a subnet of the plan by another
+                    # subnet. This is not the goal here.
                     merge_solver.apply_merge_group(task => deployed_task)
-                    debug { "  => #{deployed_task}" }
                 end
             end
 

--- a/lib/syskit/network_generation/system_network_deployer.rb
+++ b/lib/syskit/network_generation/system_network_deployer.rb
@@ -53,8 +53,7 @@ module Syskit
                     break
                 end
 
-                all_tasks = plan.find_local_tasks(TaskContext).to_a
-                selected_deployments, missing_deployments = select_deployments(all_tasks)
+                selected_deployments, missing_deployments = select_deployments
                 log_timepoint 'select_deployments'
 
                 apply_selected_deployments(selected_deployments)
@@ -68,7 +67,7 @@ module Syskit
                 return missing_deployments
             end
 
-            def select_deployments(tasks)
+            def select_deployments
                 used_deployments = Set.new
                 missing_deployments = Set.new
                 selected_deployments = Hash.new

--- a/lib/syskit/orogen_namespace.rb
+++ b/lib/syskit/orogen_namespace.rb
@@ -149,7 +149,7 @@ module Syskit
             namespace =
                 if mod.const_defined_here?(namespace)
                     mod.const_get(namespace)
-                else 
+                else
                     mod.const_set(namespace, Module.new)
                 end
 

--- a/lib/syskit/test/self.rb
+++ b/lib/syskit/test/self.rb
@@ -136,8 +136,3 @@ module Minitest
         include Syskit::Test::Self
     end
 end
-
-
-
-
-

--- a/test/models/test_component.rb
+++ b/test/models/test_component.rb
@@ -532,7 +532,7 @@ describe Syskit::Models::Component do
                 provides srv_m, as: name
             end
             task_m.each_required_dynamic_service.empty?
-            
+
             model_m = task_m.new_submodel
             dyn_srv = model_m.require_dynamic_service 'dyn', as: 'test'
             assert_equal [dyn_srv], model_m.each_required_dynamic_service.to_a
@@ -547,7 +547,7 @@ describe Syskit::Models::Component do
                     dynamic_service srv_m, as: 'test' do
                         provides srv_m
                     end
-                end 
+                end
             end
 
             it "returns false if the argument has required dynamic services that the receiver does not" do
@@ -1098,4 +1098,3 @@ describe Syskit::Models::Component do
         end
     end
 end
-

--- a/test/network_generation/test_system_network_deployer.rb
+++ b/test/network_generation/test_system_network_deployer.rb
@@ -68,16 +68,14 @@ module Syskit
                 it "does not allocate the same task twice" do
                     plan.add(task0 = task_models[0].new)
                     plan.add(task1 = task_models[0].new)
-                    all_tasks = [task0, task1]
-                    selected, missing = subject.select_deployments(all_tasks)
+                    selected, missing = subject.select_deployments
                     assert_equal 1, missing.size
                     assert [task0, task1].include?(missing.first)
                 end
                 it "does not resolve ambiguities by considering already allocated tasks" do
                     plan.add(task0 = task_models[0].new(orocos_name: 'task'))
                     plan.add(task1 = task_models[0].new)
-                    all_tasks = [task0, task1]
-                    selected, missing = subject.select_deployments(all_tasks)
+                    selected, missing = subject.select_deployments
                     assert_equal [task1], missing.to_a
                 end
             end

--- a/test/network_generation/test_system_network_deployer.rb
+++ b/test/network_generation/test_system_network_deployer.rb
@@ -68,14 +68,14 @@ module Syskit
                 it "does not allocate the same task twice" do
                     plan.add(task0 = task_models[0].new)
                     plan.add(task1 = task_models[0].new)
-                    selected, missing = subject.select_deployments
+                    _, missing = subject.select_deployments
                     assert_equal 1, missing.size
                     assert [task0, task1].include?(missing.first)
                 end
                 it "does not resolve ambiguities by considering already allocated tasks" do
                     plan.add(task0 = task_models[0].new(orocos_name: 'task'))
                     plan.add(task1 = task_models[0].new)
-                    selected, missing = subject.select_deployments
+                    _, missing = subject.select_deployments
                     assert_equal [task1], missing.to_a
                 end
             end
@@ -83,14 +83,27 @@ module Syskit
             describe "#deploy" do
                 attr_reader :deployment_models, :deployments, :task_models
                 before do
-                    @deployment_models = [Syskit::Deployment.new_submodel, Syskit::Deployment.new_submodel]
-                    @task_models = [Syskit::TaskContext.new_submodel, Syskit::TaskContext.new_submodel]
+                    @task_models = task_models = [
+                        Syskit::TaskContext.new_submodel do
+                            output_port 'out', '/int32_t'
+                        end,
+                        Syskit::TaskContext.new_submodel do
+                            input_port 'in', '/int32_t'
+                        end
+                    ]
+                    @deployment_models = [
+                        Deployment.new_submodel do
+                            task 'task', task_models[0].orogen_model
+                        end,
+                        Deployment.new_submodel do
+                            task 'other_task', task_models[1].orogen_model
+                        end
+                    ]
+
                     @deployments = Hash[
                         task_models[0] => [['machine', deployment_models[0], 'task']],
                         task_models[1] => [['other_machine', deployment_models[1], 'other_task']]
                     ]
-                    deployment_models[0].orogen_model.task 'task', task_models[0].orogen_model
-                    deployment_models[1].orogen_model.task 'other_task', task_models[1].orogen_model
                 end
 
                 subject do
@@ -122,6 +135,17 @@ module Syskit
                     # And finally replace the task with the deployed task
                     merge_solver.should_receive(:apply_merge_group).once.with(task => deployed_task)
                     subject.deploy(validate: false)
+                end
+                it "copies the connections from the tasks to their deployed counterparts" do
+                    plan.add(task0 = task_models[0].new)
+                    plan.add(task1 = task_models[1].new)
+                    task0.out_port.connect_to task1.in_port
+                    result = expect_execution { subject.deploy(validate: false) }.to_run
+                    deployed_task0 = subject.merge_solver.replacement_for(task0)
+                    deployed_task1 = subject.merge_solver.replacement_for(task1)
+                    refute_same task0, deployed_task0
+                    refute_same task1, deployed_task1
+                    assert deployed_task0.out_port.connected_to?(deployed_task1.in_port)
                 end
                 it "instanciates the same deployment only once on the same machine" do
                     plan.add(task0 = task_models[0].new(orocos_name: 'task'))


### PR DESCRIPTION
oroGen has had support integrated to define master/slave tasks. The rationale behind the feature was to declare that some tasks (the masters) are triggering some other tasks (the slaves). This is used to implement for instance single-threaded deployments, where the slave tasks are executed explicitely by the master, in a predefined order. An implementation of this scheme is for instance the [`slave_scheduler`](https://github.com/ThirteenLtda/tools-orogen-slave_scheduler)

This integrates the functionality in Syskit. The master tasks are auto-spawned if they don't exist yet, and their configuration is automatically picked based on the task name (it is either `default` if there is no section matching the task name or `default`, `task_name` if there is).