### PR TITLE
ide: implement the "Add" button

### DIFF
--- a/lib/syskit/gui/ide.rb
+++ b/lib/syskit/gui/ide.rb
@@ -29,6 +29,22 @@ module Syskit
 
                 syskit = Roby::Interface::Async::Interface.new(host, port: port)
                 @btn_reload_models = Qt::PushButton.new("Reload Models", self)
+                @btn_add = Qt::PushButton.new("Add", self)
+                btn_add_menu = Qt::Menu.new
+                btn_add_menu.add_action 'OroGen Project'
+                btn_add_menu.add_action 'OroGen Type'
+                btn_add_menu.add_action 'Model File'
+                btn_add_menu.connect(SIGNAL('triggered(QAction*)')) do |action|
+                    case action.text
+                    when "OroGen Project"
+                        add_orogen_project
+                    when "OroGen Type"
+                        add_orogen_type
+                    when "Model File"
+                        add_model_file
+                    end
+                end
+                @btn_add.menu = btn_add_menu
 
                 connect(model_browser, SIGNAL('fileOpenClicked(const QUrl&)'),
                         self, SLOT('fileOpenClicked(const QUrl&)'))
@@ -39,7 +55,8 @@ module Syskit
                 browse_container = Qt::Widget.new
                 browse_container_layout = Qt::VBoxLayout.new(browse_container)
                 status_bar = testing.create_status_bar_ui
-                status_bar.insert_widget(0, btn_reload_models)
+                status_bar.insert_widget(0, @btn_reload_models)
+                status_bar.insert_widget(1, @btn_add)
                 browse_container_layout.add_layout(status_bar)
                 browse_container_layout.add_widget(model_browser)
                 tab_widget.add_tab browse_container, "Browse"
@@ -67,6 +84,115 @@ module Syskit
 
                 if tests
                     testing.start
+                end
+            end
+
+            class Picker < Qt::Dialog
+                def initialize(parent, items)
+                    super(parent)
+
+                    model = Qt::StringListModel.new(self)
+                    model.string_list = items.sort
+                    @filter = Qt::SortFilterProxyModel.new(self)
+                    @filter.dynamic_sort_filter = true
+                    @filter.source_model = model
+
+                    @filter_text = Qt::LineEdit.new(self)
+                    @filter_text.connect(SIGNAL('textChanged(QString)')) do |text|
+                        @filter.filterRegExp = Qt::RegExp.new(text)
+                    end
+                    @list = Qt::ListView.new(self)
+                    @list.edit_triggers = Qt::AbstractItemView::NoEditTriggers
+                    @list.model = @filter
+                    @list.connect(SIGNAL('doubleClicked(const QModelIndex&)')) do |index|
+                        accept
+                    end
+                    @list.current_index = @filter.index(0, 0)
+
+                    resize(500, 500)
+
+                    layout = Qt::VBoxLayout.new(self)
+                    layout.add_widget(@filter_text)
+                    layout.add_widget(@list)
+
+                    buttons = Qt::DialogButtonBox.new(
+                        Qt::DialogButtonBox::Ok | Qt::DialogButtonBox::Cancel)
+                    connect(buttons, SIGNAL('accepted()'), self, SLOT('accept()'))
+                    connect(buttons, SIGNAL('rejected()'), self, SLOT('reject()'))
+                    layout.add_widget(buttons)
+                end
+
+                def self.select(parent, items)
+                    if items.empty?
+                        Qt::MessageBox.information(parent, "Nothing to pick",
+                            "There is nothing to pick from")
+                        return
+                    end
+                    new(parent, items).select
+                end
+
+                def select
+                    result = exec
+                    if result == Qt::Dialog::Accepted
+                        @filter.data(@list.current_index).
+                            to_string
+                    end
+                end
+            end
+
+            def add_orogen_project
+                loader = Roby.app.default_pkgconfig_loader
+                model_names = loader.each_available_task_model_name.to_a
+                syskit2orogen = model_names.
+                    each_with_object(Hash.new) do |(orogen_name, project_name), result|
+                        unless loader.has_loaded_project?(project_name)
+                            result["OroGen.#{orogen_name.gsub('::', '.')}"] = project_name
+                        end
+                    end
+
+                if (selected = Picker.select(self, syskit2orogen.keys))
+                    selected_project = syskit2orogen[selected]
+                    Roby.app.using_task_library(selected_project)
+                    Roby.app.extra_required_task_libraries << selected_project
+                    @model_browser.reload
+                end
+            end
+
+            def add_orogen_type
+                loader = Roby.app.default_pkgconfig_loader
+                syskit2orogen = loader.each_available_type_name.
+                    each_with_object(Hash.new) do |(type_name, typekit_name, _), result|
+                        next if type_name.end_with?("_m")
+                        next if type_name =~ /\[/
+                        unless loader.has_loaded_typekit?(typekit_name)
+                            result["Types#{type_name.gsub("/", ".")}"] = typekit_name
+                        end
+                    end
+
+                if (selected = Picker.select(self, syskit2orogen.keys))
+                    selected_typekit = syskit2orogen[selected]
+                    Roby.app.extra_required_typekits << selected_typekit
+                    Roby.app.import_types_from(selected_typekit)
+                    @model_browser.reload
+                end
+            end
+
+            def add_model_file
+                models_dir = File.join(Roby.app.app_dir, 'models')
+                initial_dir =
+                    if File.directory?(models_dir)
+                        models_dir
+                    else
+                        Roby.app.app_dir
+                    end
+
+                files = Qt::FileDialog.getOpenFileNames(
+                    self, "Pick model file(s) to add", initial_dir)
+                files.each do |path|
+                    Roby.app.require(path)
+                    Roby.app.additional_model_files << path
+                    @model_browser.update_exceptions
+                    @model_browser.reload
                 end
             end
 
@@ -143,4 +269,3 @@ module Syskit
         end
     end
 end
-

--- a/lib/syskit/gui/model_browser.rb
+++ b/lib/syskit/gui/model_browser.rb
@@ -20,7 +20,12 @@ module Syskit
 
                 def each_submodel(obj)
                     if obj == Typelib::Type
-                        Roby.app.default_loader.registry.each do |type|
+                        loader = Roby.app.default_loader
+                        loader.registry.each do |type|
+                            next if loader.m_type?(type)
+                            next if type.null?
+                            next if type <= Typelib::NumericType
+                            next if type <= Typelib::ArrayType
                             yield(type)
                         end
                     end
@@ -82,4 +87,3 @@ module Syskit
         end
     end
 end
-

--- a/lib/syskit/gui/testing.rb
+++ b/lib/syskit/gui/testing.rb
@@ -125,7 +125,8 @@ module Syskit
 
             def create_status_bar_ui
                 status_bar = Qt::HBoxLayout.new
-                status_bar.add_widget(start_stop_button = Qt::PushButton.new("Start", self))
+                status_bar.add_widget(start_stop_button =
+                    Qt::PushButton.new("Start Tests", self))
                 connect SIGNAL('started()') do
                     start_stop_button.text = "Stop"
                 end
@@ -163,7 +164,7 @@ module Syskit
                 test_list_ui.edit_triggers = Qt::AbstractItemView::NoEditTriggers
                 splitter.add_widget(@test_result_ui = Qt::WebView.new(self))
             end
-            
+
             def update_selected_item_state
                 item = @selected_item
                 if runtime = item.runtime
@@ -700,4 +701,3 @@ module Syskit
         end
     end
 end
-


### PR DESCRIPTION
Depends on:
- [x] https://github.com/orocos-toolchain/orogen/pull/110

It allows to add addition files, types or task models within a Syskit IDE without having to restart the IDE.

The PR also does some fine-tuning of the IDE model browsing: removes "utility" types (arrays, numeric types, m-types) from the type display, and renames "start" into "start tests"