### PR TITLE
ide: fix interaction between reloading models and runtime view

### DIFF
--- a/test/gui/test_runtime_state.rb
+++ b/test/gui/test_runtime_state.rb
@@ -15,7 +15,9 @@ module Syskit
             before do
                 @syskit = flexmock(Roby::Interface::Async::Interface.new)
                 @syskit.should_receive(:client).and_return { client }
-                @subject = RuntimeState.new(syskit: syskit)
+                Orocos.allow_blocking_calls do
+                    @subject = RuntimeState.new(syskit: syskit)
+                end
                 @client = flexmock('client')
                 @client.should_receive(:jobs).and_return([])
                 @client.should_receive(:actions).and_return([])


### PR DESCRIPTION
This is what was causing the "accessing disposed task context" error.
Reloading the models calls Orocos.clear, which in turn de-initializes
Orocos. It wasn't getting initialized again afterwards, and broke
everything.

There are other side effects - namely, that the name services are
also deinitialized. This creates new name services to avoid this.

Fixes #169