### PR TITLE
models: clean mixup between #resolve and #bind

### DIFF
--- a/lib/syskit/coordination/port_handling.rb
+++ b/lib/syskit/coordination/port_handling.rb
@@ -23,9 +23,9 @@ module Syskit
                 component_model = model_object.model
 
                 if respond_to?(:parent)
-                    component_model.resolve_child(parent.resolve).self_port_to_component_port(port)
+                    component_model.resolve_and_bind_child(parent.resolve).self_port_to_component_port(port)
                 else
-                    component_model.resolve(self.resolve).self_port_to_component_port(port)
+                    component_model.bind(self.resolve).self_port_to_component_port(port)
                 end
             end
 

--- a/lib/syskit/instance_requirements.rb
+++ b/lib/syskit/instance_requirements.rb
@@ -195,16 +195,31 @@ module Syskit
                 result
             end
 
+            # @deprecated use {#bind} instead
+            def resolve(object)
+                Roby.warn_deprecated "#{__method__} is deprecated, use "\
+                    "InstanceRequirements#bind instead"
+                bind(object)
+            end
+
+            # @deprecated use {#try_bind} instead
+            def try_resolve(task)
+                Roby.warn_deprecated "#{__method__} is deprecated, use "\
+                    "InstanceRequirements#try_bind instead"
+                try_bind(task)
+            end
+
+
             # Maps the given task to the underlying model
-            def resolve(task)
-                model.resolve(task)
+            def bind(task)
+                model.bind(task)
             end
 
             # Maps the given task to the underlying model
             #
-            # Unlike {#resolve}, it returns nil if the task cannot be mapped
-            def try_resolve(task)
-                model.try_resolve(task)
+            # Unlike {#bind}, it returns nil if the task cannot be mapped
+            def try_bind(task)
+                model.try_bind(task)
             end
 
             # The component model that is required through this object
@@ -1061,10 +1076,6 @@ module Syskit
                 end
                 dynamics.add_port_period(port_name, period, sample_count)
                 self
-            end
-
-            def bind(object)
-                model.bind(object)
             end
 
             # This module can be used to extend other objects so that instance

--- a/lib/syskit/models/bound_data_service.rb
+++ b/lib/syskit/models/bound_data_service.rb
@@ -313,20 +313,19 @@ module Syskit
                 end
             end
 
+            # @deprecated use {#bind} instead
+            def resolve(task)
+                Roby.warn_deprecated "#{__method__} is deprecated, use "\
+                    "BoundDataService#bind instead"
+                bind(task)
+            end
+
             # Creates, in the given plan, a new task matching this service in
             # the given context, and returns the instanciated data service
             #
             # @return [Syskit::BoundDataService]
             def instanciate(plan, context = DependencyInjectionContext.new, options = Hash.new)
                 bind(component_model.instanciate(plan, context, options))
-            end
-
-            # Returns the BoundDataService object that binds this provided
-            # service to an actual task
-            #
-            # @return [Syskit::BoundDataService]
-            def resolve(task)
-                bind(component_model.resolve(task))
             end
 
             # Generates the InstanceRequirements object that represents +self+

--- a/lib/syskit/models/component.rb
+++ b/lib/syskit/models/component.rb
@@ -826,23 +826,41 @@ module Syskit
                 Syskit::InstanceRequirementsTask.subplan(self)
             end
 
-            # Try resolving the given task using this model
             #
-            # @return [nil,Roby::Task] task if it matches +self+, nil otherwise
-            def try_resolve(task)
-                task if task.kind_of?(self)
+            #
+            # @return [nil,Syskit::Component] task if it fullfills self,
+            #   nil otherwise
+            # @see #bind
+            def try_bind(object)
+                object if object.fullfills?(self)
             end
 
-            # Resolves the given task using this model
+            # Return a representation of an instance that is compatible with
+            # self
             #
             # @return [Roby::Task] task if it matches self
             # @raise [ArgumentError] if task does not fullfill self
-            def resolve(task)
-                if task = try_resolve(task)
-                    task
+            # @see #try_bind
+            def bind(object)
+                if component = try_bind(object)
+                    component
                 else
-                    raise ArgumentError, "cannot resolve #{self} into #{component}"
+                    raise ArgumentError, "cannot bind #{self} to #{object}"
                 end
+            end
+
+            # @deprecated use {#bind} instead
+            def resolve(task)
+                Roby.warn_deprecated "#{__method__} is deprecated, use "\
+                    "Models::Component#bind instead"
+                bind(task)
+            end
+
+            # @deprecated use {#try_bind} instead
+            def try_resolve(task)
+                Roby.warn_deprecated "#{__method__} is deprecated, use "\
+                    "Models::Component#try_bind instead"
+                try_bind(task)
             end
 
             # Delegated call from {Port#connected?}
@@ -948,12 +966,6 @@ module Syskit
                 orogen_model.output_ports[name] = port.instanciate(name, type)
                 Syskit::Models.merge_orogen_task_context_models(self.orogen_model, [orogen_model])
                 find_output_port(name)
-            end
-
-            def bind(object)
-                if object.fullfills?(self) then object
-                else raise ArgumentError, "#{object} does not provide #{self}, cannot bind"
-                end
             end
 
             def fullfills?(object)

--- a/lib/syskit/models/composition.rb
+++ b/lib/syskit/models/composition.rb
@@ -852,7 +852,7 @@ module Syskit
                 # self, and if it is the case, make sure it is available
                 selected_child.map_use_selections! do |sel|
                     if sel.kind_of?(CompositionChild)
-                        if task = sel.try_resolve_child_recursive(self_task)
+                        if task = sel.try_resolve_and_bind_child_recursive(self_task)
                             task
                         else return
                         end

--- a/lib/syskit/models/data_service.rb
+++ b/lib/syskit/models/data_service.rb
@@ -54,7 +54,7 @@ module Syskit
             #   mappings.
             #
             #   The mapping is of the form
-            #     
+            #
             #     provided_service_model => [provided_service_model_port, port]
             #
             #   @return [Hash<DataServiceModel,Hash<String,String>>] the
@@ -276,21 +276,41 @@ module Syskit
                 pp.text short_name
             end
 
-            # Resolves a bound data service of this model from the given task
-            def try_resolve(task)
+            # Try to bind the data service model on the given task
+            #
+            # @param [Syskit::Component] component
+            # @return [nil,BoundDataService]
+            def try_bind(component)
                 begin
-                    task.find_data_service_from_type(self)
+                    component.find_data_service_from_type(self)
                 rescue AmbiguousServiceSelection
                 end
             end
 
-            # Resolves a bound data service of this model from the given task
-            def resolve(task)
-                if task = try_resolve(task)
-                    task
+            # Binds the data service model on the given task
+            #
+            # @param [Syskit::Component] component
+            # @return [nil,BoundDataService]
+            # @raise [ArgumentError] if the given component has no such data
+            #   service, or if it has more than one
+            def bind(component)
+                if bound = try_bind(component)
+                    bound
                 else
-                    raise ArgumentError, "cannot resolve #{self} into #{task}"
+                    raise ArgumentError, "cannot bind #{self} to #{component}"
                 end
+            end
+
+            # @deprecated use {#try_bind} instead
+            def try_resolve(task)
+                Roby.warn_deprecated "#{__method__} is deprecated, use #try_bind instead"
+                try_bind(task)
+            end
+
+            # @deprecated use {#bind} instead
+            def resolve(task)
+                Roby.warn_deprecated "#{__method__} is deprecated, use #bind instead"
+                bind(task)
             end
 
             def to_dot(io)

--- a/lib/syskit/models/port.rb
+++ b/lib/syskit/models/port.rb
@@ -182,28 +182,28 @@ module Syskit
             end
 
             def to_orocos_port(component)
-                component_model.resolve(component).find_port(name)
+                component_model.bind(component).find_port(name)
             end
 
             def static?
                 orogen_model.static?
             end
-            
+
             def new_sample
                 orogen_model.type.new
             end
-            
+
             def instanciate(plan)
                 bind(component_model.instanciate(plan))
             end
-            
+
             def resolve_data_source(context)
                 if context.kind_of?(Roby::Plan)
                     context.add(context = component_model.as_plan)
                 end
                 bind(context).to_data_source
             end
-            
+
             # @return [Boolean] true if this is an output port, false otherwise.
             #   The default implementation returns false
             def output?; false end
@@ -243,7 +243,7 @@ module Syskit
             def multiplexes?
                 orogen_model.multiplexes?
             end
-            
+
             def bind(component)
                 Syskit::InputPort.new(self, component_model.bind(component))
             end
@@ -254,7 +254,7 @@ module Syskit
 
             def input?; true end
         end
-        
+
         class OutputReader
             attr_reader :port
             attr_reader :policy
@@ -315,7 +315,7 @@ module Syskit
             def instanciate(plan)
                 port.instanciate(plan).writer(policy)
             end
-            
+
             def new_sample
                 port.new_sample
             end
@@ -325,7 +325,7 @@ module Syskit
                     other.port == self.port &&
                     other.policy == self.policy
             end
-        
+
         end
     end
 end

--- a/test/models/test_bound_data_service.rb
+++ b/test/models/test_bound_data_service.rb
@@ -138,8 +138,15 @@ describe Syskit::Models::BoundDataService do
             srv = task.test_srv
             assert_equal srv, srv_m.bind(task)
         end
-        it" raises ArgumentError if the provided component model is of an invalid type" do
+        it "raises ArgumentError if the provided component model is of an invalid type" do
             assert_raises(ArgumentError) { srv_m.bind(Syskit::TaskContext.new_submodel.new) }
+        end
+        it "is available as #resolve for backward compatibility" do
+            flexmock(Roby).should_receive(:warn_deprecated).
+                with(/resolve/).once
+            task = task_m.new
+            srv = task.test_srv
+            assert_equal srv, srv_m.resolve(task)
         end
 
         describe "behaviour related to placeholder models" do
@@ -181,7 +188,7 @@ describe Syskit::Models::BoundDataService do
                     dynamic_service srv_m, as: 'test' do
                         provides srv_m
                     end
-                end 
+                end
             end
 
             it "binds a dynamic data service horizontally" do

--- a/test/models/test_component.rb
+++ b/test/models/test_component.rb
@@ -478,6 +478,58 @@ describe Syskit::Models::Component do
         end
     end
 
+    describe "#bind" do
+        attr_reader :component_m
+        before do
+            @component_m = Syskit::Component.new_submodel(name: 'component_m')
+        end
+
+        it "returns the object if it fullfills the model" do
+            object = flexmock
+            object.should_receive(:fullfills?).with(component_m).and_return(true)
+            assert_equal object, component_m.bind(object)
+        end
+        it "raises ArgumentError if the object does not fullfill the model" do
+            object = flexmock(to_s: 'object')
+            object.should_receive(:fullfills?).with(component_m).and_return(false)
+            e = assert_raises(ArgumentError) do
+                component_m.bind(object)
+            end
+            assert_equal "cannot bind component_m to object", e.message
+        end
+        it "is available as 'resolve' for backward compatibility" do
+            flexmock(Roby).should_receive(:warn_deprecated).with(/resolve/).once
+            object = flexmock
+            object.should_receive(:fullfills?).with(component_m).and_return(true)
+            assert_equal object, component_m.resolve(object)
+        end
+    end
+
+    describe "#try_bind" do
+        attr_reader :component_m
+        before do
+            @component_m = Syskit::Component.new_submodel(name: 'component_m')
+        end
+
+        it "returns the object if it fullfills the model" do
+            object = flexmock
+            object.should_receive(:fullfills?).with(component_m).and_return(true)
+            assert_equal object, component_m.try_bind(object)
+        end
+        it "returns nil if the object does not fullfill the model" do
+            object = flexmock(to_s: 'object')
+            object.should_receive(:fullfills?).with(component_m).and_return(false)
+            refute component_m.try_bind(object)
+        end
+        it "is available as 'try_resolve' for backward compatibility" do
+            flexmock(Roby).should_receive(:warn_deprecated).with(/try_resolve/).once
+            object = flexmock
+            object.should_receive(:fullfills?).with(component_m).and_return(false)
+            refute component_m.try_resolve(object)
+        end
+    end
+
+
     describe "#self_port_to_component_port" do
         it "should return its argument" do
             stub_t = self.stub_t

--- a/test/test_instance_requirements.rb
+++ b/test/test_instance_requirements.rb
@@ -674,4 +674,62 @@ describe Syskit::InstanceRequirements do
             Syskit::InstanceRequirements.new([task_m]).to_action_model
         end
     end
+
+    describe "#bind" do
+        before do
+            @srv_m = Syskit::DataService.new_submodel
+            @task_m = Syskit::TaskContext.new_submodel
+            @task_m.provides @srv_m, as: 'test'
+            @ir = Syskit::InstanceRequirements.new([@srv_m])
+        end
+        it "binds the task to the model" do
+            # TODO: this is not coherent. The value returned by #bind
+            # does not match what other
+            #
+            # However, since #bind is used for the return value of
+            # InstanceRequirements#instanciate, changing this would have
+            # far-reaching consequences that I can't deal with right now
+            #
+            # I elected to keep the old behavior until I have the time
+            # to dig into it
+            task = @task_m.new
+            assert_equal task, @ir.bind(task)
+        end
+        it "raises if the task can't be bound" do
+            task = Syskit::TaskContext.new_submodel
+            assert_raises(ArgumentError) do
+                @ir.bind(task)
+            end
+        end
+        it "is available as resolve for backward-compatibility" do
+            flexmock(Roby).should_receive(:warn_deprecated).
+                with(/resolve.*bind/).once
+            task = @task_m.new
+            assert_equal task, @ir.resolve(task)
+        end
+    end
+
+    describe "#try_bind" do
+        before do
+            @srv_m = Syskit::DataService.new_submodel
+            @task_m = Syskit::TaskContext.new_submodel
+            @task_m.provides @srv_m, as: 'test'
+            @ir = Syskit::InstanceRequirements.new([@srv_m])
+        end
+        it "binds the task to the model" do
+            # See comment for #bind
+            task = @task_m.new
+            assert_equal task, @ir.try_bind(task)
+        end
+        it "returns nil if the task can't be bound" do
+            task = Syskit::TaskContext.new_submodel
+            assert_nil @ir.try_bind(task)
+        end
+        it "is available as resolve for backward-compatibility" do
+            flexmock(Roby).should_receive(:warn_deprecated).
+                with(/try_resolve.*try_bind/).once
+            task = @task_m.new
+            assert_equal task, @ir.try_resolve(task)
+        end
+    end
 end


### PR DESCRIPTION
'bind' and 'resolve' are somewhat being used interchangeably in the codebase. This attemps to clean up the usage of both, with the following semantics.
    
'bind' "binds" a model and an already existing instance, returing the part of the instance that is representative of the model.
    
~~~
srv_m = DataService.new_submodel
task_m = TaskContext.new_submodel
task_m.provides srv_m, as: 'srv'
srv_m.bind(task_m) # => task_m.srv_m
~~~
    
'resolve' will more generally resolve relationships between objects. For instance, CompositionChild#resolve_and_bind_child will 'resolve' the child from a root composition and then bind it to the composition child model.

There is an inconsistency in the behavior of InstanceRequirements#bind, though, which always returns its argument (if it is valid), **not** providing a mapping between the model services and ports to the argument's actual ports.

However, since #bind is used for the return value of InstanceRequirements#instanciate, changing this would have far-reaching consequences that I can't deal with right now

I elected to keep the old behavior until I have the time to dig into it
