### PR TITLE
test: properly handle local ports from ruby tasks in syskit_write

### DIFF
--- a/lib/syskit/test/network_manipulation.rb
+++ b/lib/syskit/test/network_manipulation.rb
@@ -58,12 +58,14 @@ module Syskit
                         writer.to_orocos_port
                     end
                 end
-                if !writer.respond_to?(:read_new)
-                    if writer.respond_to?(:writer)
-                        writer = Orocos.allow_blocking_calls do
-                            writer.writer
-                        end
+                # We can write on LocalInputPort, LocalOutputPort and InputPort
+                if writer.respond_to?(:writer)
+                    writer = Orocos.allow_blocking_calls do
+                        writer.writer
                     end
+                elsif !writer.respond_to?(:write)
+                    raise ArgumentError, "#{writer} does not seem to be a port "\
+                        "one can write on"
                 end
                 writer
             end
@@ -71,7 +73,7 @@ module Syskit
             # Write a sample on a given input port
             def syskit_write(writer, sample)
                 writer = resolve_orocos_writer(writer)
-                @__orocos_writers << writer
+                @__orocos_writers << writer if writer.respond_to?(:disconnect)
                 writer.write(sample)
             end
 

--- a/test/test/test_network_manipulation.rb
+++ b/test/test/test_network_manipulation.rb
@@ -5,16 +5,26 @@ module Syskit
         describe NetworkManipulation do
             describe "#syskit_write" do
                 before do
-                    task_m = Syskit::RubyTaskContext.new_submodel do
+                    @task_m = Syskit::RubyTaskContext.new_submodel do
                         input_port 'in', '/int'
+                        output_port 'out', '/int'
                     end
-                    use_ruby_tasks task_m => 'test', on: 'stubs'
-                    @task = syskit_deploy_configure_and_start(task_m)
+                    use_ruby_tasks @task_m => 'test', on: 'stubs'
                 end
-                
+
                 it "connects and writes to the port" do
-                    syskit_write @task.in_port, 10
-                    assert_equal 10, @task.orocos_task.in.read_new
+                    task = syskit_deploy_configure_and_start(@task_m)
+                    syskit_write task.in_port, 10
+                    assert_equal 10, task.orocos_task.in.read_new
+                end
+
+                it "allows writing to a local port" do
+                    task = syskit_deploy_configure_and_start(@task_m)
+                    out_reader = task.out_port.reader
+                    expect_execution.to { achieve { out_reader.ready? }}
+                    sample = expect_execution { syskit_write task.out_port, 10 }.
+                        to { have_one_new_sample out_reader }
+                    assert_equal 10, sample
                 end
             end
         end


### PR DESCRIPTION
Local ports don't need to be disconnected the way writers are, so skip their registration in within the @__orocos_writers array