### PR TITLE
app: load orocos/async if Conf.ui is set

### DIFF
--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -63,6 +63,8 @@ module Syskit
                     app.auto_load_all_task_libraries = true
                 end
 
+                require 'orocos/async' if Conf.ui?
+
                 if app.development_mode?
                     require 'listen'
                     app.syskit_listen_to_configuration_changes


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-roby/pull/130

This is a new flag set by the --ui argument to `syskit test`

The goal is to allow for 'interactive' UI tests, where the UIs are
displayed and we use the user as the 'evaluator' of the result.
Worst than pure tests, but better than "manual" tests.

The need to have it handled in Syskit is that there are requirements
on when orocos/async can be loaded (namely, it has to be loaded before
Orocos.initialize is called)