### PR TITLE
test: implement stubbing in the run_planners handler

### DIFF
--- a/lib/syskit/network_generation/system_network_generator.rb
+++ b/lib/syskit/network_generation/system_network_generator.rb
@@ -244,8 +244,9 @@ module Syskit
             # @param [Roby::Plan] plan the plan on which we are working
             # @raise [TaskAllocationFailed] if some abstract tasks are still in
             #   the plan
-            def self.verify_task_allocation(plan)
-                components = plan.find_local_tasks(AbstractComponent)
+            def self.verify_task_allocation(
+                plan, components: plan.find_local_tasks(AbstractComponent)
+            )
                 still_abstract = components.find_all(&:abstract?)
                 if !still_abstract.empty?
                     raise TaskAllocationFailed.new(self, still_abstract),

--- a/lib/syskit/runtime/apply_requirement_modifications.rb
+++ b/lib/syskit/runtime/apply_requirement_modifications.rb
@@ -28,7 +28,7 @@ module Syskit
             # @raise [RuntimeError] if there is already a resolution. Call
             #   {#syskit_cancel_async_resolution} first
             # @return [void]
-            def syskit_start_async_resolution(requirement_tasks)
+            def syskit_start_async_resolution(requirement_tasks, **resolver_options)
                 if syskit_has_async_resolution?
                     raise ArgumentError, "an async resolution is already running, call #syskit_cancel_async_resolution first"
                 end
@@ -41,8 +41,10 @@ module Syskit
                         syskit_current_resolution_keepalive.wrap(component_task)
                     end
                 end
-                @syskit_current_resolution = NetworkGeneration::Async.new(self, thread_pool: syskit_resolution_pool)
-                syskit_current_resolution.start(requirement_tasks)
+                @syskit_current_resolution = NetworkGeneration::Async.new(
+                    self, thread_pool: syskit_resolution_pool
+                )
+                syskit_current_resolution.start(requirement_tasks, **resolver_options)
             end
 
             # Cancels the currently running resolution
@@ -59,8 +61,15 @@ module Syskit
 
             # True if the currently running resolution is valid w.r.t. the
             # current plan's state
-            def syskit_valid_async_resolution?
-                syskit_current_resolution.valid?
+            #
+            # @param [Set<InstanceRequirementsTask>] set of expected requirements
+            #   task. It is compared with the current resolution's set of task
+            #   to determine if the resolution is valid. You usually don't want
+            #   to explicitely pass this.
+            def syskit_valid_async_resolution?(
+                current = syskit_current_resolution.default_requirement_tasks
+            )
+                syskit_current_resolution.valid?(current)
             end
 
             # Wait for the current running resolution to finish, and apply it on
@@ -73,10 +82,15 @@ module Syskit
             # Apply a finished resolution on this plan
             #
             # @raise [RuntimeError] if the current resolution is not finished.
+            # @return [Exception,nil] an exception that was raised during resolution,
+            #   or nil if the execution finished
             def syskit_apply_async_resolution_results
-                if !syskit_finished_async_resolution?
-                    raise RuntimeError, "the current network resolution is not yet finished"
+                unless syskit_finished_async_resolution?
+                    raise 'the current network resolution is not yet finished'
                 end
+
+                running_requirement_tasks =
+                    find_tasks(Syskit::InstanceRequirementsTask).running
 
                 begin
                     syskit_current_resolution.apply
@@ -84,42 +98,57 @@ module Syskit
                     syskit_current_resolution_keepalive.discard_transaction
                     @syskit_current_resolution = nil
                 end
+
+                running_requirement_tasks.each do |t|
+                    t.success_event.emit
+                end
+                nil
+            rescue ::Exception => e # rubocop:disable Lint/RescueException
+                if running_requirement_tasks.empty?
+                    add_framework_error(e, 'deployment error without '\
+                        'requirement tasks')
+                else
+                    running_requirement_tasks.each do |t|
+                        t.failed_event.emit(e)
+                    end
+                end
+                e
             end
         end
 
-        def self.apply_requirement_modifications(plan, force: false)
+        def self.apply_requirement_modifications(plan,
+                                                 force: false,
+                                                 requirement_tasks: nil)
             if plan.syskit_has_async_resolution?
                 # We're already running a resolution, make sure it is not
                 # obsolete
-                if force || !plan.syskit_valid_async_resolution?
+                valid = !force && plan.syskit_valid_async_resolution?(
+                    requirement_tasks || NetworkGeneration::Engine
+                                         .discover_requirement_tasks_from_plan(plan)
+                )
+                if !valid
                     plan.syskit_cancel_async_resolution
                 elsif plan.syskit_finished_async_resolution?
-                    running_requirement_tasks = plan.find_tasks(Syskit::InstanceRequirementsTask).running
-                    begin
-                        plan.syskit_apply_async_resolution_results
-                    rescue ::Exception => e
-                        running_requirement_tasks.each do |t|
-                            t.failed_event.emit(e)
-                        end
-                        return
-                    end
-                    running_requirement_tasks.each do |t|
-                        t.success_event.emit
-                    end
+                    plan.syskit_apply_async_resolution_results
                     return
                 end
             end
 
-            if !plan.syskit_has_async_resolution?
-                if force || plan.find_tasks(Syskit::InstanceRequirementsTask).running.any? { true }
-                    requirement_tasks = NetworkGeneration::Engine.discover_requirement_tasks_from_plan(plan)
-                    if !requirement_tasks.empty?
-                        # We're not resolving anything, but new IR tasks have been
-                        # started. Deploy them
-                        plan.syskit_start_async_resolution(requirement_tasks)
-                    end
-                end
-            end
+            # Note: this is NOT the 'else' clause from above. The if ... block
+            # above might resolve the current async resolution
+            return if plan.syskit_has_async_resolution?
+
+            needs_resolution =
+                force || plan.find_tasks(Syskit::InstanceRequirementsTask)
+                             .running
+                             .any? { true }
+            return unless needs_resolution
+
+            requirement_tasks ||= NetworkGeneration::Engine
+                                  .discover_requirement_tasks_from_plan(plan)
+            return if requirement_tasks.empty?
+
+            plan.syskit_start_async_resolution(requirement_tasks)
         end
     end
 end

--- a/lib/syskit/test.rb
+++ b/lib/syskit/test.rb
@@ -17,32 +17,31 @@ require 'syskit/test/ruby_task_context_test'
 
 Roby::Test::Spec.include Syskit::Test::NetworkManipulation
 module Syskit
-    Minitest::Spec.register_spec_type Syskit::Test::Spec do |desc|
+    Roby::Test.register_spec_type Syskit::Test::Spec do |desc|
         desc.class == Module
     end
-    Minitest::Spec.register_spec_type Syskit::Test::Spec do |desc|
+    Roby::Test.register_spec_type Syskit::Test::Spec do |desc|
         desc.kind_of?(Syskit::Models::DataServiceModel)
     end
-    Minitest::Spec.register_spec_type Syskit::Test::ActionTest do |desc|
+    Roby::Test.register_spec_type Syskit::Test::ActionTest do |desc|
         desc.kind_of?(Roby::Actions::Models::Action) || desc.kind_of?(Roby::Actions::Action)
     end
-    Minitest::Spec.register_spec_type Syskit::Test::TaskContextTest do |desc|
+    Roby::Test.register_spec_type Syskit::Test::TaskContextTest do |desc|
         (desc.kind_of?(Class) && desc <= Syskit::TaskContext)
     end
-    Minitest::Spec.register_spec_type Syskit::Test::RubyTaskContextTest do |desc|
+    Roby::Test.register_spec_type Syskit::Test::RubyTaskContextTest do |desc|
         (desc.kind_of?(Class) && desc <= Syskit::RubyTaskContext)
     end
-    Minitest::Spec.register_spec_type Syskit::Test::ComponentTest do |desc|
+    Roby::Test.register_spec_type Syskit::Test::ComponentTest do |desc|
         (desc.kind_of?(Class) && desc <= Syskit::Component && !(desc <= Syskit::TaskContext))
     end
-    Minitest::Spec.register_spec_type Syskit::Test::ProfileTest do |desc|
+    Roby::Test.register_spec_type Syskit::Test::ProfileTest do |desc|
         desc.kind_of?(Syskit::Actions::Profile)
     end
-    Minitest::Spec.register_spec_type Syskit::Test::ComponentTest do |desc|
+    Roby::Test.register_spec_type Syskit::Test::ComponentTest do |desc|
         (!desc.kind_of?(Class) && desc.kind_of?(Module) && desc <= Syskit::Device)
     end
-    Minitest::Spec.register_spec_type Syskit::Test::ActionInterfaceTest do |desc|
+    Roby::Test.register_spec_type Syskit::Test::ActionInterfaceTest do |desc|
         (desc.kind_of?(Class) && desc <= Roby::Actions::Interface)
     end
 end
-

--- a/lib/syskit/test/spec.rb
+++ b/lib/syskit/test/spec.rb
@@ -1,27 +1,69 @@
+# frozen_string_literal: true
+
+require 'roby/test/spec'
+
 module Syskit
     module Test
         # Planning handler for #roby_run_planner that handles
         # InstanceRequirementsTask
         class InstanceRequirementPlanningHandler
+            def initialize(test)
+                @test = test
+            end
+
             def start(tasks)
                 @plan = tasks.first.plan
                 @planning_tasks = tasks.map do |t|
-                    if planning_task = t.planning_task
-                        planning_task
-                    else
+                    unless (planning_task = t.planning_task)
                         raise ArgumentError, "#{t} does not have a planning task"
                     end
+
+                    planning_task
                 end
 
-                @planning_tasks.each do |t|
+                starting_tasks = @planning_tasks.find_all do |t|
                     t.start! if t.pending?
+                    t.starting?
                 end
-                Runtime.apply_requirement_modifications(@plan)
+                return apply_requirements if starting_tasks.empty?
+
+                starting_tasks.each do |t|
+                    t.start_event.on do |_|
+                        apply_requirements if starting_tasks.all?(&:running?)
+                    end
+                end
+            end
+
+            def apply_requirements
+                @plan.syskit_start_async_resolution(
+                    @planning_tasks,
+                    validate_generated_network: false,
+                    compute_deployments: false
+                )
             end
 
             def finished?
-                Runtime.apply_requirement_modifications(@plan)
-                @planning_tasks.all? { |t| t.success? }
+                if @plan.syskit_has_async_resolution?
+                    return unless @plan.syskit_finished_async_resolution?
+
+                    @plan.syskit_apply_async_resolution_results
+
+                    # NOTE: this is a run-planner equivalent to syskit_stub_network
+                    # we will have to investigate whether we could implement one with
+                    # the other (probably), but in the meantime we must keep both
+                    # in sync
+                    root_tasks = @planning_tasks.map(&:planned_task)
+                    mapped_tasks = @plan.in_transaction do |trsc|
+                        mapped_tasks = @test.syskit_stub_network_in_transaction(
+                            trsc, root_tasks
+                        )
+                        trsc.commit_transaction
+                        mapped_tasks
+                    end
+
+                    @test.syskit_stub_network_remove_obsolete_tasks(mapped_tasks)
+                end
+                @planning_tasks.all?(&:success?)
             end
         end
         Roby::Test::Spec.roby_plan_with Component.match.with_child(InstanceRequirementsTask), InstanceRequirementPlanningHandler

--- a/test/network_generation/test_async.rb
+++ b/test/network_generation/test_async.rb
@@ -13,13 +13,13 @@ module Syskit
                 result
             end
 
-            describe "#prepare" do
-                it "computes the system network in a separate plan" do
+            describe '#prepare' do
+                it 'computes the system network in a separate plan' do
                     requirements = Set[flexmock]
                     resolution = subject.prepare(requirements)
-                    flexmock(resolution.engine).should_receive(:resolve_system_network).
-                        with(requirements).
-                        once.and_return(ret = flexmock)
+                    flexmock(resolution.engine).should_receive(:resolve_system_network)
+                                               .with(requirements, {})
+                                               .once.and_return(ret = flexmock)
                     resolution.execute
                     assert_equal ret, subject.join
                 end
@@ -65,10 +65,10 @@ module Syskit
                     requirements = Set[flexmock]
                     resolution = subject.prepare(requirements)
                     engine = flexmock(resolution.engine, :strict)
-                    engine.should_receive(:resolve_system_network).
-                        with(requirements).once.and_return(ret = flexmock)
-                    engine.should_receive(:apply_system_network_to_plan).
-                        with(ret).once
+                    engine.should_receive(:resolve_system_network)
+                          .with(requirements, {}).once.and_return(ret = flexmock)
+                    engine.should_receive(:apply_system_network_to_plan)
+                          .with(ret).once
                     resolution.execute
                     subject.join
                     assert subject.finished?

--- a/test/test/test_spec.rb
+++ b/test/test/test_spec.rb
@@ -1,0 +1,105 @@
+require 'syskit/test/self'
+require 'syskit/test'
+
+module Syskit
+    module Test
+        describe InstanceRequirementPlanningHandler do
+            before do
+                @task_m = Syskit::TaskContext.new_submodel(name: 'Task')
+                @srv_m = Syskit::DataService.new_submodel(name: 'Srv')
+                @cmp_m = Syskit::Composition.new_submodel(name: 'Cmp')
+                @cmp_m.add @srv_m, as: 'srv'
+            end
+
+            after do
+                @event_loop_monitor&.dispose
+            end
+
+            it 'stubs a network mingled with non-Syskit tasks' do
+                plan.add(t0 = Roby::Tasks::Simple.new)
+                plan.add(t1 = Roby::Tasks::Simple.new)
+                task = t0.depends_on(@task_m, role: 'task')
+                cmp = t0.depends_on(@cmp_m, role: 'cmp')
+                t0.depends_on(t1, role: 'plain_task')
+                t1.depends_on(task, role: 'task')
+
+                t0 = run_planners(t0)
+                refute_same t0.cmp_child, cmp
+                assert_kind_of @cmp_m, t0.cmp_child
+                assert_kind_of @srv_m, t0.cmp_child.srv_child
+                assert_kind_of @task_m, t0.task_child
+                assert_same t0.task_child, t0.plain_task_child.task_child
+
+                # Make sure that stubbing created a network we can start
+                expect_execution.scheduler(true).to do
+                    start t0.task_child
+                    start t0.cmp_child
+                    start t0.cmp_child.srv_child
+                    start t0.plain_task_child.task_child
+                end
+            end
+
+            it 'triggers resolution immediately if the planning tasks are running' do
+                plan.add(cmp = @cmp_m.as_plan)
+                planning_task = cmp.planning_task
+                execute { planning_task.start! }
+
+                cycles = gather_planning_state(cmp, 1)
+                run_planners(cmp)
+
+                assert_equal false, cycles[0].planning_task_starting
+                assert_equal true, cycles[0].planning_task_running
+                assert cycles[0].has_async_resolution
+            end
+
+            it 'waits for the planning tasks to be started before it triggers the async resolution' do
+                plan.add(cmp = @cmp_m.as_plan)
+                cycles = gather_planning_state(cmp, 2)
+                run_planners(cmp)
+
+                assert_equal true, cycles[0].planning_task_starting
+                assert_equal false, cycles[0].planning_task_running
+                refute cycles[0].has_async_resolution
+
+                assert_equal false, cycles[1].planning_task_starting
+                assert_equal true, cycles[1].planning_task_running
+                assert cycles[1].has_async_resolution
+            end
+
+            it 'considers only the provided tasks' do
+                plan.add(task = @task_m.as_plan)
+                plan.add(cmp = @cmp_m.as_plan)
+
+                cmp = run_planners(cmp)
+                assert_equal [task], plan.find_tasks(@task_m).to_a
+
+                # Make sure that stubbing created a network we can start
+                expect_execution.scheduler(true).to do
+                    start cmp
+                    start cmp.srv_child
+                end
+            end
+
+            PlanningState = Struct.new(
+                :planning_task_starting,
+                :planning_task_running,
+                :has_async_resolution
+            )
+
+            def gather_planning_state(root_task, cycle_count)
+                data = []
+                planning_task = root_task.planning_task
+                @event_loop_monitor = execution_engine.add_propagation_handler(type: :propagation) do
+                    if data.size < cycle_count
+                        data << PlanningState.new(
+                            planning_task.starting?,
+                            planning_task.running?,
+                            plan.syskit_has_async_resolution?
+                        )
+                    end
+                end
+                data
+            end
+        end
+    end
+end


### PR DESCRIPTION
Syskit's `run_planners` support for InstanceRequirements was not stubbing the generated network,
which was essentially making it useless. Add support for stubbing, which makes test support for
e.g. action state machines compatible with Syskit-defined actions