### PR TITLE
Add flexibility to combus definitions

### DIFF
--- a/lib/syskit/models/data_service.rb
+++ b/lib/syskit/models/data_service.rb
@@ -519,15 +519,21 @@ module Syskit
 
                 # declare the relevant dynamic service
                 combus_m = self
-                dyn_name = dynamic_service_name
-                bus_srv  = bus_base_srv
                 mod.dynamic_service bus_base_srv, as: dynamic_service_name do
-                    options = Kernel.validate_options self.options, client_to_bus: nil, bus_to_client: nil
+                    options = Kernel.validate_options self.options, client_to_bus: nil,
+                                                                    bus_to_client: nil
                     in_name =
                         if in_srv = mod.find_data_service_from_type(combus_m.bus_in_srv)
                             in_srv.port_mappings_for_task['to_bus']
                         else
                             combus_m.input_name_for(name)
+                        end
+
+                    out_name =
+                        if out_srv = mod.find_data_service_from_type(combus_m.bus_out_srv)
+                            out_srv.port_mappings_for_task['from_bus']
+                        else
+                            combus_m.output_name_for(name)
                         end
 
                     begin
@@ -540,8 +546,8 @@ module Syskit
                     end
 
                     if client_to_bus && bus_to_client
-                        provides combus_m.bus_srv, 'from_bus' => combus_m.output_name_for(name),
-                            'to_bus' => in_name
+                        provides combus_m.bus_srv, 'from_bus' => out_name,
+                                                   'to_bus' => in_name
                         component_model.orogen_model
                                        .find_port(in_name)
                                        .needs_reliable_connection
@@ -551,7 +557,7 @@ module Syskit
                                        .find_port(in_name)
                                        .needs_reliable_connection
                     elsif bus_to_client
-                        provides combus_m.bus_out_srv, 'from_bus' => combus_m.output_name_for(name)
+                        provides combus_m.bus_out_srv, 'from_bus' => out_name
                     else
                         raise ArgumentError, 'at least one of bus_to_client or '\
                                              'client_to_bus must be true'

--- a/lib/syskit/robot/communication_bus.rb
+++ b/lib/syskit/robot/communication_bus.rb
@@ -49,9 +49,10 @@ module Syskit
             end
 
             # Used by the #through call to override com_bus specification.
-            def device(type_name, options = Hash.new)
-                device = robot.device(type_name, options)
-                device.attach_to(self)
+            def device(type_name, bus_to_client: true, client_to_bus: true, **options)
+                device = robot.device(type_name, **options)
+                device.attach_to(self, bus_to_client: bus_to_client,
+                                       client_to_bus: client_to_bus)
                 device
             end
         end

--- a/test/models/test_data_services.rb
+++ b/test/models/test_data_services.rb
@@ -492,6 +492,23 @@ describe ComBus do
             )
             assert_same combus_m.bus_in_srv, srv.model.model
         end
+        it 'uses a static input service if one is available' do
+            combus_m = @combus_m
+            driver_m = TaskContext.new_submodel do
+                input_port 'driver_in', '/double'
+                provides combus_m::BusInSrv, as: 'bus_in'
+            end
+            driver_m.driver_for combus_m, as: 'combus_driver'
+
+            srv = driver_m.new.require_dynamic_service(
+                'dyn_srv', as: 'dev', bus_to_client: false, client_to_bus: true
+            )
+
+            in_port_m = srv.to_bus_port.to_component_port.model
+
+            assert_equal driver_m, in_port_m.component_model.superclass
+            assert_equal 'driver_in', in_port_m.name
+        end
         it 'provides the mapping of from_bus to input_name_for if requested an input service' do
             flexmock(combus_m).should_receive(:input_name_for)
                               .with('dev').and_return('in_DEV')
@@ -530,6 +547,23 @@ describe ComBus do
             )
             assert_equal Hash['from_bus' => 'out_DEV', 'to_bus' => 'in_DEV'],
                          srv.model.port_mappings_for_task
+        end
+        it 'uses a static output service if one is available' do
+            combus_m = @combus_m
+            driver_m = TaskContext.new_submodel do
+                output_port 'driver_out', '/double'
+                provides combus_m::BusOutSrv, as: 'bus_out'
+            end
+            driver_m.driver_for combus_m, as: 'combus_driver'
+
+            srv = driver_m.new.require_dynamic_service(
+                'dyn_srv', as: 'dev', bus_to_client: true, client_to_bus: false
+            )
+
+            out_port_m = srv.from_bus_port.to_component_port.model
+
+            assert_equal driver_m, out_port_m.component_model.superclass
+            assert_equal 'driver_out', out_port_m.name
         end
         it 'raises if the bus_to_client option is not provided' do
             assert_raises(ArgumentError) do

--- a/test/robot/test_communication_bus.rb
+++ b/test/robot/test_communication_bus.rb
@@ -1,0 +1,52 @@
+require 'syskit/test/self'
+
+module Syskit
+    module Robot
+        describe ComBus do
+            describe '#device' do
+                before do
+                    @bus_m = Syskit::ComBus.new_submodel(
+                        name: 'Combus', message_type: '/double'
+                    )
+                    bus_driver_m = Syskit::TaskContext.new_submodel do
+                        input_port 'in', '/double'
+                        output_port 'out', '/double'
+                    end
+                    bus_driver_m.driver_for @bus_m, as: 'bus'
+                    @com_bus = robot.com_bus @bus_m, as: 'bus'
+
+                    @dev_m = Syskit::Device.new_submodel name: 'Device'
+                    @dev_driver_m = Syskit::TaskContext.new_submodel do
+                        input_port 'in', '/double'
+                        output_port 'out', '/double'
+                    end
+                    @dev_driver_m.driver_for @dev_m, as: 'driver'
+                end
+
+                it 'creates a device attached to a com bus' do
+                    flexmock(MasterDeviceInstance)
+                        .new_instances.should_receive(:attach_to)
+                        .with(@com_bus, bus_to_client: true, client_to_bus: true)
+                        .once
+                    @com_bus.device(@dev_m, as: 'dev')
+                end
+
+                it 'allows to create an out-only client' do
+                    flexmock(MasterDeviceInstance)
+                        .new_instances.should_receive(:attach_to)
+                        .with(@com_bus, bus_to_client: false, client_to_bus: true)
+                        .once
+                    @com_bus.device(@dev_m, as: 'dev', bus_to_client: false)
+                end
+
+                it 'allows to create an in-only client' do
+                    flexmock(MasterDeviceInstance)
+                        .new_instances.should_receive(:attach_to)
+                        .with(@com_bus, bus_to_client: true, client_to_bus: false)
+                        .once
+                    @com_bus.device(@dev_m, as: 'dev', client_to_bus: false)
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
* allow for a com bus to be run on another com bus. This allows for a logical com layer (e.g. NMEA2000) to be built to top of a lower-level one (e.g. CAN)
* allow the out-service on the com bus task to be static. The in-service could already be.
* add tests for the main com bus definition point, `#attach_to`