### PR TITLE
move task context model registration to #register_model

### DIFF
--- a/lib/syskit/models/task_context.rb
+++ b/lib/syskit/models/task_context.rb
@@ -99,13 +99,14 @@ module Syskit
                 end
                 klass = supermodel.new_submodel(orogen_model: orogen_model)
 
-                if register && orogen_model.name
-                    OroGen.syskit_model_toplevel_constant_registration =
-                        Roby.app.backward_compatible_naming?
-                    klass.name = OroGen.register_syskit_model(klass)
-                end
-
+                klass.register_model if register && orogen_model.name
                 klass
+            end
+
+            def register_model
+                OroGen.syskit_model_toplevel_constant_registration =
+                    Roby.app.backward_compatible_naming?
+                self.name = OroGen.register_syskit_model(self)
             end
 
             # This component's oroGen model

--- a/lib/syskit/orogen_namespace.rb
+++ b/lib/syskit/orogen_namespace.rb
@@ -84,6 +84,10 @@ module Syskit
             @registered_models = Hash.new
         end
 
+        def project_name?(name)
+            @project_namespaces.key?(name)
+        end
+
         # Resolve the registered syskit model that has the given orogen name
         def syskit_model_by_orogen_name(name)
             if model = @registered_models[name]


### PR DESCRIPTION
This allows plugins (e.g. syskit-log) to overload where their
model(s) are registered.