### PR TITLE
Change how deployments are selected

### DIFF
--- a/lib/syskit/instance_requirements.rb
+++ b/lib/syskit/instance_requirements.rb
@@ -732,6 +732,13 @@ module Syskit
                 self
             end
 
+            # Declare that an unmanaged task should be used for self
+            def use_unmanaged_task(*spec, **options)
+                invalidate_template
+                deployment_group.use_unmanaged_task(*spec, **options)
+                self
+            end
+
             # Add deployments into the deployments this subnet should be using
             #
             # @param [Models::DeploymentGroup] deployment_group

--- a/lib/syskit/models/configured_deployment.rb
+++ b/lib/syskit/models/configured_deployment.rb
@@ -82,7 +82,8 @@ module Syskit
             # Unlike {#each_orogen_deployed_task_context_model}, it enumerates
             # the Syskit task context model
             #
-            # @yieldparam [String] name the task name
+            # @yieldparam [String] name the task's mapped name, that is the name
+            #     the task will have at runtime
             # @yieldparam [Models::TaskCOntext] the task model
             def each_deployed_task_model
                 return enum_for(__method__) unless block_given?

--- a/lib/syskit/models/configured_deployment.rb
+++ b/lib/syskit/models/configured_deployment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Syskit
     module Models
         # Representation of a deployment that is configured with name mappings
@@ -17,9 +19,14 @@ module Syskit
             #   name in {#model} to the name this task should have while running
             attr_reader :name_mappings
 
-            def initialize(process_server_name, model, name_mappings = Hash.new, process_name = model.name, spawn_options = Hash.new)
-                default_mappings = model.each_deployed_task_model.
-                    each_with_object(Hash.new) do |(deployed_task_name, _), result|
+            def initialize(
+                process_server_name, model, name_mappings = {},
+                process_name = model.name, spawn_options = {}
+            )
+                default_mappings =
+                    model
+                    .each_deployed_task_model
+                    .each_with_object({}) do |(deployed_task_name, _), result|
                         result[deployed_task_name] = deployed_task_name
                     end
 
@@ -34,18 +41,21 @@ module Syskit
             #
             # Filters out options that are part of the spawn options but not of
             # the command-line generation options
-            def filter_command_line_options(oro_logfile: nil, wait: nil, output: nil,
-                **command_line_options)
-                return command_line_options
+            def filter_command_line_options(
+                oro_logfile: nil, wait: nil, output: nil,
+                **command_line_options
+            )
+                command_line_options
             end
-
 
             # Returns the command line information needed to start this
             # deployment on the same machine than Syskit
             def command_line(loader: Roby.app.default_pkgconfig_loader, **options)
-                model.command_line(process_name, name_mappings,
+                model.command_line(
+                    process_name, name_mappings,
                     loader: loader,
-                    **filter_command_line_options(options))
+                    **filter_command_line_options(options)
+                )
             end
 
             # The oroGen model object that represents this configured deployment
@@ -55,9 +65,7 @@ module Syskit
             #
             # @return [OroGen::Spec::Deployment]
             def orogen_model
-                if @orogen_model
-                    return @orogen_model
-                end
+                return @orogen_model if @orogen_model
 
                 @orogen_model = model.orogen_model.dup
                 orogen_model.task_activities.map! do |activity|
@@ -77,7 +85,8 @@ module Syskit
             # @yieldparam [String] name the task name
             # @yieldparam [Models::TaskCOntext] the task model
             def each_deployed_task_model
-                return enum_for(__method__) if !block_given?
+                return enum_for(__method__) unless block_given?
+
                 model.each_deployed_task_model do |name, model|
                     yield(name_mappings[name], model)
                 end
@@ -87,7 +96,8 @@ module Syskit
             #
             # @yieldparam [OroGen::Spec::TaskDeployment]
             def each_orogen_deployed_task_context_model
-                return enum_for(__method__) if !block_given?
+                return enum_for(__method__) unless block_given?
+
                 model.each_orogen_deployed_task_context_model do |deployed_task|
                     task = deployed_task.dup
                     task.name = name_mappings[task.name] || task.name
@@ -99,12 +109,13 @@ module Syskit
             #
             # @return [Syskit::Deployment] a new, properly configured, instance
             #   of {#model}. Usually a {Syskit::Deployment}
-            def new(options = Hash.new)
+            def new(options = {})
                 options = options.merge(
                     process_name: process_name,
                     name_mappings: name_mappings,
                     spawn_options: spawn_options,
-                    on: process_server_name)
+                    on: process_server_name
+                )
                 options.delete(:working_directory)
                 options.delete(:output)
                 options.delete(:wait)
@@ -112,8 +123,9 @@ module Syskit
             end
 
             def ==(other)
-                return if !other.kind_of?(ConfiguredDeployment)
-                return process_server_name == other.process_server_name &&
+                return unless other.kind_of?(ConfiguredDeployment)
+
+                process_server_name == other.process_server_name &&
                     process_name == other.process_name &&
                     model == other.model &&
                     spawn_options == other.spawn_options &&
@@ -124,7 +136,9 @@ module Syskit
                 [process_name, model].hash
             end
 
-            def eql?(other); self == other end
+            def eql?(other)
+                self == other
+            end
 
             def pretty_print(pp)
                 pp.text "deployment #{model.orogen_model.name} with the following tasks"

--- a/lib/syskit/models/deployment_group.rb
+++ b/lib/syskit/models/deployment_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Syskit
     module Models
         # A set of deployments logically grouped together
@@ -15,8 +17,8 @@ module Syskit
             attr_reader :deployments
 
             def initialize
-                @deployed_tasks = Hash.new
-                @deployments = Hash.new
+                @deployed_tasks = {}
+                @deployments = {}
                 invalidate_caches
             end
 
@@ -26,8 +28,8 @@ module Syskit
 
             def initialize_copy(original)
                 super
-                @deployed_tasks = Hash.new
-                @deployments = Hash.new
+                @deployed_tasks = {}
+                @deployments = {}
                 use_group!(original)
             end
 
@@ -43,15 +45,16 @@ module Syskit
             # @see use_group!
             def use_group(other)
                 other = other.to_deployment_group
-                @deployed_tasks = @deployed_tasks.merge(other.deployed_tasks) do |task_name, self_deployment, other_deployment|
-                    if self_deployment != other_deployment
-                        raise TaskNameAlreadyInUse.new(
-                            task_name,
-                            self_deployment,
-                            other_deployment), "there is already a deployment that provides #{task_name}"
+                @deployed_tasks =
+                    @deployed_tasks
+                    .merge(other.deployed_tasks) do |task_name, self_d, other_d|
+                        if self_d != other_d
+                            raise TaskNameAlreadyInUse.new(task_name, self_d, other_d),
+                                  'there is already a deployment that '\
+                                  "provides #{task_name}"
+                        end
+                        self_d
                     end
-                    self_deployment
-                end
                 other.deployments.each do |manager_name, manager_deployments|
                     (deployments[manager_name] ||= Set.new).merge(manager_deployments)
                 end
@@ -68,9 +71,9 @@ module Syskit
             # @see use_group
             def use_group!(other)
                 other = other.to_deployment_group
-                @deployed_tasks.merge!(other.deployed_tasks) do |task_name, self_deployment, other_deployment|
-                    if self_deployment != other_deployment
-                        deployments[self_deployment.process_server_name].delete(self_deployment)
+                @deployed_tasks.merge!(other.deployed_tasks) do |_, self_d, other_d|
+                    if self_d != other_d
+                        deployments[seld_d.process_server_name].delete(self_d)
                     end
                     other_deployment
                 end
@@ -86,11 +89,11 @@ module Syskit
 
             # Returns a deployment group that represents a single deployed task
             def find_deployed_task_by_name(task_name)
-                if configured_deployment = find_deployment_from_task_name(task_name)
-                    result = new
-                    result.register_deployed_task(task_name, configured_deployment)
-                    result
-                end
+                return unless (deployment = find_deployment_from_task_name(task_name))
+
+                result = new
+                result.register_deployed_task(task_name, deployment)
+                result
             end
 
             # A mapping from task models to the set of registered
@@ -104,20 +107,22 @@ module Syskit
             #   (machine_name,deployment_model,task_name) tuples representing
             #   the known ways this task context model could be deployed
             def task_context_deployment_candidates
-                @task_context_deployment_candidates ||= compute_task_context_deployment_candidates
+                @task_context_deployment_candidates ||=
+                    compute_task_context_deployment_candidates
             end
 
             # @api private
             #
             # Computes {#task_context_deployment_candidates}
             def compute_task_context_deployment_candidates
-                deployed_models = Hash.new
-                deployments.each do |machine_name, machine_deployments|
+                deployed_models = {}
+                deployments.each_value do |machine_deployments|
                     machine_deployments.each do |configured_deployment|
-                        configured_deployment.each_deployed_task_model do |task_name, task_model|
-                            deployed_models[task_model] ||= Set.new
-                            deployed_models[task_model] << [configured_deployment, task_name]
-                        end
+                        configured_deployment
+                            .each_deployed_task_model do |task_name, task_model|
+                                s = (deployed_models[task_model] ||= Set.new)
+                                s << [configured_deployment, task_name]
+                            end
                     end
                 end
                 deployed_models
@@ -133,11 +138,13 @@ module Syskit
                 if !candidates || candidates.empty?
                     candidates = task_context_deployment_candidates[task.concrete_model]
                     if !candidates || candidates.empty?
-                        Syskit.debug { "no deployments found for #{task} (#{task.concrete_model})" }
+                        Syskit.debug do
+                            "no deployments found for #{task} (#{task.concrete_model})"
+                        end
                         return Set.new
                     end
                 end
-                return candidates
+                candidates
             end
 
             # Returns the deployment that provides the given task
@@ -149,41 +156,47 @@ module Syskit
 
             # Returns all the deployments registered on a given process manager
             def find_all_deployments_from_process_manager(process_manager_name)
-                deployments[process_manager_name] || Array.new
+                deployments[process_manager_name] || []
             end
 
             # Register a specific task of a configured deployment
             def register_deployed_task(task_name, configured_deployment)
-                if existing = find_deployment_from_task_name(task_name)
-                    if existing != configured_deployment
-                        raise TaskNameAlreadyInUse.new(task_name, existing, configured_deployment), "there is already a deployment that provides #{task_name}"
-                    end
-                    return
+                if (existing = find_deployment_from_task_name(task_name))
+                    return if existing == configured_deployment
+
+                    raise TaskNameAlreadyInUse.new(task_name, existing,
+                                                   configured_deployment),
+                          "there is already a deployment that provides #{task_name}"
                 end
 
                 deployed_tasks[tasks_name] = configured_deployment
-                deployments[configured_deployment.process_server_name] ||= Set.new
-                deployments[configured_deployment.process_server_name] << configured_deployment
+                s = (deployments[configured_deployment.process_server_name] ||= Set.new)
+                s << configured_deployment
+                invalidate_caches
             end
 
             # Register a new deployment in this group
             def register_configured_deployment(configured_deployment)
                 configured_deployment.each_orogen_deployed_task_context_model do |task|
                     orocos_name = task.name
-                    if deployed_tasks[orocos_name] && deployed_tasks[orocos_name] != configured_deployment
-                        raise TaskNameAlreadyInUse.new(orocos_name, deployed_tasks[orocos_name], configured_deployment), "there is already a deployment that provides #{orocos_name}"
+                    existing = deployed_tasks[orocos_name]
+                    if existing && existing != configured_deployment
+                        raise TaskNameAlreadyInUse.new(orocos_name,
+                                                       deployed_tasks[orocos_name],
+                                                       configured_deployment),
+                              "there is already a deployment that provides #{orocos_name}"
                     end
                 end
                 configured_deployment.each_orogen_deployed_task_context_model do |task|
                     deployed_tasks[task.name] = configured_deployment
                 end
-                deployments[configured_deployment.process_server_name] ||= Set.new
-                deployments[configured_deployment.process_server_name] << configured_deployment
+                s = (deployments[configured_deployment.process_server_name] ||= Set.new)
+                s << configured_deployment
                 invalidate_caches
             end
 
             # Enumerates all the deployments registered on self
-            # 
+            #
             # @yieldparam [ConfiguredDeployment]
             def each_configured_deployment
                 return enum_for(__method__) unless block_given?
@@ -195,7 +208,8 @@ module Syskit
 
             # Remove a deployment from this group
             def deregister_configured_deployment(configured_deployment)
-                deployments[configured_deployment.process_server_name].delete(configured_deployment)
+                deployments[configured_deployment.process_server_name]
+                    .delete(configured_deployment)
                 configured_deployment.each_orogen_deployed_task_context_model do |task|
                     deployed_tasks.delete(task.name)
                 end
@@ -221,22 +235,25 @@ module Syskit
             # @param process_managers the object that maintains the set of
             #   process managers
             # @return [[ConfiguredDeployment]]
-            def use_ruby_tasks(mappings, remote_task: false, on: 'ruby_tasks',
-                    process_managers: Syskit.conf)
-
+            def use_ruby_tasks(
+                mappings, remote_task: false, on: 'ruby_tasks',
+                process_managers: Syskit.conf
+            )
                 # Verify that the process manager exists
                 process_managers.process_server_config_for(on)
 
                 if !mappings.respond_to?(:each_key)
-                    raise ArgumentError, "mappings should be given as model => name"
+                    raise ArgumentError, 'mappings should be given as model => name'
                 elsif mappings.size > 1
-                    Roby.warn_deprecated "defining more than one ruby task context " \
-                        "deployment in a single use_ruby_tasks call is deprecated"
+                    Roby.warn_deprecated(
+                        'defining more than one ruby task context ' \
+                        'deployment in a single use_ruby_tasks call is deprecated'
+                    )
                 end
 
                 mappings.each_key do |task_model|
                     valid_model = task_model.kind_of?(Class) &&
-                        (task_model <= Syskit::RubyTaskContext)
+                                  (task_model <= Syskit::RubyTaskContext)
                     unless valid_model
                         raise ArgumentError, "#{task_model} is not a ruby task model"
                     end
@@ -251,9 +268,10 @@ module Syskit
 
                 mappings.map do |task_model, name|
                     deployment_model = task_model.deployment_model
-                    configured_deployment = Models::ConfiguredDeployment.
-                        new(on, deployment_model, Hash['task' => name], name,
-                            Hash[task_context_class: task_context_class])
+                    configured_deployment =
+                        Models::ConfiguredDeployment
+                        .new(on, deployment_model, { 'task' => name }, name,
+                             task_context_class: task_context_class)
                     register_configured_deployment(configured_deployment)
                     configured_deployment
                 end
@@ -261,23 +279,25 @@ module Syskit
 
             # Declare tasks that are going to be started by some other process,
             # but whose tasks are going to be integrated in the syskit network
-            def use_unmanaged_task(mappings, on: 'unmanaged_tasks',
-                process_managers: Syskit.conf)
-
+            def use_unmanaged_task(
+                mappings, on: 'unmanaged_tasks', process_managers: Syskit.conf
+            )
                 # Verify that the process manager exists
                 process_managers.process_server_config_for(on)
 
                 model_to_name = mappings.map do |task_model, name|
                     if task_model.respond_to?(:to_str)
-                        Roby.warn_deprecated "specifying the task model as string "\
-                            "is deprecated. Load the task library and use Syskit's "\
-                            "task class"
+                        Roby.warn_deprecated(
+                            'specifying the task model as string '\
+                            'is deprecated. Load the task library and use Syskit\'s '\
+                            'task class'
+                        )
                         task_model_name = task_model
-                        task_model = Syskit::TaskContext.
-                            find_model_from_orogen_name(task_model_name)
+                        task_model = Syskit::TaskContext
+                                     .find_model_from_orogen_name(task_model_name)
                         unless task_model
                             raise ArgumentError,
-                                "#{task_model_name} is not a known oroGen model name"
+                                  "#{task_model_name} is not a known oroGen model name"
                         end
                     end
                     [task_model, name]
@@ -289,20 +309,23 @@ module Syskit
                         (task_model <= Syskit::TaskContext) &&
                         !(task_model <= Syskit::RubyTaskContext)
                     unless is_pure_task_context_model
-                        raise ArgumentError, "expected a mapping from a task context "\
-                            "model to a name, but got #{task_model}"
+                        raise ArgumentError,
+                              'expected a mapping from a task context '\
+                              "model to a name, but got #{task_model}"
                     end
                 end
 
                 model_to_name.map do |task_model, name|
                     orogen_model = task_model.orogen_model
-                    deployment_model = Syskit::Deployment.
-                        new_submodel(name: "Deployment::Unmanaged::#{name}") do
+                    deployment_model =
+                        Syskit::Deployment
+                        .new_submodel(name: "Deployment::Unmanaged::#{name}") do
                             task name, orogen_model
                         end
 
-                    configured_deployment = Models::ConfiguredDeployment.
-                        new(on, deployment_model, Hash[name => name], name, Hash.new)
+                    configured_deployment =
+                        Models::ConfiguredDeployment
+                        .new(on, deployment_model, { name => name }, name, {})
                     register_configured_deployment(configured_deployment)
                     configured_deployment
                 end
@@ -316,36 +339,39 @@ module Syskit
             #   server on which this deployment should be started
             #
             # @return [Array<Deployment>]
-            def use_deployment(*names, on: 'localhost', simulation: Roby.app.simulation?,
+            def use_deployment(
+                *names, on: 'localhost', simulation: Roby.app.simulation?,
                 loader: Roby.app.default_loader, process_managers: Syskit.conf,
-                **run_options)
+                **run_options
+            )
 
-                deployment_spec = Hash.new
-                if names.last.kind_of?(Hash)
-                    deployment_spec = names.pop
-                end
+                deployment_spec = {}
+                deployment_spec = names.pop if names.last.kind_of?(Hash)
 
                 process_server_name = on
                 process_server_config =
                     if simulation
-                        process_managers.sim_process_server_config_for(process_server_name)
+                        process_managers
+                            .sim_process_server_config_for(process_server_name)
                     else
-                        process_managers.process_server_config_for(process_server_name)
+                        process_managers
+                            .process_server_config_for(process_server_name)
                     end
 
-                deployments_by_name = Hash.new
+                deployments_by_name = {}
                 names = names.map do |n|
                     if n.respond_to?(:orogen_model)
                         if !n.kind_of?(Class)
-                            raise ArgumentError, "only deployment models can be given "\
-                                "without a name"
+                            raise ArgumentError,
+                                  'only deployment models can be given without a name'
                         elsif n <= Syskit::TaskContext && !(n <= Syskit::RubyTaskContext)
-                            raise TaskNameRequired, "you must provide a task name when "\
-                                "starting a component by type, as e.g. use_deployment "\
-                                "OroGen.xsens_imu.Task => 'imu'"
+                            raise TaskNameRequired,
+                                  'you must provide a task name when starting a '\
+                                  'component by type, as e.g. use_deployment '\
+                                  "OroGen.xsens_imu.Task => 'imu'"
                         elsif !(n <= Syskit::Deployment)
-                            raise ArgumentError, "only deployment models can be given "\
-                                "without a name"
+                            raise ArgumentError,
+                                  'only deployment models can be given without a name'
                         end
                         deployments_by_name[n.orogen_model.name] = n
                         n.orogen_model
@@ -361,27 +387,31 @@ module Syskit
                             (k <= Syskit::TaskContext || k <= Syskit::Deployment) &&
                             !(k <= Syskit::RubyTaskContext)
                         unless is_valid
-                            raise ArgumentError, "only deployment and task context "\
-                                "models can be deployed by use_deployment, got #{k}"
+                            raise ArgumentError,
+                                  'only deployment and task context '\
+                                  "models can be deployed by use_deployment, got #{k}"
                         end
                         deployments_by_name[k.orogen_model.name] = k
                         k.orogen_model
                     end
                 end
 
-                new_deployments, _ = Orocos::Process.parse_run_options(
-                    *names, deployment_spec, loader: loader, **run_options)
+                new_deployments, = Orocos::Process.parse_run_options(
+                    *names, deployment_spec, loader: loader, **run_options
+                )
                 new_deployments.map do |deployment_name, name_mappings, name, spawn_options|
                     unless (model = deployments_by_name[deployment_name])
                         orogen_model = loader.deployment_model_from_name(deployment_name)
                         model = Syskit::Deployment.find_model_by_orogen(orogen_model)
                     end
                     model.default_run_options.merge!(
-                        process_managers.default_run_options(model))
+                        process_managers.default_run_options(model)
+                    )
 
-                    configured_deployment = Models::ConfiguredDeployment.
-                        new(process_server_config.name, model, name_mappings, name,
-                            spawn_options)
+                    configured_deployment =
+                        Models::ConfiguredDeployment
+                        .new(process_server_config.name, model, name_mappings, name,
+                             spawn_options)
                     register_configured_deployment(configured_deployment)
                     configured_deployment
                 end
@@ -394,7 +424,10 @@ module Syskit
             #   project should be loaded from
             # @return [Array<Model<Deployment>>] the set of deployments
             # @see #use_deployment
-            def use_deployments_from(project_name, process_managers: Syskit.conf, loader: Roby.app.default_loader, **use_options)
+            def use_deployments_from(
+                project_name, process_managers: Syskit.conf,
+                loader: Roby.app.default_loader, **use_options
+            )
                 Syskit.info "using deployments from #{project_name}"
                 orogen = loader.project_model_from_name(project_name)
 
@@ -402,7 +435,11 @@ module Syskit
                 orogen.each_deployment do |deployment_def|
                     if deployment_def.install?
                         Syskit.info "  #{deployment_def.name}"
-                        result << use_deployment(deployment_def.name, process_managers: process_managers, loader: loader, **use_options)
+                        result << use_deployment(
+                            deployment_def.name,
+                            process_managers: process_managers,
+                            loader: loader, **use_options
+                        )
                     end
                 end
                 result

--- a/lib/syskit/models/deployment_group.rb
+++ b/lib/syskit/models/deployment_group.rb
@@ -368,11 +368,13 @@ module Syskit
             #
             # @return [Array<Deployment>]
             def use_deployment(
-                *names, on: 'localhost', simulation: Roby.app.simulation?,
-                loader: Roby.app.default_loader, process_managers: Syskit.conf,
+                *names,
+                on: 'localhost',
+                simulation: Roby.app.simulation?,
+                loader: nil,
+                process_managers: Syskit.conf,
                 **run_options
             )
-
                 deployment_spec = {}
                 deployment_spec = names.pop if names.last.kind_of?(Hash)
 
@@ -385,6 +387,8 @@ module Syskit
                         process_managers
                             .process_server_config_for(process_server_name)
                     end
+
+                loader ||= process_server_config.loader
 
                 deployments_by_name = {}
                 names = names.map do |n|

--- a/lib/syskit/models/task_context.rb
+++ b/lib/syskit/models/task_context.rb
@@ -198,6 +198,21 @@ module Syskit
                 Syskit::Models.merge_orogen_task_context_models(
                     orogen_model, [service_model.orogen_model], port_mappings)
             end
+
+            # Return the instance requirement object that runs this task
+            # model with the given name
+            def deployed_as(name, **options)
+                to_instance_requirements
+                    .use_deployment(self => name, **options)
+            end
+
+            # Return the instance requirement object that will hook onto
+            # an otherwise started component of the given name
+            # model with the given name
+            def deployed_as_unmanaged(name, **options)
+                to_instance_requirements
+                    .use_unmanaged_task(self => name, **options)
+            end
         end
     end
 end

--- a/lib/syskit/network_generation/system_network_deployer.rb
+++ b/lib/syskit/network_generation/system_network_deployer.rb
@@ -56,174 +56,40 @@ module Syskit
             def deploy(validate: true)
                 debug "Deploying the system network"
 
-                deployment_groups = propagate_deployment_groups
-
-                debug do
-                    debug "Deployment candidates"
-                    log_nest(2) do
-                        deployment_groups.each do |task, group|
-                            candidates = group.
-                                find_all_suitable_deployments_for(task)
-                            log_pp :debug, task
-                            log_nest(2) do
-                                if candidates.empty?
-                                    debug "no deployments"
-                                else
-                                    candidates.each do |deployment|
-                                        log_pp :debug, deployment
-                                    end
-                                end
-                            end
-                        end
-                    end
-                    break
-                end
-
                 all_tasks = plan.find_local_tasks(TaskContext).to_a
                 selected_deployments, missing_deployments =
-                    select_deployments(all_tasks, deployment_groups)
+                    select_deployments(all_tasks)
                 log_timepoint 'select_deployments'
 
                 apply_selected_deployments(selected_deployments)
                 log_timepoint 'apply_selected_deployments'
 
                 if validate
-                    validate_deployed_network(deployment_groups)
+                    validate_deployed_network
                     log_timepoint 'validate_deployed_network'
                 end
 
-                return missing_deployments
+                missing_deployments
             end
 
-            # @api private
+            # Find all candidates, resolved using deployment groups in the task hierarchy
             #
-            # A DFS visitor that propagates the deployment group attribute in
-            # the plan hierarchy
-            class DeploymentGroupVisitor < RGL::DFSVisitor
-                attr_reader :default_group
-                attr_reader :deployment_groups
+            # The method falls back to the default deployment group if no
+            # deployments for the task could be found in the plan itself
+            def find_all_suitable_deployments_for(task, from: task)
+                candidates = from.requirements.deployment_group
+                                 .find_all_suitable_deployments_for(task)
+                return candidates unless candidates.empty?
 
-                attr_predicate :use_cow?
-
-                def initialize(graph, default_group, use_cow: true)
-                    super(graph)
-                    @default_group = default_group
-                    @deployment_groups = Hash.new
-                    @use_cow = use_cow
+                parents = from.each_parent_task.to_a
+                if parents.empty?
+                    return default_deployment_group
+                           .find_all_suitable_deployments_for(task)
                 end
 
-                def handle_start_vertex(root_task)
-                    return if !root_task.kind_of?(Syskit::Component)
-                    task_group = root_task.requirements.deployment_group
-                    group =
-                        if task_group.empty?
-                            default_group
-                        else task_group
-                        end
-
-                    deployment_groups[root_task] =
-                        if use_cow?
-                            [true, group]
-                        else
-                            [false, group.dup]
-                        end
+                parents.each_with_object(Set.new) do |p, s|
+                    s.merge(find_all_suitable_deployments_for(task, from: p))
                 end
-
-                def self.update_deployment_groups(
-                        deployment_groups, task, added_group, use_cow: true)
-                    shared, existing_group = deployment_groups[task]
-                    if existing_group
-                        if existing_group.eql?(added_group)
-                            return
-                        elsif shared
-                            existing_group = existing_group.dup
-                        end
-                        existing_group.use_group(added_group)
-                        deployment_groups[task] = [false, existing_group]
-                    elsif use_cow
-                        deployment_groups[task] = [true, added_group]
-                    else
-                        deployment_groups[task] = [false, added_group.dup]
-                    end
-                end
-
-                def propagate_deployment_group(parent_task, child_task)
-                    if !parent_task.kind_of?(Syskit::Component)
-                        if child_task.kind_of?(Syskit::Component) &&
-                                !deployment_groups[child_task]
-                            handle_start_vertex(child_task)
-                        end
-                        return
-                    elsif !child_task.kind_of?(Syskit::Component)
-                        return
-                    end
-
-                    child_group = child_task.requirements.deployment_group
-                    if !child_group.empty?
-                        deployment_groups[child_task] =
-                            if use_cow?
-                                [true, child_group]
-                            else
-                                [false, child_group.dup]
-                            end
-                    else
-                        _, parent_group = deployment_groups[parent_task]
-                        DeploymentGroupVisitor.update_deployment_groups(
-                            deployment_groups, child_task, parent_group,
-                            use_cow: use_cow?)
-                    end
-                end
-
-                def handle_tree_edge(parent_task, child_task)
-                    propagate_deployment_group(parent_task, child_task)
-                end
-                def handle_forward_edge(parent_task, child_task)
-                    propagate_deployment_group(parent_task, child_task)
-                end
-            end
-
-            # @api private
-            #
-            # Create a hash of task instances to the deployment group that
-            # should be used for that instance
-            def propagate_deployment_groups(use_cow: true)
-                dependency_graph = plan.
-                    task_relation_graph_for(Roby::TaskStructure::Dependency)
-
-                all_groups = Hash.new
-                dependency_graph.each_vertex do |task|
-                    next unless dependency_graph.root?(task)
-
-                    visitor = DeploymentGroupVisitor.new(
-                        dependency_graph, default_deployment_group, use_cow: use_cow)
-                    visitor.handle_start_vertex(task)
-                    dependency_graph.depth_first_visit(task, visitor) {}
-
-                    visitor.deployment_groups.each do |task, (_shared, task_group)|
-                        DeploymentGroupVisitor.update_deployment_groups(
-                            all_groups, task, task_group, use_cow: use_cow)
-                    end
-                end
-
-                groups = Hash.new
-                all_groups.each do |task, (_shared, task_group)|
-                    groups[task] = task_group
-                end
-
-                # 'groups' here includes only the tasks that are in the
-                # dependency graph. Make sure we add entries for the rest as
-                # well
-                plan.find_local_tasks(Syskit::Component).each do |task|
-                    if !groups.has_key?(task)
-                        task_group = task.requirements.deployment_group
-                        groups[task] =
-                            if task_group.empty?
-                                default_deployment_group
-                            else task_group
-                            end
-                    end
-                end
-                groups
             end
 
             # Finds the deployments suitable for a task in a given group
@@ -234,9 +100,8 @@ module Syskit
             # @param [Component] task
             # @param [Models::DeploymentGroup] deployment_groups
             # @return [nil,Deployment]
-            def find_suitable_deployment_for(task, deployment_groups)
-                candidates = deployment_groups[task].
-                    find_all_suitable_deployments_for(task)
+            def find_suitable_deployment_for(task)
+                candidates = find_all_suitable_deployments_for(task)
 
                 return candidates.first if candidates.size <= 1
 
@@ -253,7 +118,7 @@ module Syskit
                 else
                     debug do
                         "  deployment of #{task} (#{task.concrete_model}) "\
-                        "is ambiguous"
+                        'is ambiguous'
                     end
                     return
                 end
@@ -268,14 +133,15 @@ module Syskit
             # @return [(Component=>Deployment,[Component])] the association
             #   between components and the deployments that should be used
             #   for them, and the list of components without deployments
-            def select_deployments(tasks, deployment_groups)
+            def select_deployments(tasks)
                 used_deployments = Set.new
                 missing_deployments = Set.new
-                selected_deployments = Hash.new
+                selected_deployments = {}
 
                 tasks.each do |task|
                     next if task.execution_agent
-                    if !(selected = find_suitable_deployment_for(task, deployment_groups))
+
+                    if !(selected = find_suitable_deployment_for(task))
                         missing_deployments << task
                     elsif used_deployments.include?(selected)
                         debug do
@@ -298,10 +164,12 @@ module Syskit
             #   component-to-deployment association
             # @return [void]
             def apply_selected_deployments(selected_deployments)
-                deployment_tasks = Hash.new
+                deployment_tasks = {}
                 selected_deployments.each do |task, (configured_deployment, task_name)|
-                    deployment_task = (deployment_tasks[[configured_deployment]] ||=
-                            configured_deployment.new)
+                    deployment_task = (
+                        deployment_tasks[[configured_deployment]] ||=
+                            configured_deployment.new
+                    )
 
                     if Syskit.conf.permanent_deployments?
                         plan.add_permanent_task(deployment_task)
@@ -309,8 +177,10 @@ module Syskit
                         plan.add(deployment_task)
                     end
                     deployed_task = deployment_task.task(task_name)
-                    debug { "deploying #{task} with #{task_name} of "\
-                        "#{configured_deployment.short_name} (#{deployed_task})" }
+                    debug do
+                        "deploying #{task} with #{task_name} of "\
+                        "#{configured_deployment.short_name} (#{deployed_task})"
+                    end
                     # We MUST merge one-by-one here. Calling apply_merge_group
                     # on all the merges at once would NOT copy the connections
                     # that exist between the tasks of the "from" group to the
@@ -327,8 +197,8 @@ module Syskit
             # is valid
             #
             # @raise [MissingDeployments] if some tasks could not be deployed
-            def validate_deployed_network(deployment_groups)
-                verify_all_tasks_deployed(deployment_groups)
+            def validate_deployed_network
+                verify_all_tasks_deployed
             end
 
             # Verifies that all tasks in the plan are deployed
@@ -336,7 +206,7 @@ module Syskit
             # @param [Component=>DeploymentGroup] deployment_groups which
             #   deployment groups has been used for which task. This is used
             #   to generate the error messages when needed.
-            def verify_all_tasks_deployed(deployment_groups)
+            def verify_all_tasks_deployed
                 not_deployed = plan.find_local_tasks(TaskContext).
                     not_finished.not_abstract.
                     find_all { |t| !t.execution_agent }
@@ -344,8 +214,7 @@ module Syskit
                 if !not_deployed.empty?
                     tasks_with_candidates = Hash.new
                     not_deployed.each do |task|
-                        candidates = deployment_groups[task].
-                            find_all_suitable_deployments_for(task)
+                        candidates = find_all_suitable_deployments_for(task)
                         candidates = candidates.map do |configured_deployment, task_name|
                             existing = plan.find_local_tasks(task.model).
                                 find_all { |t| t.orocos_name == task_name }

--- a/lib/syskit/network_generation/system_network_deployer.rb
+++ b/lib/syskit/network_generation/system_network_deployer.rb
@@ -33,9 +33,10 @@ module Syskit
             # @return [Models::DeploymentGroup]
             attr_accessor :default_deployment_group
 
-            def initialize(plan, event_logger: plan.event_logger,
-                    merge_solver: MergeSolver.new(plan),
-                    default_deployment_group: Syskit.conf.deployment_group)
+            def initialize(plan,
+                           event_logger: plan.event_logger,
+                           merge_solver: MergeSolver.new(plan),
+                           default_deployment_group: Syskit.conf.deployment_group)
 
                 @plan = plan
                 @event_logger = event_logger
@@ -54,7 +55,7 @@ module Syskit
             # @return [Set] the set of tasks for which the deployer could
             #   not find a deployment
             def deploy(validate: true)
-                debug "Deploying the system network"
+                debug 'Deploying the system network'
 
                 all_tasks = plan.find_local_tasks(TaskContext).to_a
                 selected_deployments, missing_deployments =

--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -507,6 +507,10 @@ module Syskit
                 def in_process?
                     host_id == 'syskit'
                 end
+
+                def loader
+                    client.loader
+                end
             end
 
             # Make a process server available to syskit

--- a/lib/syskit/test/task_context_test.rb
+++ b/lib/syskit/test/task_context_test.rb
@@ -21,8 +21,9 @@ module Syskit
                     end
                     task_context_m.abstract = false
 
-                    process_name = OroGen::Spec::Project.default_deployment_name(task_context_m.orogen_model.name)
-                    syskit_stub_deployment_model(nil, process_name) do
+                    process_name = OroGen::Spec::Project
+                                   .default_deployment_name(task_context_m.orogen_model.name)
+                    syskit_stub_configured_deployment(nil, process_name) do
                         task process_name, task_context_m.orogen_model
                     end
                 else

--- a/test/coordination/test_fault_response_table_extension.rb
+++ b/test/coordination/test_fault_response_table_extension.rb
@@ -64,7 +64,7 @@ describe Syskit::Coordination::Models::FaultResponseTableExtension do
         plan.use_fault_response_table table_model
         assert_equal Array[table_model.data_monitoring_tables.first.table],
             plan.data_monitoring_tables.map(&:model)
-        syskit_stub_deployment_model(component_m)
+        syskit_stub_configured_deployment(component_m)
         component = syskit_deploy_configure_and_start(component_m)
         ruby_task = component.orocos_task.local_ruby_task
         syskit_wait_data_monitoring_ready

--- a/test/coordination/test_models_task_extension.rb
+++ b/test/coordination/test_models_task_extension.rb
@@ -40,7 +40,7 @@ describe Syskit::Coordination::Models::TaskExtension do
                 emit task.monitor_failed_event
             start task
         end
-        syskit_stub_deployment_model(component_m)
+        syskit_stub_configured_deployment(component_m)
         task = action_m.test_machine.instanciate(plan)
         plan.add(task)
         execute { task.start! }
@@ -68,7 +68,7 @@ describe Syskit::Coordination::Models::TaskExtension do
         assert_equal Roby::Coordination::Models::Base::Argument.new(:test_arg, true, nil), task.data_monitoring_table.arguments[:test_arg]
         assert_equal Hash[arg: :test_arg], task.data_monitoring_arguments
 
-        syskit_stub_deployment_model(component_m)
+        syskit_stub_configured_deployment(component_m)
         task = action_m.test_machine(arg: 0).instanciate(plan)
         recorder.should_receive(:called).with(0).once
         plan.add_mission_task(task)

--- a/test/models/test_deployment_group.rb
+++ b/test/models/test_deployment_group.rb
@@ -111,7 +111,7 @@ module Syskit
                 end
             end
 
-            describe "#task_context_deployment_candidates" do
+            describe '#task_context_deployment_candidates' do
                 attr_reader :task_m, :deployment_m
                 before do
                     @task_m = task_m = Syskit::TaskContext.new_submodel
@@ -120,17 +120,27 @@ module Syskit
                     end
                 end
 
-                it "registers the mapping from task models to available deployments" do
-                    first  = group.use_deployment(Hash[deployment_m => '1_'],
-                        on: 'test-mng', process_managers: conf, loader: loader).first
-                    second = group.use_deployment(Hash[deployment_m => '2_'],
-                        on: 'test-mng', process_managers: conf, loader: loader).first
-                    assert_equal Hash[task_m => Set[
-                            [first, '1_task'], [second, '2_task']]],
+                it 'registers the mapping from task models to available deployments' do
+                    first = group.use_deployment(
+                        { deployment_m => '1_' },
+                        on: 'test-mng', process_managers: conf, loader: loader
+                    ).first
+                    second = group.use_deployment(
+                        { deployment_m => '2_' },
+                        on: 'test-mng', process_managers: conf, loader: loader
+                    ).first
+
+                    deployed_tasks =
+                        Set[DeploymentGroup::DeployedTask.new(first, '1_task'),
+                            DeploymentGroup::DeployedTask.new(second, '2_task')]
+
+                    assert_equal(
+                        { task_m => deployed_tasks },
                         group.task_context_deployment_candidates
+                    )
                 end
 
-                it "caches the computed result" do
+                it 'caches the computed result' do
                     group.task_context_deployment_candidates
                     flexmock(group).
                         should_receive(:compute_task_context_deployment_candidates).
@@ -138,7 +148,7 @@ module Syskit
                     group.task_context_deployment_candidates
                 end
 
-                it "recomputes on #invalidate_cache" do
+                it 'recomputes on #invalidate_cache' do
                     group.task_context_deployment_candidates
                     flexmock(group).
                         should_receive(:compute_task_context_deployment_candidates).
@@ -158,31 +168,45 @@ module Syskit
                 end
 
                 it "returns matching deployments with the exact task model" do
-                    first  = group.use_deployment(Hash[deployment_m => '1_'],
-                        on: 'test-mng', process_managers: conf, loader: loader).first
-                    second = group.use_deployment(Hash[deployment_m => '2_'],
-                        on: 'test-mng', process_managers: conf, loader: loader).first
+                    first = group.use_deployment(
+                        { deployment_m => '1_' },
+                        on: 'test-mng', process_managers: conf, loader: loader
+                    ).first
+                    second = group.use_deployment(
+                        { deployment_m => '2_' },
+                        on: 'test-mng', process_managers: conf, loader: loader
+                    ).first
                     task = task_m.new
-                    assert_equal Set[[first, '1_task'], [second, '2_task']],
+                    assert_equal(
+                        Set[DeploymentGroup::DeployedTask.new(first, '1_task'),
+                            DeploymentGroup::DeployedTask.new(second, '2_task')],
                         group.find_all_suitable_deployments_for(task)
+                    )
                 end
 
-                it "returns deployments valid for the task's concrete model "\
-                    "if there are none for the actual" do
-                    first  = group.use_deployment(Hash[deployment_m => '1_'],
-                        on: 'test-mng', process_managers: conf, loader: loader).first
-                    second = group.use_deployment(Hash[deployment_m => '2_'],
-                        on: 'test-mng', process_managers: conf, loader: loader).first
+                it 'returns deployments valid for the task\'s concrete model if there are none for the actual' do
+                    first = group.use_deployment(
+                        { deployment_m => '1_' },
+                        on: 'test-mng', process_managers: conf, loader: loader
+                    ).first
+                    second = group.use_deployment(
+                        { deployment_m => '2_' },
+                        on: 'test-mng', process_managers: conf, loader: loader
+                    ).first
                     task = task_m.new
                     task.specialize
                     refute_same task.concrete_model, task.model
-                    assert_equal Set[[first, '1_task'], [second, '2_task']],
+                    assert_equal(
+                        Set[DeploymentGroup::DeployedTask.new(first, '1_task'),
+                            DeploymentGroup::DeployedTask.new(second, '2_task')],
                         group.find_all_suitable_deployments_for(task)
+                    )
                 end
 
-                it "returns an empty set if there is no match" do
-                    assert_equal Set[], group.
-                        find_all_suitable_deployments_for(task_m.new)
+                it 'returns an empty set if there is no match' do
+                    assert_equal(
+                        Set[], group.find_all_suitable_deployments_for(task_m.new)
+                    )
                 end
             end
 

--- a/test/network_generation/test_engine.rb
+++ b/test/network_generation/test_engine.rb
@@ -596,7 +596,9 @@ module Syskit
                     plan.execution_engine.garbage_collect
                     plan_copy, mappings = plan.deep_copy
 
-                    syskit_engine.resolve
+                    syskit_engine.resolve(
+                        default_deployment_group: default_deployment_group
+                    )
                     plan.execution_engine.garbage_collect
                     diff = plan.find_plan_difference(plan_copy, mappings)
                     assert !diff, diff.to_s

--- a/test/network_generation/test_system_network_deployer.rb
+++ b/test/network_generation/test_system_network_deployer.rb
@@ -13,166 +13,62 @@ module Syskit
 
             before do
                 @default_deployment_group = Models::DeploymentGroup.new
-                @deployer = SystemNetworkDeployer.new(plan, default_deployment_group: default_deployment_group)
+                @deployer = SystemNetworkDeployer.new(
+                    plan, default_deployment_group: default_deployment_group
+                )
 
                 @merge_solver = flexmock(deployer.merge_solver)
                 @deployment_m = Syskit::Deployment.new_submodel
                 @template_group = Models::DeploymentGroup.new
                 @template_configured_deployment =
-                    Models::ConfiguredDeployment.new('test-mng', deployment_m, Hash['task' => 'task'])
-                template_group.register_configured_deployment(template_configured_deployment)
+                    Models::ConfiguredDeployment.new(
+                        'test-mng', deployment_m, 'task' => 'task'
+                    )
+                template_group.register_configured_deployment(
+                    template_configured_deployment
+                )
             end
 
-            describe "#propagate_deployment_groups" do
-                attr_reader :parent, :child
-                before do
-                    task_m = Syskit::TaskContext.new_submodel
-                    plan.add(@parent = task_m.new)
-                    plan.add(@child = task_m.new)
-                    parent.depends_on child, role: 'test'
-                end
-
-                def assert_has_merged_template_group(selection, child)
-                    assert_equal Set[template_configured_deployment],
-                        selection[child].find_all_deployments_from_process_manager('test-mng')
-                end
-
-                it "propagates the group from parent to child" do
-                    parent.requirements.deployment_group.
-                        use_group(template_group)
-                    selection = deployer.propagate_deployment_groups
-                    assert_has_merged_template_group selection, child
-                end
-                it "ignores plain roby tasks present as root" do
-                    plan.add(task = Roby::Task.new)
-                    task.depends_on child
-                    deployer.propagate_deployment_groups
-                end
-                it "ignores plain roby tasks present as child" do
-                    plan.add(task = Roby::Task.new)
-                    parent.depends_on task
-                    deployer.propagate_deployment_groups
-                end
-
-                it "computes the deployment group for tasks that are not present in the dependency graph" do
-                    plan.add(task = Syskit::TaskContext.new_submodel.new)
-                    groups = deployer.propagate_deployment_groups
-                    assert groups[task]
-                end
-
-                it "selects a task's group if it has an explicit one" do
-                    child.requirements.deployment_group.
-                        use_group(template_group)
-                    selection = deployer.propagate_deployment_groups
-                    assert_same child.requirements.deployment_group,
-                        selection[child]
-                end
-                it "uses the default deployment group for toplevel tasks that have no group" do
-                    default_deployment_group.use_group(template_group)
-                    selection = deployer.propagate_deployment_groups
-                    assert_has_merged_template_group selection, parent
-                    assert_has_merged_template_group selection, child
-                end
-
-                it "handles having roots that are not components" do
-                    plan.add(root = Roby::Task.new)
-                    root.depends_on parent
-                    selection = deployer.propagate_deployment_groups
-                    assert_same default_deployment_group, selection[child]
-                end
-
-                describe "propagation with multiple parents" do
-                    attr_reader :task_m
-                    attr_reader :other_parent, :other_deployment
-                    before do
-                        @task_m = Syskit::TaskContext.new_submodel
-                        parent.requirements.deployment_group.
-                            use_group(template_group)
-                        plan.add(@other_parent = task_m.new)
-                        @other_deployment =
-                            Models::ConfiguredDeployment.new('test-mng', deployment_m, Hash['task' => 'other'])
-                        other_parent.requirements.deployment_group.
-                            register_configured_deployment(other_deployment)
-                        other_parent.depends_on child, role: 'other'
-                    end
-
-                    it "merges groups coming from two independent branches" do
-                        selection = deployer.propagate_deployment_groups
-                        assert_equal Set[other_deployment, template_configured_deployment],
-                            selection[child].find_all_deployments_from_process_manager('test-mng')
-                    end
-
-                    it "merges groups coming from a diamond" do
-                        plan.add(root = task_m.new)
-                        root.depends_on parent
-                        root.depends_on other_parent
-                        selection = deployer.propagate_deployment_groups
-                        assert_equal Set[other_deployment, template_configured_deployment],
-                            selection[child].find_all_deployments_from_process_manager('test-mng')
-                    end
-
-                    it "keeps the parent groups independent" do
-                        selection = deployer.propagate_deployment_groups
-                        refute_same selection[parent], selection[child]
-                        refute_same selection[other_parent], selection[child]
-                    end
-
-                    it "propagates both branches to granchildren" do
-                        plan.add(grandchild = task_m.new)
-                        child.depends_on grandchild, role: 'deeper'
-                        # Must use_cow: false here, otherwise the test set up is
-                        # super fragile. We really want to be sure that the
-                        # algorithm goes over all tasks
-                        selection = deployer.propagate_deployment_groups(use_cow: false)
-                        assert_equal Set[other_deployment, template_configured_deployment],
-                            selection[grandchild].find_all_deployments_from_process_manager('test-mng')
-                    end
-
-                    it "does not merge the default deployments into intermediate tasks with no specific requirements" do
-                        # ORDER MATTERS HERE. The issue is with RGL's default
-                        # depth first visit implementation, which picks the
-                        # vertices one by one in order
-                        execute { plan.clear }
-                        plan.add(child = task_m.new)
-                        plan.task_relation_graph_for(Roby::TaskStructure::Dependency).add_vertex(child)
-                        plan.add(parent = task_m.new)
-                        parent.depends_on child
-                        parent.requirements.use_deployment(deployment_m)
-                        selection = deployer.propagate_deployment_groups
-                        assert_equal parent.requirements.deployment_group, selection[child]
-                    end
-                end
-            end
-
-            describe "#resolve_deployment_ambiguity" do
+            describe '#resolve_deployment_ambiguity' do
                 def mock_configured_deployment
                     flexmock(process_server_name: 'test-mng')
                 end
 
-                it "resolves ambiguity by orocos_name" do
-                    candidates = [[mock_configured_deployment, 'task'], [mock_configured_deployment, 'other_task']]
-                    assert_equal candidates[1],
-                        deployer.resolve_deployment_ambiguity(candidates, flexmock(orocos_name: 'other_task'))
+                it 'resolves ambiguity by orocos_name' do
+                    candidates = [[mock_configured_deployment, 'task'],
+                                  [mock_configured_deployment, 'other_task']]
+                    assert_equal(
+                        candidates[1],
+                        deployer.resolve_deployment_ambiguity(
+                            candidates, flexmock(orocos_name: 'other_task')
+                        )
+                    )
                 end
-                it "returns nil if the requested orocos_name cannot be found" do
+                it 'returns nil if the requested orocos_name cannot be found' do
                     candidates = [[mock_configured_deployment, 'task']]
-                    refute deployer.resolve_deployment_ambiguity(candidates, flexmock(orocos_name: 'other_task'))
+                    refute deployer.resolve_deployment_ambiguity(
+                        candidates, flexmock(orocos_name: 'other_task')
+                    )
                 end
-                it "resolves ambiguity by deployment hints if there are no name" do
-                    candidates = [[mock_configured_deployment, 'task'], [mock_configured_deployment, 'other_task']]
+                it 'resolves ambiguity by deployment hints if there are no name' do
+                    candidates = [[mock_configured_deployment, 'task'],
+                                  [mock_configured_deployment, 'other_task']]
                     task = flexmock(orocos_name: nil, deployment_hints: [/other/])
                     assert_equal candidates[1],
-                        deployer.resolve_deployment_ambiguity(candidates, task)
+                                 deployer.resolve_deployment_ambiguity(candidates, task)
                 end
-                it "returns nil if there are neither an orocos name nor hints" do
-                    candidates = [[mock_configured_deployment, 'task'], [mock_configured_deployment, 'other_task']]
+                it 'returns nil if there are neither an orocos name nor hints' do
+                    candidates = [[mock_configured_deployment, 'task'],
+                                  [mock_configured_deployment, 'other_task']]
                     task = flexmock(orocos_name: nil, deployment_hints: [], model: nil)
-                    assert !deployer.resolve_deployment_ambiguity(candidates, task)
+                    refute deployer.resolve_deployment_ambiguity(candidates, task)
                 end
-                it "returns nil if the hints don't allow to resolve the ambiguity" do
-                    candidates = [[mock_configured_deployment, 'task'], [mock_configured_deployment, 'other_task']]
-                    task = flexmock(orocos_name: nil, deployment_hints: [/^other/, /^task/], model: nil)
-                    assert !deployer.resolve_deployment_ambiguity(candidates, task)
+                it 'returns nil if the hints don\'t allow to resolve the ambiguity' do
+                    candidates = [[mock_configured_deployment, 'task'],
+                                  [mock_configured_deployment, 'other_task']]
+                    task = flexmock(orocos_name: nil, model: nil,
+                                    deployment_hints: [/^other/, /^task/])
+                    refute deployer.resolve_deployment_ambiguity(candidates, task)
                 end
             end
 
@@ -193,58 +89,190 @@ module Syskit
                 end
 
                 it "selects a deployment returned by #find_suitable_deployment_for" do
-                    groups = flexmock
                     flexmock(deployer).should_receive(:find_suitable_deployment_for).
-                        with(task, groups).
+                        with(task).
                         and_return(deployment = flexmock)
                     assert_equal [Hash[task => deployment], Set.new],
-                        deployer.select_deployments([task], groups)
+                        deployer.select_deployments([task])
                 end
                 it "ignores tasks that already have an execution agent" do
                     flexmock(task).should_receive(:execution_agent).and_return(true)
                     assert_equal [Hash[], Set[]],
-                        deployer.select_deployments([task], flexmock)
+                        deployer.select_deployments([task])
                 end
                 it "reports a task that has no deployments in the returned "\
                     "missing_deployments set" do
-                    groups = flexmock
                     flexmock(deployer).should_receive(:find_suitable_deployment_for).
-                        with(task, groups).
+                        with(task).
                         and_return(nil)
                     assert_equal [Hash[], Set[task]],
-                        deployer.select_deployments([task], groups)
+                        deployer.select_deployments([task])
                 end
                 it "does not select the same deployment twice" do
-                    groups = flexmock
                     flexmock(deployer).should_receive(:find_suitable_deployment_for).
                         and_return(deployment = flexmock)
                     plan.add(task1 = task_m.new)
                     assert_equal [Hash[task => deployment], Set[task1]],
-                        deployer.select_deployments([task, task1], groups)
+                        deployer.select_deployments([task, task1])
                 end
 
                 it "does not allocate the same task twice" do
-                    groups = flexmock
                     flexmock(deployer).should_receive(:find_suitable_deployment_for).
                         and_return(deployment = flexmock)
                     plan.add(task0 = task_models[0].new)
                     plan.add(task1 = task_models[0].new)
-                    _, missing = deployer.select_deployments([task0, task1], groups)
+                    _, missing = deployer.select_deployments([task0, task1])
                     assert_equal 1, missing.size
                     assert [task0, task1].include?(missing.first)
                 end
                 it "does not resolve ambiguities by considering already allocated tasks" do
-                    groups = flexmock
                     flexmock(deployer).should_receive(:find_suitable_deployment_for).
                         and_return(deployment = flexmock)
                     plan.add(task0 = task_models[0].new(orocos_name: 'task'))
                     plan.add(task1 = task_models[0].new)
-                    _, missing = deployer.select_deployments([task0, task1], groups)
+                    _, missing = deployer.select_deployments([task0, task1])
                     assert_equal [task1], missing.to_a
                 end
             end
 
-            describe "#find_suitable_deployment_for" do
+            describe '#find_all_suitable_deployments_for' do
+                attr_reader :task_m, :deployment_m
+
+                before do
+                    @task_m = Syskit::TaskContext.new_submodel(name: 'Test')
+                    @deployment_m = syskit_stub_deployment_model(
+                        task_m, 'orogen_default_Test'
+                    )
+                    @deployer = SystemNetworkDeployer.new(plan)
+                end
+
+                it 'returns a deployment stored on the task itself' do
+                    task = @task_m.deployed_as('test', on: 'stubs')
+                                  .instanciate(plan)
+
+                    deployments = @deployer.find_all_suitable_deployments_for(task)
+                    assert_equal 1, deployments.size
+                    assert_equal 'test', deployments.first.mapped_task_name
+                    assert_equal deployment_m,
+                                 deployments.first.configured_deployment.model
+                end
+
+                it 'falls back on the default deployment if a standalone task has no suitable deployment' do
+                    @deployer.default_deployment_group
+                             .use_deployment(@task_m => 'test', on: 'stubs')
+                    task = @task_m.instanciate(plan)
+
+                    deployments = @deployer.find_all_suitable_deployments_for(task)
+                    assert_equal 1, deployments.size
+                    assert_equal 'test', deployments.first.mapped_task_name
+                    assert_equal deployment_m,
+                                 deployments.first.configured_deployment.model
+                end
+
+                it 'returns a deployment stored on the task\'s parent' do
+                    cmp_m = Syskit::Composition.new_submodel
+                    cmp_m.add @task_m, as: 'child'
+                    cmp = cmp_m.to_instance_requirements
+                               .use_deployment(@task_m => 'test', on: 'stubs')
+                               .instanciate(plan)
+
+                    deployments = @deployer
+                                  .find_all_suitable_deployments_for(cmp.child_child)
+                    assert_equal 1, deployments.size
+                    assert_equal 'test', deployments.first.mapped_task_name
+                    assert_equal deployment_m,
+                                 deployments.first.configured_deployment.model
+                end
+
+                it 'stops at the first level with a matching deployment' do
+                    cmp_m = Syskit::Composition.new_submodel
+                    cmp_m.add @task_m.deployed_as('child'), as: 'child'
+                    cmp = cmp_m.to_instance_requirements
+                               .use_deployment(@task_m => 'test', on: 'stubs')
+                               .instanciate(plan)
+
+                    deployments = @deployer
+                                  .find_all_suitable_deployments_for(cmp.child_child)
+                    assert_equal 1, deployments.size
+                    assert_equal 'child', deployments.first.mapped_task_name
+                    assert_equal deployment_m,
+                                 deployments.first.configured_deployment.model
+                end
+
+                it 'resolves multiple branches if the hierarchy graph forks' do
+                    cmp_m = Syskit::Composition.new_submodel
+                    cmp_m.add @task_m, as: 'child'
+
+                    cmp0 = cmp_m.to_instance_requirements
+                                .use_deployment(@task_m => 'test0', on: 'stubs')
+                                .instanciate(plan)
+                    cmp1 = cmp_m.to_instance_requirements
+                                .use_deployment(@task_m => 'test1', on: 'stubs')
+                                .instanciate(plan)
+                    cmp1.remove_child(cmp1.child_child)
+                    cmp1.depends_on cmp0.child_child, role: 'child'
+
+                    deployments = @deployer
+                                  .find_all_suitable_deployments_for(cmp0.child_child)
+                    assert_equal 2, deployments.size
+                    assert_equal %w[test0 test1], deployments.map(&:mapped_task_name)
+                    assert_equal([deployment_m, deployment_m],
+                                 deployments.map { |d| d.configured_deployment.model })
+                end
+
+                it 'reports a given deployment only once' do
+                    cmp_m = Syskit::Composition.new_submodel
+                    cmp_m.add @task_m, as: 'child'
+
+                    cmp0 = cmp_m.to_instance_requirements
+                                .use_deployment(@task_m => 'test0', on: 'stubs')
+                                .instanciate(plan)
+                    cmp1 = cmp_m.to_instance_requirements
+                                .use_deployment(@task_m => 'test0', on: 'stubs')
+                                .instanciate(plan)
+                    cmp1.remove_child(cmp1.child_child)
+                    cmp1.depends_on cmp0.child_child, role: 'child'
+
+                    deployments = @deployer
+                                  .find_all_suitable_deployments_for(cmp0.child_child)
+                    assert_equal %w[test0], deployments.map(&:mapped_task_name)
+                    assert_equal([deployment_m],
+                                 deployments.map { |d| d.configured_deployment.model })
+                end
+
+                it 'falls back on the default deployment group if there are no suitable definitions in the hierarchy' do
+                    @deployer.default_deployment_group
+                             .use_deployment(@task_m => 'test', on: 'stubs')
+
+                    cmp_m = Syskit::Composition.new_submodel
+                    cmp_m.add @task_m, as: 'child'
+                    cmp0 = cmp_m.to_instance_requirements.instanciate(plan)
+                    cmp1 = cmp_m.to_instance_requirements.instanciate(plan)
+                    cmp1.remove_child(cmp1.child_child)
+                    cmp1.depends_on cmp0.child_child, role: 'child'
+
+                    deployments = @deployer
+                                  .find_all_suitable_deployments_for(cmp0.child_child)
+                    assert_equal %w[test], deployments.map(&:mapped_task_name)
+                    assert_equal([deployment_m],
+                                 deployments.map { |d| d.configured_deployment.model })
+                end
+
+                it 'returns an empty set if there is nothing suitable' do
+                    cmp_m = Syskit::Composition.new_submodel
+                    cmp_m.add @task_m, as: 'child'
+                    cmp0 = cmp_m.to_instance_requirements.instanciate(plan)
+                    cmp1 = cmp_m.to_instance_requirements.instanciate(plan)
+                    cmp1.remove_child(cmp1.child_child)
+                    cmp1.depends_on cmp0.child_child, role: 'child'
+
+                    deployments = @deployer
+                                  .find_all_suitable_deployments_for(cmp0.child_child)
+                    assert_equal Set.new, deployments
+                end
+            end
+
+            describe '#find_suitable_deployment_for' do
                 attr_reader :task_m, :task
                 before do
                     @task_m = Syskit::TaskContext.new_submodel
@@ -257,32 +285,30 @@ module Syskit
                     deployer
                 end
 
-                it "returns the possible deployment if it is unique" do
-                    group = flexmock(:on, Models::DeploymentGroup)
-                    group.should_receive(:find_all_suitable_deployments_for).with(task).
-                        and_return([deployment = flexmock])
-                    assert_equal deployment, deployer.find_suitable_deployment_for(
-                        task, Hash[task => group])
+                it 'returns the possible deployment if it is unique' do
+                    flexmock(deployer).should_receive(:find_all_suitable_deployments_for)
+                                      .with(task)
+                                      .and_return([deployment = flexmock])
+                    assert_equal deployment,
+                                 deployer.find_suitable_deployment_for(task)
                 end
-                it "disambiguates tasks that have more than one possible deployments" do
-                    group = flexmock(:on, Models::DeploymentGroup)
-                    group.should_receive(:find_all_suitable_deployments_for).with(task).
-                        and_return(candidates = [flexmock, deployment1 = flexmock])
-                    flexmock(deployer).should_receive(:resolve_deployment_ambiguity).
-                        with(candidates, task).
-                        and_return(deployment1)
-                    assert_equal deployment1, deployer.find_suitable_deployment_for(
-                        task, Hash[task => group])
+                it 'disambiguates tasks that have more than one possible deployments' do
+                    flexmock(deployer).should_receive(:find_all_suitable_deployments_for)
+                                      .with(task)
+                                      .and_return(candidates = [flexmock, deployment1 = flexmock])
+                    flexmock(deployer).should_receive(:resolve_deployment_ambiguity)
+                                      .with(candidates, task)
+                                      .and_return(deployment1)
+                    assert_equal deployment1,
+                                 deployer.find_suitable_deployment_for(task)
                 end
-                it "returns nil if the disambiguation failed" do
-                    group = flexmock(:on, Models::DeploymentGroup)
-                    group.should_receive(:find_all_suitable_deployments_for).with(task).
-                        and_return(candidates = [flexmock, flexmock])
-                    flexmock(deployer).should_receive(:resolve_deployment_ambiguity).
-                        with(candidates, task).
-                        and_return(nil)
-                    assert_nil deployer.find_suitable_deployment_for(
-                        task, Hash[task => group])
+                it 'returns nil if the disambiguation failed' do
+                    flexmock(deployer).should_receive(:find_all_suitable_deployments_for)
+                                      .with(task)
+                                      .and_return([flexmock, flexmock])
+                    flexmock(deployer).should_receive(:resolve_deployment_ambiguity)
+                                      .and_return(nil)
+                    assert_nil deployer.find_suitable_deployment_for(task)
                 end
             end
 
@@ -386,9 +412,8 @@ module Syskit
                     task_m = Syskit::TaskContext.new_submodel
                     deployment_m.orogen_model.task 'task', task_m.orogen_model
                     plan.add(task = task_m.new)
-                    groups = Hash[task => template_group]
                     assert_raises(MissingDeployments) do
-                        deployer.validate_deployed_network(groups)
+                        deployer.validate_deployed_network
                     end
                 end
             end

--- a/test/test/test_network_manipulation.rb
+++ b/test/test/test_network_manipulation.rb
@@ -96,6 +96,30 @@ module Syskit
                     end
                 end
             end
+
+            describe '#syskit_deploy' do
+                before do
+                    @task_m = Syskit::TaskContext.new_submodel(name: 'Test')
+                    syskit_stub_deployment_model(@task_m, 'orogen_default_Test')
+                end
+
+                it 'uses a usable deployment from the requirement\'s deployment group' do
+                    task = syskit_deploy(@task_m.deployed_as('local_level', on: 'stubs'))
+                    assert_equal 'local_level', task.orocos_name
+                end
+
+                it 'prefers a requirement-level deployment over a test-level one' do
+                    use_deployment @task_m => 'test_level', on: 'stubs'
+                    task = syskit_deploy(@task_m.deployed_as('local_level', on: 'stubs'))
+                    assert_equal 'local_level', task.orocos_name
+                end
+
+                it 'uses a usable deployment from the test\'s deployment group' do
+                    use_deployment @task_m => 'test_level', on: 'stubs'
+                    task = syskit_deploy(@task_m)
+                    assert_equal 'test_level', task.orocos_name
+                end
+            end
         end
     end
 end

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -1131,8 +1131,8 @@ module Syskit
             dev.attach_to(bus, client_to_bus: false)
 
             # Now, deploy !
-            syskit_stub_deployment_model(combus_driver_m, 'bus_task', remote_task: false)
-            syskit_stub_deployment_model(device_driver_m, 'dev_task')
+            syskit_stub_configured_deployment(combus_driver_m, 'bus_task', remote_task: false)
+            syskit_stub_configured_deployment(device_driver_m, 'dev_task')
             dev_driver = syskit_deploy(dev)
             bus_driver = plan.find_tasks(combus_driver_m).first
             syskit_start_execution_agents(bus_driver)


### PR DESCRIPTION
Depends on:
- [x] https://github.com/orocos-toolchain/orogen/pull/126

Note: the orogen dependency is needed for the change in the syskit_stub method.
The method now resolves models using the process server's own loader instead
of the hardcoded global Roby.app, which triggered a limitation in orogen's loaders
design.

Deployment groups were introduced to refactor the way deployments
were declared and managed.

Pre-groups, all deployments were declared at the level of the global
configuration, and chosen using `prefer_deployed_tasks`. This showed
serious limitations (apart from the ugliness of the globality of it
...). The two main usability issues were:

1. deployments are defined in the robot config and used in profiles. The
   link between the two is implicit. Reusing a deployed profile turned
   out to be difficult, as was "instanciating" a profile multiple times
2. Locally "massaging" instance requirements to change how things are
   deployed without affecting the rest of the system is close to
   impossible.

Deployment group's propositions was to create an object to manage and
resolve deployments locally, and attach a group to a task's (through
InstanceRequirements). The system deployer would be asking these
objects for deployments _et voila_. A global deployment group would
be used as fallback to keep things running.

However, the current implementation would resolve a "deployment group"
that is a top-down merge of the groups present in the plan: start with
the root of the hierarchy, the groups would be merged (as in: union-ed)
until the leaves (the tasks) and then deployments would be resolved.
This made overriding (obviously) impossible and forbid gradually
moving to groups (if a deployment is available for a task globally, it
would create ambiguities when another one is defined more locally).

This changes the implementation to instead look for the first matching
deployment bottom-up, and stop there. Overriding becomes the default.

With this change (and the new #deployed_as helper), one can define an
deploy a task (e.g. a device) with

~~~ ruby
define 'camera', camera_dev.deployed_as('front_camera')
~~~

Ambiguities might still happen if there is a fork in the hierarchy tree:

- A depends on task
- B depends on task
- both A and B define different deployments for task

This could be solved by applying deployments _before_ merging the
network(s), which would also allow us to force multiple instanciations
of the same task by assigning multiple deployments. But that's for
another time.

