### PR TITLE
fix multiple bugs in flow dynamics computation related to busses

### DIFF
--- a/lib/syskit/network_generation/dataflow_dynamics.rb
+++ b/lib/syskit/network_generation/dataflow_dynamics.rb
@@ -102,6 +102,8 @@ module Syskit
             end
 
             def merge(other_dynamics)
+                return if other_dynamics.equal?(self)
+
                 DataFlowDynamics.debug do
                     DataFlowDynamics.debug "adding triggers from #{other_dynamics.name} to #{name}"
                     DataFlowDynamics.log_nest(4) do

--- a/test/network_generation/test_dataflow_dynamics.rb
+++ b/test/network_generation/test_dataflow_dynamics.rb
@@ -69,7 +69,58 @@ module Syskit
                         port_dynamics.triggers.to_a
                 end
 
-                describe "master/slave deployments" do
+                describe 'communication busses' do
+                    before do
+                        @stub_t = stub_t = stub_type '/test'
+                        @bus_m = ComBus.new_submodel message_type: stub_t
+                        bus_driver_m = Syskit::TaskContext.new_submodel do
+                            dynamic_output_port(/\w+/, stub_t)
+                        end
+                        bus_driver_m.driver_for @bus_m, as: 'bus'
+
+                        @dev_m = Device.new_submodel
+                        @dev_m.provides @bus_m::ClientInSrv
+                        @dev_driver_m = TaskContext.new_submodel do
+                            input_port 'in', stub_t
+                        end
+                        @dev_driver_m.driver_for @dev_m, as: 'dev'
+
+                        @robot = Robot::RobotDefinition.new
+                        @bus = robot.com_bus @bus_m, driver: bus_driver_m, as: 'bus'
+                        @device = @robot.device(
+                            @dev_m, driver: @dev_driver_m, as: 'dev'
+                        )
+                        @device.attach_to(@bus, client_to_bus: false)
+                    end
+
+                    it 'uses the attached device\'s information as initial information '\
+                       'for the bus port' do
+                        @device.period 42
+                        @device.burst 21
+                        @device.sample_size 2
+
+                        task = syskit_stub_and_deploy(@device)
+                        bus = task.each_child.first[0]
+                        dynamics.initial_task_information(bus)
+
+                        info = dynamics.port_info(bus, 'dev')
+                        assert_equal 1, info.sample_size
+                        triggers = info.triggers.map { |t| [t.name, t.period, t.sample_count] }
+                        assert_equal ['dev', 42, 2], triggers[0]
+                        assert_equal ['dev-burst', 0, 42], triggers[1]
+                    end
+
+                    it 'marks the port as done' do
+                        @device.period 0.1
+
+                        task = syskit_stub_and_deploy(@device)
+                        bus = task.each_child.first[0]
+                        dynamics.initial_task_information(bus)
+                        assert dynamics.has_final_information_for_port?(bus, 'dev')
+                    end
+                end
+
+                describe 'master/slave deployments' do
                     before do
                         task_m = Syskit::TaskContext.new_submodel do
                             output_port 'out', '/double'


### PR DESCRIPTION
Bursts were bizarrely handled, fed as a trigger of size 1 and period
"dev.period * dev.burst".  I can't find any justification for this in
the history, so reset it to a period of zero (meaning "count one
burst").

The code iterates on ports from the device service, and was adding the
port name as declared in the service to handled_ports.  This meant that
the wrong port name was passed to done_port_info later in the method and
could lead to a failure in the end.

Last, but not least, the code was iterating on inputs, not outputs which
makes no sense given that a device periods characterizes the data it
produces.