### PR TITLE
fix application of computed policies

### DIFF
--- a/lib/syskit/data_flow.rb
+++ b/lib/syskit/data_flow.rb
@@ -33,10 +33,18 @@ module Syskit
         # @return [ConnectionGraph,nil]
         attr_reader :concrete_connection_graph
 
+        # The graph that provides policies between concrete tasks
+        #
+        # It is computed during network generation
+        #
+        # @return [Hash]
+        attr_accessor :policy_graph
+
         def initialize(*args, **options)
             super
             @modified_tasks = Set.new
             @concrete_connection_graph = nil
+            @policy_graph = {}
         end
 
         # @api private

--- a/lib/syskit/exceptions.rb
+++ b/lib/syskit/exceptions.rb
@@ -820,7 +820,7 @@ module Syskit
 
         # Exception raised when a connection is being created with mismatching
         # port types
-        class WrongPortConnectionTypes < RuntimeError
+        class WrongPortConnectionDataTypes < RuntimeError
             attr_reader :source, :sink
             def initialize(source, sink)
                 @source = source
@@ -828,8 +828,17 @@ module Syskit
             end
 
             def pretty_print(pp)
-                pp.text "cannot connect output port #{source} to input port #{sink}: types mismatch (resp. #{source.type} and #{sink.type})"
+                pp.text "cannot connect output port #{source} to input port #{sink}: "\
+                        "data types mismatch (resp. #{source.type} and #{sink.type})"
             end
+        end
+
+        # TODO: remove
+        WrongPortConnectionTypes = WrongPortConnectionDataTypes
+
+        # Exception raised when attempting to use a connection type (data, buffer, ...)
+        # that is not supported by Syskit
+        class UnsupportedConnectionType < RuntimeError
         end
 
         # Exception raised when a connection is being created between two ports

--- a/lib/syskit/graphviz.rb
+++ b/lib/syskit/graphviz.rb
@@ -691,7 +691,7 @@ module Syskit
             def format_task_label(task, task_colors = {})
                 label = []
 
-                if task.placeholder?
+                if task.respond_to?(:placeholder?) && task.placeholder?
                     name = task.proxied_data_service_models.map(&:name)
                     unless COMPONENT_ROOT_CLASSES.include?(task.model.superclass)
                         name = [task.model.superclass.name] + name

--- a/lib/syskit/gui/component_network_base_view.rb
+++ b/lib/syskit/gui/component_network_base_view.rb
@@ -158,6 +158,28 @@ module Syskit
                 end
             end
 
+            # Compute the deployed network for a model
+            #
+            # @param [Model<Component>] model the model whose representation is
+            #   needed
+            # @param [Roby::Plan,nil] main_plan the plan in which we need to
+            #   generate the network, if nil a new plan object is created
+            # @return [Roby::Task] the toplevel task that represents the
+            #   deployed model
+            def compute_deployed_network(model, main_plan = nil)
+                main_plan ||= Roby::Plan.new
+                main_plan.add(original_task = model.as_plan)
+                base_task = original_task.as_service
+                engine = Syskit::NetworkGeneration::Engine.new(main_plan)
+                engine.resolve_system_network([base_task.task.planning_task])
+                base_task.task
+            ensure
+                if engine && engine.work_plan.respond_to?(:commit_transaction)
+                    engine.commit_work_plan
+                    main_plan.remove_task(original_task)
+                end
+            end
+
             # Instanciate a model
             #
             # @param [Model<Component>] model the model whose instanciation is

--- a/lib/syskit/gui/component_network_view.rb
+++ b/lib/syskit/gui/component_network_view.rb
@@ -93,6 +93,19 @@ module Syskit
                 hierarchy_options[:buttons] = buttons
             end
 
+            def add_button(button)
+                add_dataflow_button(button)
+                add_hierarchy_button(button)
+            end
+
+            def add_dataflow_button(button)
+                dataflow_options[:buttons] << button
+            end
+
+            def add_hierarchy_button(button)
+                hierarchy_options[:buttons] << button
+            end
+
             # Render a model on this view
             #
             # @param [Model<Component>] model
@@ -136,6 +149,10 @@ module Syskit
                     if method == :compute_system_network
                         tic = Time.now
                         @task = compute_system_network(model, plan)
+                        timing = Time.now - tic
+                    elsif method == :compute_deployed_network
+                        tic = Time.now
+                        @task = compute_deployed_network(model, plan)
                         timing = Time.now - tic
                     else
                         @task = instanciate_model(model, plan, instanciate_options)

--- a/lib/syskit/models/port.rb
+++ b/lib/syskit/models/port.rb
@@ -151,7 +151,8 @@ module Syskit
                 end
             end
 
-            OROGEN_MODEL_EXCLUDED_FORWARDINGS = [:task]
+            OROGEN_MODEL_EXCLUDED_FORWARDINGS = [:task].freeze
+
             def method_missing(m, *args, &block)
                 if !OROGEN_MODEL_EXCLUDED_FORWARDINGS.include?(m) && orogen_model.respond_to?(m)
                     orogen_model.public_send(m, *args, &block)

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -680,6 +680,10 @@ module Syskit
                     log_timepoint 'validate_final_network'
                 end
 
+                commit_work_plan
+            end
+
+            def commit_work_plan
                 work_plan.commit_transaction
                 log_timepoint 'commit_transaction'
 

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -683,6 +683,19 @@ module Syskit
                 work_plan.commit_transaction
                 log_timepoint 'commit_transaction'
 
+                # Update the work plan's expected policies
+                if @dataflow_dynamics
+                    real_flow_graph = real_plan.task_relation_graph_for(Flows::DataFlow)
+                    work_flow_graph = work_plan.task_relation_graph_for(Flows::DataFlow)
+                    real_flow_graph.policy_graph =
+                        work_flow_graph
+                        .policy_graph
+                        .transform_keys do |(source_t, sink_t)|
+                            [work_plan.may_unwrap(merge_solver.replacement_for(source_t)),
+                             work_plan.may_unwrap(merge_solver.replacement_for(sink_t))]
+                        end
+                end
+
                 # Reset the oroGen model on all already-running tasks
                 real_plan.find_tasks(Syskit::TaskContext).each do |task|
                     if (orocos_task = task.orocos_task) && orocos_task.respond_to?(:model=)

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -92,6 +92,10 @@ module Syskit
                 orogen_model.worstcase_trigger_latency
             end
 
+            def trigger_latency=(latency)
+                orogen_model.worstcase_trigger_latency = latency
+            end
+
             def initialize(orogen_model: nil, **arguments)
                 super(**arguments)
 

--- a/test/network_generation/test_dataflow_dynamics.rb
+++ b/test/network_generation/test_dataflow_dynamics.rb
@@ -199,6 +199,339 @@ module Syskit
                     end
                 end
             end
+
+            describe 'compute_connection_policies' do
+                before do
+                    @task_m = Syskit::TaskContext.new_submodel do
+                        input_port 'in', '/double'
+                        output_port 'out', '/double'
+                    end
+
+                    @cmp_m = Syskit::Composition.new_submodel
+                    @cmp_m.add @task_m, as: 'c'
+                    @cmp_m.export @cmp_m.c_child.out_port
+
+                    @dynamics = NetworkGeneration::DataFlowDynamics.new(plan)
+                end
+
+                it 'computes policies and saves them in the graph\'s policy_graph' do
+                    plan.add(task0 = @task_m.new)
+                    plan.add(task1 = @task_m.new)
+
+                    add_agents(tasks = [task0, task1])
+                    flexmock(@dynamics).should_receive(:propagate).with(tasks)
+
+                    task0.out_port.connect_to(task1.in_port)
+
+                    @dynamics.should_receive(:policy_for)
+                             .with(task0, 'out', 'in', task1, nil)
+                             .and_return(type: :buffer, size: 42)
+                    policy_graph = @dynamics.compute_connection_policies
+
+                    assert_equal({ type: :buffer, size: 42 },
+                                 policy_graph[[task0, task1]][%w[out in]])
+                end
+
+                it 'computes the policies on the concrete connections' do
+                    plan.add(task = @task_m.new)
+                    cmp = @cmp_m.instanciate(plan)
+
+                    add_agents(tasks = [task, cmp.c_child])
+                    flexmock(@dynamics).should_receive(:propagate).with(tasks)
+
+                    cmp.c_child.out_port.connect_to(task.in_port)
+
+                    @dynamics.should_receive(:policy_for)
+                             .with(cmp.c_child, 'out', 'in', task, nil)
+                             .and_return(type: :buffer, size: 42)
+                    policy_graph = @dynamics.compute_connection_policies
+
+                    assert_equal({ type: :buffer, size: 42 },
+                                 policy_graph[[cmp.c_child, task]][%w[out in]])
+                end
+
+                it 'uses in-graph policies over the computed ones' do
+                    plan.add(task0 = @task_m.new)
+                    plan.add(task1 = @task_m.new)
+
+                    add_agents(tasks = [task0, task1])
+                    flexmock(@dynamics).should_receive(:propagate).with(tasks)
+
+                    task0.out_port.connect_to(task1.in_port, type: :buffer, size: 42)
+
+                    @dynamics.should_receive(:policy_for).never
+                    policy_graph = @dynamics.compute_connection_policies
+
+                    assert_equal({ type: :buffer, size: 42 },
+                                 policy_graph[[task0, task1]][%w[out in]])
+                end
+
+                it 'passes the fallback policy to #policy_for if there is one' do
+                    plan.add(task0 = @task_m.new)
+                    plan.add(task1 = @task_m.new)
+
+                    add_agents(tasks = [task0, task1])
+                    flexmock(@dynamics).should_receive(:propagate).with(tasks)
+
+                    task0.out_port.connect_to(
+                        task1.in_port, fallback_policy: { type: :data }
+                    )
+
+                    @dynamics.should_receive(:policy_for)
+                             .with(task0, 'out', 'in', task1, { type: :data })
+                             .and_return(type: :buffer, size: 42)
+
+                    policy_graph = @dynamics.compute_connection_policies
+
+                    assert_equal({ type: :buffer, size: 42 },
+                                 policy_graph[[task0, task1]][%w[out in]])
+                end
+
+                it 'ignores the fallback policy if there is a policy in-graph' do
+                    plan.add(task0 = @task_m.new)
+                    plan.add(task1 = @task_m.new)
+
+                    add_agents(tasks = [task0, task1])
+                    flexmock(@dynamics).should_receive(:propagate).with(tasks)
+
+                    task0.out_port.connect_to(
+                        task1.in_port,
+                        type: :buffer, size: 42,
+                        fallback_policy: { type: :data }
+                    )
+
+                    @dynamics.should_receive(:policy_for).never
+                    policy_graph = @dynamics.compute_connection_policies
+                    assert_equal({ type: :buffer, size: 42 },
+                                 policy_graph[[task0, task1]][%w[out in]])
+                end
+
+                it 'ignores non-deployed tasks' do
+                    tasks = (0...4).map { @task_m.new }
+                    tasks.each { |t| plan.add(t) }
+                    add_agents(tasks[0, 2])
+                    flexmock(@dynamics).should_receive(:propagate).with(tasks[0, 2])
+                end
+            end
+
+            describe '#policy_for' do
+                before do
+                    @task_m = Syskit::TaskContext.new_submodel do
+                        input_port 'in', '/double'
+                        output_port 'out', '/double'
+                    end
+                    @source_task_m = @task_m.new_submodel
+                    @sink_task_m = @task_m.new_submodel
+                    plan.add(@source_t = @source_task_m.new)
+                    plan.add(@sink_t = @sink_task_m.new)
+                    @source_t.out_port.connect_to @sink_t.in_port
+                end
+
+                it 'validates that the source port exists' do
+                    e = assert_raises(InternalError) do
+                        @dynamics.policy_for(@source_t, 'does_not_exist',
+                                             'in', @sink_t, nil)
+                    end
+                    assert_equal 'does_not_exist is not an output port '\
+                                 "of #{@source_t}", e.message
+                end
+
+                it 'validates that the sink port exists' do
+                    e = assert_raises(InternalError) do
+                        @dynamics.policy_for(@source_t, 'out',
+                                             'does_not_exist', @sink_t, nil)
+                    end
+                    assert_equal 'does_not_exist is not an input port '\
+                                 "of #{@sink_t}", e.message
+                end
+
+                it 'returns a data connection by default' do
+                    policy = @dynamics.policy_for(@source_t, 'out', 'in', @sink_t, nil)
+                    assert_equal :data, policy[:type]
+                end
+
+                it 'returns a buffer connection of size 1 if the sink\'s required '\
+                   'connection type is "buffer"' do
+                    @sink_task_m.in_port.needs_buffered_connection
+                    policy = @dynamics.policy_for(@source_t, 'out', 'in', @sink_t, nil)
+                    assert_equal :buffer, policy[:type]
+                    assert_equal 1, policy[:size]
+                end
+
+                it 'raises if the required connection type is unknown and '\
+                   'needs_reliable_connection is not set' do
+                    flexmock(@sink_task_m.in_port)
+                        .should_receive(:required_connection_type).explicitly
+                        .and_return(:something)
+                    assert_raises(UnsupportedConnectionType) do
+                        @dynamics.policy_for(@source_t, 'out', 'in', @sink_t, nil)
+                    end
+                end
+
+                it 'returns the value from compute_reliable_connection_policy if '\
+                    'the sink port is marked as needs_reliable_connection' do
+                    @sink_task_m.in_port.needs_reliable_connection
+                    fallback_policy = flexmock
+                    flexmock(@dynamics)
+                        .should_receive(:compute_reliable_connection_policy)
+                        .with(@source_t.out_port, @sink_t.in_port, fallback_policy)
+                        .once.and_return(expected_policy = flexmock)
+                    policy = @dynamics.policy_for(
+                        @source_t, 'out', 'in', @sink_t, fallback_policy
+                    )
+                    assert_equal expected_policy, policy
+                end
+            end
+
+            describe '#compute_reliable_connection_policy' do
+                before do
+                    @task_m = Syskit::TaskContext.new_submodel do
+                        input_port 'in', '/double'
+                        output_port 'out', '/double'
+                    end
+                    @source_task_m = @task_m.new_submodel
+                    @sink_task_m = @task_m.new_submodel
+                    plan.add(@source_t = @source_task_m.new)
+                    plan.add(@sink_t = @sink_task_m.new)
+                    @source_t.out_port.connect_to @sink_t.in_port
+
+                    @source_dynamics = PortDynamics.new('out')
+                    @source_dynamics.add_trigger('test', 1, 1)
+                end
+
+                it 'computes the buffer size given the source dynamics and sink '\
+                   'reading latency' do
+                    @dynamics.add_port_info(@source_t, 'out', @source_dynamics)
+                    @dynamics.done_port_info(@source_t, 'out')
+                    flexmock(@dynamics)
+                        .should_receive(:compute_reading_latency)
+                        .with(@sink_t, @sink_t.in_port)
+                        .and_return(0.5)
+
+                    flexmock(@dynamics).should_receive(:compute_buffer_policy)
+                                       .with(@source_dynamics, 0.5)
+                                       .and_return(expected_policy = flexmock)
+                    policy = @dynamics.compute_reliable_connection_policy(
+                        @source_t.out_port, @sink_t.in_port, nil
+                    )
+                    assert_equal expected_policy, policy
+                end
+
+                describe 'fallback conditions' do
+                    before do
+                        @fallback_policy = { type: flexmock }
+                        flexmock(@dynamics).should_receive(:compute_buffer_policy).never
+                        @dynamics.add_port_info(@source_t, 'out', @source_dynamics)
+                    end
+
+                    it 'falls back if the port info is not final' do
+                        flexmock(@dynamics).should_receive(compute_reading_latency: 0.5)
+
+                        policy = @dynamics.compute_reliable_connection_policy(
+                            @source_t.out_port, @sink_t.in_port, @fallback_policy
+                        )
+                        assert_equal @fallback_policy, policy
+                    end
+
+                    it 'throws if the port info is not final and no fallback policy is specified' do
+                        flexmock(@dynamics).should_receive(compute_reading_latency: 0.5)
+
+                        assert_raises(SpecError) do
+                            @dynamics.compute_reliable_connection_policy(
+                                @source_t.out_port, @sink_t.in_port, nil
+                            )
+                        end
+                    end
+
+                    it 'falls back if the reading latency cannot be computed' do
+                        @dynamics.done_port_info(@source_t, 'out')
+                        flexmock(@dynamics).should_receive(compute_reading_latency: nil)
+
+                        policy = @dynamics.compute_reliable_connection_policy(
+                            @source_t.out_port, @sink_t.in_port, @fallback_policy
+                        )
+                        assert_equal @fallback_policy, policy
+                    end
+
+                    it 'throws if the reading latency cannot be computed and no fallback policy is specified' do
+                        @dynamics.done_port_info(@source_t, 'out')
+                        flexmock(@dynamics).should_receive(compute_reading_latency: nil)
+
+                        assert_raises(SpecError) do
+                            @dynamics.compute_reliable_connection_policy(
+                                @source_t.out_port, @sink_t.in_port, nil
+                            )
+                        end
+                    end
+                end
+            end
+
+            describe '#compute_buffer_policy' do
+                it 'returns the queue_size corrected by the global buffer size margin' do
+                    source_dynamics = flexmock(PortDynamics.new('test'))
+                    source_dynamics.add_trigger('test', 1, 1)
+                    source_dynamics.should_receive(:queue_size).with(0.4).and_return(20)
+                    flexmock(Syskit.conf).should_receive(buffer_size_margin: 0.11)
+                    assert_equal({ type: :buffer, size: 23 },
+                                 @dynamics.compute_buffer_policy(source_dynamics, 0.4))
+                end
+            end
+
+            describe '#compute_reading_latency' do
+                before do
+                    @task_m = Syskit::TaskContext.new_submodel do
+                        input_port 'in', '/double'
+                        output_port 'out', '/double'
+                    end
+                    plan.add(@task = @task_m.new)
+                    add_agents([@task])
+                end
+
+                it 'returns the task\'s trigger latency if it is a trigger port' do
+                    @task_m.in_port.trigger_port = true
+                    @task.trigger_latency = 0.5
+                    assert_equal(
+                        0.5, @dynamics.compute_reading_latency(@task, @task.in_port)
+                    )
+                end
+
+                it 'returns otherwise the task\'s period added to its latency' do
+                    @task.trigger_latency = 0.5
+                    task_dynamics = PortDynamics.new('test')
+                    task_dynamics.add_trigger('test', 1, 1)
+                    @dynamics.add_task_info(@task, task_dynamics)
+                    @dynamics.done_task_info(@task)
+                    assert_equal(
+                        1.5, @dynamics.compute_reading_latency(@task, @task.in_port)
+                    )
+                end
+
+                it 'returns nil if the task has no known period' do
+                    @task.trigger_latency = 0.5
+                    task_dynamics = PortDynamics.new('test')
+                    @dynamics.add_task_info(@task, task_dynamics)
+                    @dynamics.done_task_info(@task)
+                    assert_nil @dynamics.compute_reading_latency(@task, @task.in_port)
+                end
+
+                it 'returns nil if the there is no final trigger info for the task' do
+                    @task.trigger_latency = 0.5
+                    task_dynamics = PortDynamics.new('test')
+                    task_dynamics.add_trigger('test', 1, 1)
+                    @dynamics.add_task_info(@task, dynamics)
+                    assert_nil @dynamics.compute_reading_latency(@task, @task.in_port)
+                end
+            end
+
+            def add_agents(tasks)
+                unless @agent_m
+                    @agent_m = Roby::Task.new_submodel
+                    @agent_m.event :ready
+                end
+
+                agents = tasks.map { @agent_m.new }
+                tasks.each_with_index { |t, i| t.add_execution_agent(agents[i]) }
+            end
         end
     end
 end


### PR DESCRIPTION
Since f1672d0 (merged 2019/01), Syskit would not apply *any* of the connection
policies computed during net gen to the runtime plan. Meaning, all
connections except logging would be using data.

Yep.

I found this out while trying to debug a CAN-based driver that
had to deal with bursts of 10 packets, but only seeing 1/3 of them
coming in, regardless of the computed buffer size.

The bug was created by having one line of the commit commented out
(because it wasn't implemented :() and no integration tests related
to this particular issue. This commit fixes both.

The general idea of the change was a good one, though. The problem
it tried to solve was that policy computation would change **one**
element in DataFlow, which would lose information (what are the
requirements exactly ?) and makes it harder to reason on the result.

Since policies are really computed for concrete connections, it's now
computed as a hash over the task/ports and passed on to the runtime
subsystem along with the connection graph. This is possible
since we're computing the whole graph each time. Entries that are
not present use the "old" method based on the DataFlow graph, to
allow for connections manually added to the DataFlow graph after
deployment.