### PR TITLE
do not load rock/bundles if SYSKIT_USE_ROCK_BUNDLES is set to zero

### DIFF
--- a/bin/syskit
+++ b/bin/syskit
@@ -4,13 +4,15 @@
 # so this makes sure that the Roby app is based on the handler's expected state
 trap('INT', 'DEFAULT')
 
-require 'rock/bundle'
+if (ENV['SYSKIT_USE_ROCK_BUNDLES'] != '0')
+    require 'rock/bundle'
 
-# The logs are public by default in bundles, but are private by default in Roby
-# (the Roby-oriented scripts must set it to true when needed)
-#
-# Reset to the Roby default
-Roby.app.public_logs = false
+    # The logs are public by default in bundles, but are private by default in Roby
+    # (the Roby-oriented scripts must set it to true when needed)
+    #
+    # Reset to the Roby default
+    Roby.app.public_logs = false
+end
 
 require 'syskit/cli/main'
 


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/package_set/pull/160

Syskit/Roby has its own dependency-loading mechanism, and
in my experience relying on the rock-bundle system to
load dependencies have been very fragile.

Let people use `Roby.app.register_app` to explicitly load
dependencies if they wish to.