### PR TITLE
auto-disconnect port accessors on component finalization 

### DIFF
--- a/lib/syskit/port.rb
+++ b/lib/syskit/port.rb
@@ -227,7 +227,7 @@ module Syskit
                     resolved_port = component.find_port(port.name)
                     unless resolved_port
                         raise ArgumentError,
-                            "cannot find a port called #{port.name} on #{component}"
+                              "cannot find a port called #{port.name} on #{component}"
                     end
 
                     @actual_port = resolved_port.to_actual_port
@@ -239,6 +239,11 @@ module Syskit
                         @actual_port.component.execute do
                             resolve(component, @actual_port)
                         end
+                    end
+
+                    @execution_engine = @actual_port.component.execution_engine
+                    @actual_port.component.when_finalized do
+                        disconnect
                     end
                 end
             end
@@ -286,8 +291,8 @@ module Syskit
 
         def disconnect
             @disconnected = true
-            if actual_reader = self.reader
-                actual_port.component.execution_engine.promise(description: "disconnect #{self}") do
+            if @execution_engine && (actual_reader = self.reader)
+                @execution_engine.promise(description: "disconnect #{self}") do
                     begin actual_reader.disconnect
                     rescue Orocos::ComError
                     end
@@ -376,8 +381,8 @@ module Syskit
 
         def disconnect
             @disconnected = true
-            if actual_writer = self.writer
-                actual_port.component.execution_engine.promise(description: "disconnect #{self}") do
+            if @execution_engine && (actual_writer = self.writer)
+                @execution_engine.promise(description: "disconnect #{self}") do
                     begin actual_writer.disconnect
                     rescue Orocos::ComError
                     end

--- a/test/gui/test_runtime_state.rb
+++ b/test/gui/test_runtime_state.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'syskit/test/self'
 require 'vizkit'
 require 'metaruby/gui'

--- a/test/test_port.rb
+++ b/test/test_port.rb
@@ -1,26 +1,30 @@
+# frozen_string_literal: true
+
 require 'syskit/test/self'
 
 describe Syskit::Port do
-    describe "#to_component_port" do
+    describe '#to_component_port' do
         attr_reader :component, :port
         before do
-            component_model = Syskit::TaskContext.new_submodel { output_port 'port', '/int' }
-            port_model = Syskit::Models::Port.new(component_model, component_model.orogen_model.find_port('port'))
+            component_model = Syskit::TaskContext.new_submodel do
+                output_port 'port', '/int'
+            end
             @component = component_model.new
             @port = component.port_port
         end
 
-        it "calls self_port_to_component_port on its component model to resolve itself" do
-            flexmock(component).should_receive(:self_port_to_component_port).with(port).and_return(obj = Object.new).once
+        it 'calls self_port_to_component_port on its component model to resolve itself' do
+            flexmock(component).should_receive(:self_port_to_component_port)
+                               .with(port).and_return(obj = Object.new).once
             assert_equal obj, port.to_component_port
         end
-        it "raises ArgumentError if its model does not allow to resolve" do
+        it 'raises ArgumentError if its model does not allow to resolve' do
             port = Syskit::Port.new(component.model.port_port, Object.new)
             assert_raises(ArgumentError) { port.to_component_port }
         end
     end
 
-    describe "#connect_to" do
+    describe '#connect_to' do
         attr_reader :out_task, :in_task
         before do
             @out_task = Syskit::TaskContext.new_submodel do
@@ -32,14 +36,15 @@ describe Syskit::Port do
             end.new
         end
 
-        it "creates the connection directly if the argument is a port" do
-            policy = Hash.new
-            flexmock(out_task).should_receive(:connect_ports).once.
-                with(in_task, ['out', 'in'] => policy)
+        it 'creates the connection directly if the argument is a port' do
+            policy = {}
+            flexmock(out_task).should_receive(:connect_ports).once
+                              .with(in_task, %w[out in] => policy)
             out_task.out_port.connect_to in_task.in_port, policy
         end
-        it "raises if the two ports have different types" do
-            policy = Hash.new
+
+        it 'raises if the two ports have different types' do
+            policy = {}
             out_task = Syskit::TaskContext.new_submodel do
                 output_port 'out', '/double'
             end
@@ -52,29 +57,30 @@ describe Syskit::Port do
                 out_task.out_port.connect_to in_task.in_port, policy
             end
         end
-        it "passes through Syskit.connect if the argument is not a port" do
-            policy = Hash.new
-            flexmock(Syskit).should_receive(:connect).once.
-                with(out_task.out_port, in_task, policy)
+        it 'passes through Syskit.connect if the argument is not a port' do
+            policy = {}
+            flexmock(Syskit).should_receive(:connect).once
+                            .with(out_task.out_port, in_task, policy)
             out_task.out_port.connect_to in_task, policy
         end
-        it "raises WrongPortConnectionDirection if the source is an input port" do
+        it 'raises WrongPortConnectionDirection if the source is an input port' do
             assert_raises(Syskit::WrongPortConnectionDirection) do
                 in_task.in_port.connect_to in_task.in_port
             end
         end
-        it "raises WrongPortConnectionDirection if the sink is an output port" do
+        it 'raises WrongPortConnectionDirection if the sink is an output port' do
             assert_raises(Syskit::WrongPortConnectionDirection) do
                 out_task.out_port.connect_to out_task.out_port
             end
         end
-        it "raises SelfConnection if the source and sink are part of the same component" do
+        it 'raises SelfConnection if the source and sink are part '\
+           'of the same component' do
             assert_raises(Syskit::SelfConnection) do
                 out_task.out_port.connect_to out_task.in_port
             end
         end
 
-        describe "in transaction context" do
+        describe 'in transaction context' do
             attr_reader :task_m, :source, :sink, :transaction
             before do
                 @task_m = Syskit::TaskContext.new_submodel do
@@ -86,15 +92,15 @@ describe Syskit::Port do
                 @transaction = create_transaction
             end
 
-            it "does not modify the connections of the underlying tasks" do
+            it 'does not modify the connections of the underlying tasks' do
                 transaction[source].out_port.connect_to transaction[sink].in_port
                 assert !source.out_port.connected_to?(sink.in_port)
             end
         end
     end
 
-    describe "#disconnect_from" do
-        describe "in transaction context" do
+    describe '#disconnect_from' do
+        describe 'in transaction context' do
             attr_reader :task_m, :source, :sink, :transaction
             before do
                 @task_m = Syskit::TaskContext.new_submodel do
@@ -106,7 +112,7 @@ describe Syskit::Port do
                 @transaction = create_transaction
             end
 
-            it "does not modify the connections of the underlying tasks" do
+            it 'does not modify the connections of the underlying tasks' do
                 source.out_port.connect_to sink.in_port
                 transaction[source].out_port.disconnect_from transaction[sink].in_port
                 assert source.out_port.connected_to?(sink.in_port)
@@ -114,7 +120,7 @@ describe Syskit::Port do
         end
     end
 
-    describe "#connected_to?" do
+    describe '#connected_to?' do
         attr_reader :task_m, :source, :sink, :transaction
         before do
             @task_m = Syskit::TaskContext.new_submodel do
@@ -125,33 +131,34 @@ describe Syskit::Port do
             plan.add(@sink = task_m.new)
         end
 
-        it "returns true if the ports are connected" do
+        it 'returns true if the ports are connected' do
             source.out_port.connect_to sink.in_port
             assert source.out_port.connected_to?(sink.in_port)
         end
 
-        it "returns false if the ports are not connected" do
+        it 'returns false if the ports are not connected' do
             assert !source.out_port.connected_to?(sink.in_port)
         end
 
         it "resolves 'self' to the component port" do
             p = source.out_port
             flexmock(p).should_receive(:to_component_port).once.and_return(m = flexmock)
-            m.should_receive(:connected_to?).with(sink.in_port).and_return(ret = flexmock)
+            m.should_receive(:connected_to?).with(sink.in_port).and_return(flexmock)
             p.connected_to?(sink.in_port)
         end
 
         it "resolves 'in_port' to the component port" do
             p = sink.in_port
-            flexmock(p).should_receive(:to_component_port).once.and_return(flexmock(component: nil, name: ''))
+            flexmock(p).should_receive(:to_component_port).once
+                       .and_return(flexmock(component: nil, name: ''))
             # Would have been true if we were not meddling with
             # to_component_port
             assert !source.out_port.connected_to?(p)
         end
     end
 
-    describe "handling in Hash" do
-        it "can be used as a hash key" do
+    describe 'handling in Hash' do
+        it 'can be used as a hash key' do
             task_m = Syskit::TaskContext.new_submodel do
                 output_port 'out', '/double'
                 output_port 'out2', '/double'
@@ -171,19 +178,19 @@ describe Syskit::InputWriter do
     before do
         @task_m = Syskit::TaskContext.new_submodel do
             input_port 'in', '/double'
-            dynamic_input_port /in\d/, '/double'
+            dynamic_input_port(/in\d/, '/double')
         end
     end
 
-    it "resolves the writer" do
+    it 'resolves the writer' do
         task = syskit_stub_deploy_and_configure(task_m)
         port_writer = task.in_port.writer
         syskit_wait_ready(port_writer, component: task)
         assert_equal task.in_port, port_writer.resolved_port
         assert_equal Orocos.allow_blocking_calls { task.orocos_task.port('in') },
-            port_writer.writer.port
+                     port_writer.writer.port
     end
-    it "waits for the underlying component to be configured if the port is dynamic" do
+    it 'waits for the underlying component to be configured if the port is dynamic' do
         in_srv_m = Syskit::DataService.new_submodel do
             input_port 'in', '/double'
         end
@@ -215,29 +222,33 @@ describe Syskit::InputWriter do
             achieve { port_reader.ready? }
         end
     end
-    it "queues a PortAccessFailure error on the port's component if creating the port failed" do
+    it 'queues a PortAccessFailure error on the port\'s component if creating '\
+       'the port failed' do
         error = Class.new(RuntimeError)
         task = syskit_stub_deploy_and_configure(task_m)
         in_port = Orocos.allow_blocking_calls { task.orocos_task.raw_port('in') }
-        flexmock(task.orocos_task).should_receive(:raw_port).
-            with('in').once.and_return(in_port)
+        flexmock(task.orocos_task).should_receive(:raw_port)
+                                  .with('in').once.and_return(in_port)
         flexmock(in_port).should_receive(:writer).once.and_raise(error)
         port_writer = task.in_port.writer
         plan.unmark_mission_task(task)
         expect_execution { task.start! }.to do
-            have_internal_error task, Syskit::PortAccessFailure.match.
-                with_ruby_exception(error)
+            have_internal_error(
+                task, Syskit::PortAccessFailure
+                      .match.with_ruby_exception(error)
+            )
         end
 
         refute port_writer.ready?
     end
-    it "validates the given samples if the writer is not yet accessible" do
+    it 'validates the given samples if the writer is not yet accessible' do
         plan.add_permanent_task(abstract_task = task_m.as_plan)
         port_writer = abstract_task.in_port.writer
-        flexmock(Typelib).should_receive(:from_ruby).once.with([], abstract_task.in_port.type)
+        flexmock(Typelib).should_receive(:from_ruby).once
+                         .with([], abstract_task.in_port.type)
         port_writer.write([])
     end
-    it "rebinds to actual tasks that replaced the task" do
+    it 'rebinds to actual tasks that replaced the task' do
         plan.add_permanent_task(abstract_task = task_m.as_plan)
         port_writer = abstract_task.in_port.writer
         task = syskit_stub_deploy_and_configure(task_m)
@@ -246,23 +257,24 @@ describe Syskit::InputWriter do
         syskit_wait_ready(port_writer, component: task)
         assert_equal task.in_port, port_writer.resolved_port
         assert_equal Orocos.allow_blocking_calls { task.orocos_task.port('in') },
-            port_writer.writer.port
+                     port_writer.writer.port
     end
 
-    describe "#disconnect" do
+    describe '#disconnect' do
         attr_reader :task, :writer
         before do
             @task = syskit_stub_deploy_and_configure(task_m)
             @writer = task.in_port.writer
         end
 
-        it "asynchronously disconnects a port that is ready" do
+        it 'asynchronously disconnects a port that is ready' do
             syskit_wait_ready(writer)
             writer.disconnect
             expect_execution.to { achieve { !writer.connected? } }
         end
 
-        it "ensures that the port will not become ready if called before the resolution starts" do
+        it 'ensures that the port will not become ready if called '\
+           'before the resolution starts' do
             task = syskit_stub_deploy_and_configure(task_m)
             writer = task.in_port.writer
             flexmock(writer).should_receive(:resolve).never
@@ -271,7 +283,7 @@ describe Syskit::InputWriter do
             execute_one_cycle
         end
 
-        it "ensures that the port will not become ready if resolution is progressing" do
+        it 'ensures that the port will not become ready if resolution is progressing' do
             task = syskit_stub_deploy_and_configure(task_m)
             writer = task.in_port.writer
             # Do not use syskit_start here. It would run all the event handlers,
@@ -291,19 +303,19 @@ describe Syskit::OutputReader do
     before do
         @task_m = Syskit::TaskContext.new_submodel do
             output_port 'out', '/double'
-            dynamic_output_port /out\d/, '/double'
+            dynamic_output_port(/out\d/, '/double')
         end
     end
 
-    it "resolves the reader" do
+    it 'resolves the reader' do
         task = syskit_stub_deploy_and_configure(task_m)
         port_reader = task.out_port.reader
         syskit_wait_ready(port_reader)
         assert_equal task.out_port, port_reader.resolved_port
         assert_equal Orocos.allow_blocking_calls { task.orocos_task.port('out') },
-            port_reader.reader.port
+                     port_reader.reader.port
     end
-    it "waits for the underlying component to be configured if the port is dynamic" do
+    it 'waits for the underlying component to be configured if the port is dynamic' do
         out_srv_m = Syskit::DataService.new_submodel do
             output_port 'out', '/double'
         end
@@ -335,23 +347,28 @@ describe Syskit::OutputReader do
             achieve { port_reader.ready? }
         end
     end
-    it "queues a PortAccessFailure error on the port's component if creating the port failed" do
+    it 'queues a PortAccessFailure error on the port\'s component '\
+       'if creating the port failed' do
         error = Class.new(RuntimeError)
         task = syskit_stub_deploy_and_configure(task_m)
         out_port = Orocos.allow_blocking_calls { task.orocos_task.raw_port('out') }
-        flexmock(task.orocos_task).should_receive(:raw_port).
-            with('out').once.and_return(out_port)
+        flexmock(task.orocos_task).should_receive(:raw_port)
+                                  .with('out').once.and_return(out_port)
         flexmock(out_port).should_receive(:reader).once.and_raise(error)
         port_reader = task.out_port.reader
 
         plan.unmark_mission_task(task)
-        expect_execution { task.start! }.to do
-            have_internal_error task, Syskit::PortAccessFailure.match.
-                with_ruby_exception(error)
-        end
+        expect_execution { task.start! }
+            .to do
+                have_internal_error(
+                    task, Syskit::PortAccessFailure
+                          .match
+                          .with_ruby_exception(error)
+                )
+            end
         refute port_reader.ready?
     end
-    it "rebinds to actual tasks that replaced the task" do
+    it 'rebinds to actual tasks that replaced the task' do
         plan.add_permanent_task(abstract_task = task_m.as_plan)
         port_reader = abstract_task.out_port.reader
         task = syskit_stub_deploy_and_configure(task_m)
@@ -360,10 +377,10 @@ describe Syskit::OutputReader do
         syskit_wait_ready(port_reader, component: task)
         assert_equal task.out_port, port_reader.resolved_port
         assert_equal Orocos.allow_blocking_calls { task.orocos_task.port('out') },
-            port_reader.reader.port
+                     port_reader.reader.port
     end
 
-    describe "#read_new" do
+    describe '#read_new' do
         before do
             @task = syskit_stub_deploy_and_configure(task_m, remote_task: false)
             @port_reader = @task.out_port.reader
@@ -371,42 +388,42 @@ describe Syskit::OutputReader do
                 @task.orocos_task.raw_port('out')
             end
         end
-        it "returns nil if the reader is not yet connected" do
+        it 'returns nil if the reader is not yet connected' do
             refute @port_reader.connected?
             assert_nil @port_reader.read_new
         end
-        describe "without an explicitely-provided sample" do
+        describe 'without an explicitely-provided sample' do
             before do
                 syskit_wait_ready(@port_reader)
             end
-            it "reads new samples" do
+            it 'reads new samples' do
                 @orocos_port.write(10)
                 assert_equal 10, @port_reader.read_new
             end
-            it "returns nil if there are no samples" do
+            it 'returns nil if there are no samples' do
                 assert_nil @port_reader.read_new
             end
-            it "returns nil if there are no new samples" do
+            it 'returns nil if there are no new samples' do
                 @orocos_port.write(10)
                 @port_reader.read_new
                 assert_nil @port_reader.read_new
             end
         end
-        describe "with an explicitely-provided sample" do
+        describe 'with an explicitely-provided sample' do
             before do
                 syskit_wait_ready(@port_reader)
                 @sample = Typelib.from_ruby(0, @task.out_port.type)
             end
-            it "reads new samples" do
+            it 'reads new samples' do
                 @orocos_port.write(10)
                 assert_equal 10, @port_reader.read_new(@sample)
                 assert_equal 10, @sample.to_ruby
             end
-            it "returns nil if there are no samples" do
+            it 'returns nil if there are no samples' do
                 assert_nil @port_reader.read_new(@sample)
                 assert_equal 0, @sample.to_ruby
             end
-            it "returns nil if there are no new samples" do
+            it 'returns nil if there are no new samples' do
                 @orocos_port.write(10)
                 @port_reader.read_new(@sample)
                 assert_nil @port_reader.read_new(@sample)
@@ -415,7 +432,7 @@ describe Syskit::OutputReader do
         end
     end
 
-    describe "#read" do
+    describe '#read' do
         before do
             @task = syskit_stub_deploy_and_configure(task_m, remote_task: false)
             @port_reader = @task.out_port.reader
@@ -423,42 +440,42 @@ describe Syskit::OutputReader do
                 @task.orocos_task.raw_port('out')
             end
         end
-        it "returns nil if the reader is not yet connected" do
+        it 'returns nil if the reader is not yet connected' do
             refute @port_reader.connected?
             assert_nil @port_reader.read
         end
-        describe "without an explicitely-provided sample" do
+        describe 'without an explicitely-provided sample' do
             before do
                 syskit_wait_ready(@port_reader)
             end
-            it "reads new samples" do
+            it 'reads new samples' do
                 @orocos_port.write(10)
                 assert_equal 10, @port_reader.read
             end
-            it "returns nil if there are no samples" do
+            it 'returns nil if there are no samples' do
                 assert_nil @port_reader.read
             end
-            it "returns the last received sample if there are no new samples" do
+            it 'returns the last received sample if there are no new samples' do
                 @orocos_port.write(10)
                 @port_reader.read
                 assert_equal 10, @port_reader.read
             end
         end
-        describe "with an explicitely-provided sample" do
+        describe 'with an explicitely-provided sample' do
             before do
                 syskit_wait_ready(@port_reader)
                 @sample = Typelib.from_ruby(0, @task.out_port.type)
             end
-            it "reads new samples" do
+            it 'reads new samples' do
                 @orocos_port.write(10)
                 assert_equal 10, @port_reader.read(@sample)
                 assert_equal 10, @sample.to_ruby
             end
-            it "returns nil if there are no samples" do
+            it 'returns nil if there are no samples' do
                 assert_nil @port_reader.read(@sample)
                 assert_equal 0, @sample.to_ruby
             end
-            it "returns the last received sample if there are no new samples" do
+            it 'returns the last received sample if there are no new samples' do
                 @orocos_port.write(10)
                 @port_reader.read
                 assert_equal 10, @port_reader.read(@sample)
@@ -467,7 +484,7 @@ describe Syskit::OutputReader do
         end
     end
 
-    describe "#clear" do
+    describe '#clear' do
         before do
             @task = syskit_stub_deploy_and_configure(task_m, remote_task: false)
             @port_reader = @task.out_port.reader
@@ -475,17 +492,17 @@ describe Syskit::OutputReader do
                 @task.orocos_task.raw_port('out')
             end
         end
-        it "does nothing if the port is not yet connected" do
+        it 'does nothing if the port is not yet connected' do
             refute @port_reader.connected?
             @port_reader.clear
         end
-        it "removes any newly received sample" do
+        it 'removes any newly received sample' do
             syskit_wait_ready(@port_reader)
             @orocos_port.write(10)
             @port_reader.clear
             assert_nil @port_reader.read
         end
-        it "removes any already-read sample" do
+        it 'removes any already-read sample' do
             syskit_wait_ready(@port_reader)
             @orocos_port.write(10)
             @port_reader.read
@@ -494,20 +511,21 @@ describe Syskit::OutputReader do
         end
     end
 
-    describe "#disconnect" do
+    describe '#disconnect' do
         attr_reader :task, :reader
         before do
             @task = syskit_stub_deploy_and_configure(task_m)
             @reader = task.out_port.reader
         end
 
-        it "asynchronously disconnects a port that is ready" do
+        it 'asynchronously disconnects a port that is ready' do
             syskit_wait_ready(reader)
             reader.disconnect
             expect_execution.to { achieve { !reader.connected? } }
         end
 
-        it "ensures that the port will not become ready if called before the resolution starts" do
+        it 'ensures that the port will not become ready if called before the '\
+           'resolution starts' do
             task = syskit_stub_deploy_and_configure(task_m)
             reader = task.out_port.reader
             flexmock(reader).should_receive(:resolve).never
@@ -515,7 +533,7 @@ describe Syskit::OutputReader do
             syskit_start(task)
         end
 
-        it "ensures that the port will not become ready if resolution is progressing" do
+        it 'ensures that the port will not become ready if resolution is progressing' do
             task = syskit_stub_deploy_and_configure(task_m)
             reader = task.out_port.reader
             # Do not use syskit_start here. It would run all the event handlers,
@@ -525,8 +543,8 @@ describe Syskit::OutputReader do
             # #start! runs through the synchronous event processing codepath,
             # and therefore does not call any handler
             expect_execution { task.start! }.join_all_waiting_work(false).to_run
-            expect_execution { reader.disconnect }.
-                to { achieve { !reader.ready? } }
+            expect_execution { reader.disconnect }
+                .to { achieve { !reader.ready? } }
         end
     end
 end


### PR DESCRIPTION
The accessors will now be automatically disconnected once the target
port's component gets finalized, or if the actual port component is (in
case of port exports). So far, port readers had an automatic lifetime
only when created in task scripts, and even there it could lead to
weird issues - like having a connected port but no component actually
listening to it (since the target component was stopped).

In addition, since the ports were outliving their target components,
calling `#disconnect` would fail as `#disconnect` was using the
execution engine of the port's component as resolved at disconnection
time. We now cache this value as it can't change in any case.