### PR TITLE
provide a method-based access to deployment models

### DIFF
--- a/lib/syskit/models/deployment.rb
+++ b/lib/syskit/models/deployment.rb
@@ -77,7 +77,7 @@ module Syskit
             def define_from_orogen(orogen_model, register: false)
                 model = new_submodel(orogen_model: orogen_model)
                 if register && orogen_model.name
-                    Deployments.const_set(orogen_model.name.camelcase(:upper), model)
+                    OroGen::Deployments.register_syskit_model(model)
                 end
                 model
             end

--- a/lib/syskit/models/task_context.rb
+++ b/lib/syskit/models/task_context.rb
@@ -1,6 +1,7 @@
 # Module where all the OroGen task context models get registered
 module OroGen
     extend Syskit::OroGenNamespace
+    Deployments = Syskit::OroGenNamespace::DeploymentNamespace.new
 
     self.syskit_model_constant_registration = true
 end

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -655,7 +655,7 @@ module Syskit
                 if Deployment.has_model_for?(deployer)
                     Deployment.find_model_by_orogen(deployer)
                 else
-                    Deployment.define_from_orogen(deployer, :register => true)
+                    Deployment.define_from_orogen(deployer, register: true)
                 end
             end
 
@@ -736,6 +736,7 @@ module Syskit
 
             def self.clear_models(app)
                 OroGen.clear
+                OroGen::Deployments.clear
 
                 app.loaded_orogen_projects.clear
                 app.default_loader.clear

--- a/test/test_orogen_namespace.rb
+++ b/test/test_orogen_namespace.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'syskit/test/self'
 
 module Syskit
@@ -11,7 +13,9 @@ module Syskit
             obj = flexmock(
                 orogen_model: flexmock(
                     project: flexmock(name: 'project'),
-                    name: 'project::Task'))
+                    name: 'project::Task'
+                )
+            )
             @object.register_syskit_model(obj)
             assert_same obj, @object.project.Task
         end
@@ -20,7 +24,8 @@ module Syskit
             obj = flexmock(
                 orogen_model: flexmock(
                     project: flexmock(name: 'project'),
-                    name: 'project::test::Task')
+                    name: 'project::test::Task'
+                )
             )
             @object.register_syskit_model(obj)
             assert_same obj, @object.project.test.Task
@@ -30,7 +35,9 @@ module Syskit
             obj = flexmock(
                 orogen_model: flexmock(
                     project: flexmock(name: 'project'),
-                    name: 'project::Task'))
+                    name: 'project::Task'
+                )
+            )
             @object.register_syskit_model(obj)
             e = assert_raises(ArgumentError) do
                 @object.project.Task('something')
@@ -42,7 +49,9 @@ module Syskit
             obj = flexmock(
                 orogen_model: flexmock(
                     project: flexmock(name: 'project'),
-                    name: 'project::Task'))
+                    name: 'project::Task'
+                )
+            )
             @object.register_syskit_model(obj)
             e = assert_raises(NoMethodError) do
                 @object.project.Other
@@ -50,53 +59,67 @@ module Syskit
             assert_equal 'no task Other on project, available tasks: Task', e.message
         end
 
-        it "allows to resolve a project by its orogen name" do
+        it 'allows to resolve a project by its orogen name' do
             obj = flexmock(
                 orogen_model: flexmock(
                     project: flexmock(name: 'project'),
-                    name: 'project::Task'))
+                    name: 'project::Task'
+                )
+            )
             @object.register_syskit_model(obj)
             assert_same obj, @object.syskit_model_by_orogen_name('project::Task')
         end
 
-        it "raises if resolving a project that does not exist" do
+        it 'raises if resolving a project that does not exist' do
             obj = flexmock(
                 orogen_model: flexmock(
                     project: flexmock(name: 'project'),
-                    name: 'project::Task'))
+                    name: 'project::Task'
+                )
+            )
             @object.register_syskit_model(obj)
             e = assert_raises(NoMethodError) do
                 @object.does_not_exist.Other
             end
-            assert_equal "undefined method `does_not_exist' for #{@object}, available OroGen projects: project", e.message
+            assert_equal(
+                "undefined method `does_not_exist' for #{@object}, "\
+                'available OroGen projects: project',
+                e.message
+            )
         end
 
-        it "does not register a model by constant by default" do
+        it 'does not register a model by constant by default' do
             obj = flexmock(
                 orogen_model: flexmock(
                     project: flexmock(name: 'project'),
-                    name: 'project::Task'))
+                    name: 'project::Task'
+                )
+            )
             @object.register_syskit_model(obj)
             refute @object.const_defined?(:Project)
         end
 
-        it "registers a model by constant by CamelCasing it if enabled" do
+        it 'registers a model by constant by CamelCasing it if enabled' do
             @object.syskit_model_constant_registration = true
             obj = flexmock(
                 orogen_model: flexmock(
                     project: flexmock(name: 'project'),
-                    name: 'project::Task'))
+                    name: 'project::Task'
+                )
+            )
             @object.register_syskit_model(obj)
             assert @object.const_defined?(:Project)
             assert_same obj, @object::Project::Task
         end
 
-        it "returns the call chain that leads to the model" do
+        it 'returns the call chain that leads to the model' do
             flexmock(@object, name: 'test')
             obj = flexmock(
                 orogen_model: flexmock(
                     project: flexmock(name: 'project'),
-                    name: 'project::Task'))
+                    name: 'project::Task'
+                )
+            )
             assert_equal 'test.project.Task', @object.register_syskit_model(obj)
         end
 

--- a/test/test_orogen_namespace.rb
+++ b/test/test_orogen_namespace.rb
@@ -99,5 +99,59 @@ module Syskit
                     name: 'project::Task'))
             assert_equal 'test.project.Task', @object.register_syskit_model(obj)
         end
+
+        describe OroGenNamespace::DeploymentNamespace do
+            before do
+                @m = OroGenNamespace::DeploymentNamespace.new
+            end
+
+            after do
+                @m.clear
+            end
+
+            it 'resolves a given model through method call' do
+                syskit_m = Deployment.new_submodel(name: 'blablabla')
+                @m.register_syskit_model(syskit_m)
+                assert_equal syskit_m, @m.blablabla
+            end
+
+            it 'reports the list of available models on NoMethodError' do
+                @m.register_syskit_model(Deployment.new_submodel(name: 'depl1'))
+                @m.register_syskit_model(Deployment.new_submodel(name: 'depl2'))
+                e = assert_raises(NoMethodError) do
+                    @m.does_not_exist
+                end
+                assert_equal(
+                    'no deployment registered with the name \'does_not_exist\', '\
+                    'available deployments are: depl1, depl2',
+                    e.message
+                )
+            end
+
+            describe 'constant registration' do
+                before do
+                    @constant_registration = OroGen.syskit_model_constant_registration?
+                end
+                after do
+                    OroGen.syskit_model_constant_registration = @constant_registration
+                end
+
+                it 'registers the deployments as constants on ::Deployments if '\
+                   'OroGen.syskit_model_constant_registration is set' do
+                    OroGen.syskit_model_constant_registration = true
+                    depl_m = Deployment.new_submodel(name: 'depl')
+                    @m.register_syskit_model(depl_m)
+                    assert_same depl_m, ::Deployments::Depl
+                end
+
+                it 'clears the registered constants on clear' do
+                    OroGen.syskit_model_constant_registration = true
+                    depl_m = Deployment.new_submodel(name: 'depl')
+                    @m.register_syskit_model(depl_m)
+                    @m.clear
+                    refute ::Deployments.const_defined?(:Depl)
+                end
+            end
+        end
     end
 end


### PR DESCRIPTION
So far, deployment models were registered as constants under the Deployments namespace. This was matching what was happening for tasks (under OroGen) and types (under Types).

A few years ago, I changed the Types access to a method-based access, which is much more flexible and does not require changing the case (registering constants require CamelCasing all names) - Types::Base::Samples::RigidBodyState became Types.base.samples.RigidBodyState. I "recently" [probably a year or two ago] did the same move for components (`OroGen.project_name.TaskModel`).

This PR implements the same for deployments, under `OroGen::Deployments`. This allows to use the model name instead of a string in `use_deployment`, and internally avoids altogether the guessing game of "is this string a task model or a deployment model ?".