### PR TITLE
cli: modernize the gen templates

### DIFF
--- a/lib/syskit/cli/gen/bus/class.rb.erb
+++ b/lib/syskit/cli/gen/bus/class.rb.erb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 # Load the relevant typekits with import_types_from
-# import_types_from 'base'
+# import_types_from "base"
 # You MUST require files that define services that
 # you want <%= class_name.last %> to provide
 <% indent, open_code, close_code = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
 <%= open_code %>
-<%= indent %>com_bus_type '<%= class_name.last %>', message_type: '/int' do
-<%= indent %>    # input_port 'in', '/base/Vector3d'
-<%= indent %>    # output_port 'out', '/base/Vector3d'
+<%= indent %>com_bus_type "<%= class_name.last %>", message_type: "/int" do
+<%= indent %>    # input_port "in", "/base/Vector3d"
+<%= indent %>    # output_port "out", "/base/Vector3d"
 <%= indent %>    #
 <%= indent %>    # Tell syskit that this service provides another. It adds the
 <%= indent %>    # ports from the provided service to this service
@@ -17,7 +17,7 @@
 <%= indent %>    # Tell syskit that this service provides another. It maps ports
 <%= indent %>    # from the provided service to the one in this service (instead
 <%= indent %>    # of adding)
-<%= indent %>    # provides AnotherSrv, 'provided_srv_in' => 'in'
+<%= indent %>    # provides AnotherSrv, "provided_srv_in" => "in"
 
 <%= indent %>    ##### Attached Device Configuration Extensions
 <%= indent %>    # # When using bus models, it is possible to extend the device
@@ -33,37 +33,41 @@
 <%= indent %>    # end
 <%= indent %>    # # One can do the following in the robot description:
 <%= indent %>    # # robot do
-<%= indent %>    # #     com_bus <%= class_name.last %>, as: 'bus' do
-<%= indent %>    # #         device(<%= class_name.last %>SpecificDevice, as: 'dev')
+<%= indent %>    # #     com_bus <%= class_name.last %>, as: "bus" do
+<%= indent %>    # #         device(<%= class_name.last %>SpecificDevice, as: "dev")
 <%= indent %>    # #             .bus_id(0x1, 0xF)
 <%= indent %>    # #     end
 <%= indent %>    # # end
 <%= indent %>    # #
 <%= indent %>    # # and then use the information to auto-configure the bus driver
-<%= indent %>    # # class OroGen::MyBusDeviceDriver::Task
-<%= indent %>    # #     driver_for <%= class_name.last %>, as: 'driver'
+<%= indent %>    # # Syskit.extend_model OroGen.bus_device_driver.Task do
+<%= indent %>    # #     driver_for <%= class_name.last %>, as: "driver"
 <%= indent %>    # #     def configure
 <%= indent %>    # #         super
 <%= indent %>    # #
-<%= indent %>    # #         # Set the bus driver's 'watches' property to the declared devices
-<%= indent %>    # #         properties.watches = each_declared_attached_device.map do |dev|
-<%= indent %>    # #             bus_id = Types.my_bus_device_driver.BusID.new
-<%= indent %>    # #             bus_id.name = dev.name
-<%= indent %>    # #             bus_id.id = dev.bus_id.id
-<%= indent %>    # #             bus_id.mask = dev.bus_id.mask
-<%= indent %>    # #             bus_id
-<%= indent %>    # #         end
+<%= indent %>    # #         # Set the bus driver's 'watches' property to the
+<%= indent %>    # #         # declared devices
+<%= indent %>    # #         properties.watches =
+<%= indent %>    # #             each_declared_attached_device.map do |dev|
+<%= indent %>    # #                 bus_id = Types.my_bus_device_driver.BusID.new
+<%= indent %>    # #                 bus_id.name = dev.name
+<%= indent %>    # #                 bus_id.id = dev.bus_id.id
+<%= indent %>    # #                 bus_id.mask = dev.bus_id.mask
+<%= indent %>    # #                 bus_id
+<%= indent %>    # #             end
 <%= indent %>    # #     end
 <%= indent %>    # # end
 <%= indent %>    # #
-<%= indent %>    # # NOTE: this should be limited to device-specific configurations
-<%= indent %>    # # NOTE: driver-specific parameters must be set in the corresponding
-<%= indent %>    # # NOTE: oroGen configuration file
+<%= indent %>    # # NOTE: this should be limited to device-specific
+<%= indent %>    # # NOTE: configurations driver-specific parameters
+<%= indent %>    # # NOTE: must be set in the corresponding oroGen
+<%= indent %>    # # NOTE: configuration file
 
 <%= indent %>    ##### Device Configuration Extensions
 <%= indent %>    # # Bus models are first device models. They can therefore
 <%= indent %>    # # define configuration extensions, which extend the
-<%= indent %>    # # configuration capabilities of the device. For instance, with
+<%= indent %>    # # configuration capabilities of the device.
+<%= indent %>    # # For instance, with
 <%= indent %>    # extend_device_configuration do
 <%= indent %>    #     # Communication baudrate in bit/s
 <%= indent %>    #     dsl_attribute :baudrate do |value|
@@ -79,16 +83,16 @@
 <%= indent %>    # # and then use the information to auto-configure the device
 <%= indent %>    # # drivers
 <%= indent %>    # # class OroGen::MyDeviceDriver::Task
-<%= indent %>    # #     driver_for <%= class_name.last %>, as: 'driver'
+<%= indent %>    # #     driver_for <%= class_name.last %>, as: "driver"
 <%= indent %>    # #     def configure
 <%= indent %>    # #         super
 <%= indent %>    # #         properties.baudrate = robot_device.baudrate
 <%= indent %>    # #     end
 <%= indent %>    # # end
 <%= indent %>    # #
-<%= indent %>    # # NOTE: this should be limited to device-specific configurations
-<%= indent %>    # # NOTE: driver-specific parameters must be set in the corresponding
-<%= indent %>    # # NOTE: oroGen configuration file
-
+<%= indent %>    # # NOTE: this should be limited to device-specific
+<%= indent %>    # # NOTE: configurations driver-specific parameters
+<%= indent %>    # # NOTE: must be set in the corresponding oroGen
+<%= indent %>    # # NOTE: configuration file
 <%= indent %>end
 <%= close_code %>

--- a/lib/syskit/cli/gen/bus/test.rb.erb
+++ b/lib/syskit/cli/gen/bus/test.rb.erb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require '<%= require_path %>'
+require "<%= require_path %>"
 <% indent, open, close = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
 <%= open %>
 <%= indent %>describe <%= class_name.last %> do

--- a/lib/syskit/cli/gen/cmp/class.rb.erb
+++ b/lib/syskit/cli/gen/cmp/class.rb.erb
@@ -1,42 +1,42 @@
 # frozen_string_literal: true
 
-<% indent, open_code, close_code = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
-<%= open_code %>
+<% indent, open_code, close_code = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %><%= open_code %>
 <%= indent %>class <%= class_name.last %> < Syskit::Composition
-<%= indent %>    # Declare an argument to the task. Use :default => VALUE to set up a default
-<%= indent %>    # value. The default can be nil
+<%= indent %>    # Declare an argument to the task. Use :default => VALUE to
+<%= indent %>    # set up a default value. The default can be nil
 <%= indent %>    # argument :arg[, :default => 1]
 
-<%= indent %>    # Add children to this composition. The relevant files must have
-<%= indent %>    # been required already at the top of this file
+<%= indent %>    # Add children to this composition. The relevant files must
+<%= indent %>    # have been required already at the top of this file
 <%= indent %>    # add A::ProducerTask, :as => 'producer'
 <%= indent %>    # add A::ConsumerTask, :as => 'consumer'
 
-<%= indent %>    # Connect ports between the children. On each side of the connection,
-<%= indent %>    # either a child or a port can be used. If a child is used, it will
-<%= indent %>    # fail if the connection(s) are ambiguous
+<%= indent %>    # Connect ports between the children. On each side of the
+<%= indent %>    # connection, either a child or a port can be used. If a
+<%= indent %>    # child is used, it will fail if the connection(s) are ambiguous
 <%= indent %>    # producer_child.connect_to consumer_child.in_port
 
-<%= indent %>    # Script. This is the recommended way to implement functionality in tasks.
-<%= indent %>    # It executes instructions in sequence, in a way that is compatible with
-<%= indent %>    # Roby's reactor. For instance, below, block given to 'execute' will only be
-<%= indent %>    # executed once the updated event is emitted
+<%= indent %>    # Script. This is the recommended way to implement functionality
+<%= indent %>    # in tasks. It executes instructions in sequence, in a way that
+<%= indent %>    # is compatible with Roby's reactor. For instance, below, block
+<%= indent %>    # given to 'execute' will only be executed once the updated
+<%= indent %>    # event is emitted
 <%= indent %>    #
 <%= indent %>    # WARNING: the top level of the script is evaluated at loading time.
 <%= indent %>    #
-<%= indent %>    # See the documentation of Roby::Coordination::Models::TaskScript. The API
-<%= indent %>    # calls are the calls available on the script
+<%= indent %>    # See the documentation of Roby::Coordination::Models::TaskScript.
+<%= indent %>    # The API calls are the calls available on the script
 <%= indent %>    #
 <%= indent %>    # script do
 <%= indent %>    #   # Waits for an event to be emitted
 <%= indent %>    #   wait updated_event
 <%= indent %>    #   execute do
-<%= indent %>    #     # The code in this block is going to be called at runtime, unlike the
-<%= indent %>    #     # code at the script level
+<%= indent %>    #     # The code in this block is going to be called at runtime,
+<%= indent %>    #     # unlike the code at the script level
 <%= indent %>    #   end
 <%= indent %>    #   poll do
-<%= indent %>    #     # This code is executed at each execution cycle. Call transition!
-<%= indent %>    #     # to continue with the next script instruction
+<%= indent %>    #     # This code is executed at each execution cycle. Call
+<%= indent %>    #     # transition! to continue with the next script instruction
 <%= indent %>    #   end
 <%= indent %>    # end
 
@@ -44,8 +44,9 @@
 <%= indent %>    # Roby::EventGenerator
 <%= indent %>    # event :updated
 
-<%= indent %>    # Add forwarding to say "when event X is emitted, event Y should". This is
-<%= indent %>    # usually used to make a task finish when an event is emitted
+<%= indent %>    # Add forwarding to say "when event X is emitted, event Y should".
+<%= indent %>    # This is usually used to make a task finish when an event is
+<%= indent %>    # emitted
 <%= indent %>    # forward :X => :Y
 <%= indent %>end
 <%= close_code %>

--- a/lib/syskit/cli/gen/cmp/test.rb.erb
+++ b/lib/syskit/cli/gen/cmp/test.rb.erb
@@ -1,22 +1,27 @@
 # frozen_string_literal: true
 
-require '<%= require_path %>'
-<% indent, open, close = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
-<%= open %>
+require "<%= require_path %>"
+
+<% indent, open, close = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %><%= open %>
 <%= indent %>describe <%= class_name.last %> do
-<%= indent %>    it 'starts' do
+<%= indent %>    it "starts" do
 <%= indent %>        # Note, you might want to inject specific children
 <%= indent %>        # here, but it is not strictly required. The syskit_stub_*
-<%= indent %>        # methods generate what is needed to have a run-able composition
-<%= indent %>        cmp_task = syskit_stub_deploy_configure_and_start(<%= class_name.last %>)
+<%= indent %>        # methods generate what is needed to have a run-able
+<%= indent %>        # composition
+<%= indent %>        cmp_task = syskit_stub_deploy_configure_and_start(
+<%= indent %>            <%= class_name.last %>
+<%= indent %>        )
 
 <%= indent %>        # At this point, cmp_task and all its children are started
 <%= indent %>        # and can be manipulated
 
 <%= indent %>        # Task contexts are stubs, so you can read input ports and
 <%= indent %>        # write output ports by accessing them with e.g.
-<%= indent %>        # sample = expect_execution { cmp_task.my_child.orocos_task.an_output.write test_sample }.
-<%= indent %>        #     to { have_one_new_sample cmp_task.my_child.an_input_port }
+<%= indent %>        # sample =
+<%= indent %>        #     expect_execution do
+<%= indent %>        #         syskit_write cmp_task.my_child.an_output_port, test_sample
+<%= indent %>        #     end.to { have_one_new_sample cmp_task.my_child.an_input_port }
 <%= indent %>        # assert_equal 10, sample.value
 <%= indent %>    end
 <%= indent %>end

--- a/lib/syskit/cli/gen/dev/class.rb.erb
+++ b/lib/syskit/cli/gen/dev/class.rb.erb
@@ -6,9 +6,9 @@
 # you want <%= class_name.last %> to provide
 <% indent, open_code, close_code = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
 <%= open_code %>
-<%= indent %>device_type '<%= class_name.last %>' do
-<%= indent %>    # input_port 'in', '/base/Vector3d'
-<%= indent %>    # output_port 'out', '/base/Vector3d'
+<%= indent %>device_type "<%= class_name.last %>" do
+<%= indent %>    # input_port "in", "/base/Vector3d"
+<%= indent %>    # output_port "out", "/base/Vector3d"
 <%= indent %>    #
 <%= indent %>    # Tell syskit that this service provides another. It adds the
 <%= indent %>    # ports from the provided service to this service
@@ -17,7 +17,7 @@
 <%= indent %>    # Tell syskit that this service provides another. It maps ports
 <%= indent %>    # from the provided service to the one in this service (instead
 <%= indent %>    # of adding)
-<%= indent %>    # provides AnotherSrv, 'provided_srv_in' => 'in'
+<%= indent %>    # provides AnotherSrv, "provided_srv_in" => 'in'
 
 <%= indent %>    # # Device models can define configuration extensions, which
 <%= indent %>    # # extend the additconfiguration capabilities of the device
@@ -36,16 +36,17 @@
 <%= indent %>    # #
 <%= indent %>    # # and then use the information to auto-configure the device
 <%= indent %>    # # drivers
-<%= indent %>    # # class OroGen::MyDeviceDriver::Task
-<%= indent %>    # #     driver_for <%= class_name.last %>, as: 'driver'
+<%= indent %>    # # Syskit.extend_task OroGen.my_device_driver.Task do
+<%= indent %>    # #     driver_for <%= class_name.last %>, as: "driver"
 <%= indent %>    # #     def configure
 <%= indent %>    # #         super
 <%= indent %>    # #         orocos_task.baudrate = robot_device.baudrate
 <%= indent %>    # #     end
 <%= indent %>    # # end
 <%= indent %>    # #
-<%= indent %>    # # NOTE: this should be limited to device-specific configurations
-<%= indent %>    # # NOTE: driver-specific parameters must be set in the corresponding
-<%= indent %>    # # NOTE: oroGen configuration file
+<%= indent %>    # # NOTE: this should be limited to device-specific
+<%= indent %>    # # NOTE: configurations driver-specific parameters
+<%= indent %>    # # NOTE: must be set in the corresponding oroGen
+<%= indent %>    # # NOTE: configuration file
 <%= indent %>end
 <%= close_code %>

--- a/lib/syskit/cli/gen/dev/test.rb.erb
+++ b/lib/syskit/cli/gen/dev/test.rb.erb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require '<%= require_path %>'
+require "<%= require_path %>"
 <% indent, open, close = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
 <%= open %>
 <%= indent %>describe <%= class_name.last %> do

--- a/lib/syskit/cli/gen/profile/class.rb.erb
+++ b/lib/syskit/cli/gen/profile/class.rb.erb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 <% indent, open_code, close_code = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
 <%= open_code %>
 <%= indent %>profile "<%= class_name.last %>" do

--- a/lib/syskit/cli/gen/profile/test.rb.erb
+++ b/lib/syskit/cli/gen/profile/test.rb.erb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
-require '<%= require_path %>'
+require "<%= require_path %>"
 <% indent, open, close = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
 <%= open %>
 <%= indent %>describe <%= class_name.last %> do
 <%= indent %>    # Verifies that the only variation points in the profile are
-<%= indent %>    # profile tags. If you want to limit the test to certain definitions,
+<%= indent %>    # profile tags. If you want to limit the test to certain
+<%= indent %>    # definitions,
 <%= indent %>    # give them as argument
 <%= indent %>    #
 <%= indent %>    # You usually want this. Really. Keep it there.
 <%= indent %>    it { is_self_contained }
 
-<%= indent %>    # If you really really want to allow some definitions to NOT be self-contained
-<%= indent %>    # (but you really do not, trust me), you can call assert_is_self_contained with
+<%= indent %>    # If you really really want to allow some definitions to
+<%= indent %>    # NOT be self-contained (but you really do not, trust me),
+<%= indent %>    # you can call assert_is_self_contained with
 <%= indent %>    # specific definitions
 <%= indent %>    # it "has only a_def self-contained" do
 <%= indent %>    #    assert_is_self_contained a_def
@@ -21,9 +23,10 @@ require '<%= require_path %>'
 <%= indent %>    # Test if all definitions can be instanciated, i.e. are
 <%= indent %>    # well-formed networks with no data services
 <%= indent %>    #
-<%= indent %>    # In principle you could remove the self-contained test above, but that
-<%= indent %>    # would mean that, were you to disable this test you would not check for
-<%= indent %>    # the profile being self-contained. And that's a bad idea. Keep both.
+<%= indent %>    # In principle you could remove the self-contained test above,
+<%= indent %>    # but that would mean that, were you to disable this test you
+<%= indent %>    # would not check for the profile being self-contained. And
+<%= indent %>    # that's a bad idea. Keep both.
 <%= indent %>    it { can_instanciate }
 
 <%= indent %>    # If only parts of the profile should be instanciated, you can
@@ -33,9 +36,10 @@ require '<%= require_path %>'
 <%= indent %>    # call assert_can_instanciate with specific definitions
 <%= indent %>    # it { can_instanciate a_def }
 
-<%= indent %>    # Test if specific definitions can be deployed, i.e. are ready to be
-<%= indent %>    # started. You want this on the "final" profiles (i.e. the definitions
-<%= indent %>    # you will actually on the robot)
+<%= indent %>    # Test if specific definitions can be deployed, i.e. are
+<%= indent %>    # ready to be started. You want this on the "final"
+<%= indent %>    # profiles (i.e. the definitions you will actually run
+<%= indent %>    # on the robot)
 <%= indent %>    #
 <%= indent %>    # In principle you could avoid testing for instanciation and/or
 <%= indent %>    # self-contained properties, but it is advisable to keep them.
@@ -47,11 +51,12 @@ require '<%= require_path %>'
 <%= indent %>    # call assert_can_deploy with specific definitions
 <%= indent %>    # it { can_deploy a_def }
 
-<%= indent %>    # If you want to verify properties when some actions are present in the same network
-<%= indent %>    # use the _together variants:
+<%= indent %>    # If you want to verify properties when some actions are
+<%= indent %>    # present in the same network use the _together variants:
 <%= indent %>    # it { can_instanciate_together a_def, another_def }
 <%= indent %>    # it { can_deploy_together a_def, another_def }
 
-<%= indent %>    # See the documentation of Syskit::Test::ProfileAssertions for more
+<%= indent %>    # See the documentation of Syskit::Test::ProfileAssertions
+<%= indent %>    # for more
 <%= indent %>end
 <%= close %>

--- a/lib/syskit/cli/gen/ruby_task/class.rb.erb
+++ b/lib/syskit/cli/gen/ruby_task/class.rb.erb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-<% indent, open_code, close_code = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
-<%= open_code %>
+<% indent, open_code, close_code = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %><%= open_code %>
 <%= indent %>class <%= class_name.last %> < Syskit::RubyTaskContext
 <%= indent %>end
 <%= close_code %>

--- a/lib/syskit/cli/gen/ruby_task/test.rb.erb
+++ b/lib/syskit/cli/gen/ruby_task/test.rb.erb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-require '<%= require_path %>'
+require "<%= require_path %>"
 <% indent, open, close = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
 <%= open %>
 <%= indent %>describe <%= class_name.last %> do
 <%= indent %>    it "starts" do
-<%= indent %>        task = syskit_stub_deploy_configure_and_start(<%= class_name.last %>)
+<%= indent %>        task = syskit_stub_deploy_configure_and_start(
+<%= indent %>            <%= class_name.last %>
+<%= indent %>        )
 <%= indent %>    end
 <%= indent %>end
 <%= close %>

--- a/lib/syskit/cli/gen/srv/class.rb.erb
+++ b/lib/syskit/cli/gen/srv/class.rb.erb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 # Load the relevant typekits with import_types_from
-# import_types_from 'base'
+# import_types_from "base"
 # You MUST require files that define services that
 # you want <%= class_name.last %> to provide
 <% indent, open_code, close_code = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
 <%= open_code %>
-<%= indent %>data_service_type '<%= class_name.last %>' do
-<%= indent %>    # input_port 'in', '/base/Vector3d'
-<%= indent %>    # output_port 'out', '/base/Vector3d'
+<%= indent %>data_service_type "<%= class_name.last %>" do
+<%= indent %>    # input_port "in", "/base/Vector3d"
+<%= indent %>    # output_port "out", "/base/Vector3d"
 <%= indent %>    #
 <%= indent %>    # Tell syskit that this service provides another. It adds the
 <%= indent %>    # ports from the provided service to this service
@@ -17,6 +17,6 @@
 <%= indent %>    # Tell syskit that this service provides another. It maps ports
 <%= indent %>    # from the provided service to the one in this service (instead
 <%= indent %>    # of adding)
-<%= indent %>    # provides AnotherSrv, 'provided_srv_in' => 'in'
+<%= indent %>    # provides AnotherSrv, "provided_srv_in" => "in"
 <%= indent %>end
 <%= close_code %>

--- a/test/cli/test_gen_main.rb
+++ b/test/cli/test_gen_main.rb
@@ -13,6 +13,14 @@ module Syskit
                 syskit_quit = run_command "syskit quit --retry"
                 assert_command_stops syskit_run
                 assert_command_stops syskit_quit
+
+                # Disable Lint/UselessAssignment as we do assign "uselessly"
+                # in tests to show how it is done
+                #
+                # Note that we expect the user to go through the test file
+                # before he/she commits it ...
+                rubocop = run_command "rubocop --except Lint/UselessAssignment"
+                assert_command_stops rubocop
             end
 
             def run_syskit_test(*args)


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-roby/pull/163

Make sure they pass rubocop, and use new constructs (e.g.
Syskit.extend_task) instead of old ones