### PR TITLE
 expand on the `have_.*_sample` riff

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,7 +1,8 @@
-SimpleCov.command_name 'syskit'
-SimpleCov.start do
-  add_filter "/test/"
-  add_filter "/gui/"
-  add_filter "/scripts/"
-end
+# frozen_string_literal: true
 
+SimpleCov.command_name "syskit"
+SimpleCov.start do
+    add_filter "/test/"
+    add_filter "/gui/"
+    add_filter "/scripts/"
+end

--- a/lib/syskit/test/execution_expectations.rb
+++ b/lib/syskit/test/execution_expectations.rb
@@ -7,7 +7,7 @@ module Syskit
             # @api private
             #
             # Helper used to resolve reader objects
-            def self.resolve_orocos_reader(reader)
+            def self.resolve_orocos_reader(reader, **policy)
                 if reader.respond_to?(:to_orocos_port)
                     reader = Orocos.allow_blocking_calls do
                         reader.to_orocos_port
@@ -16,23 +16,30 @@ module Syskit
                 unless reader.respond_to?(:read_new)
                     if reader.respond_to?(:reader)
                         reader = Orocos.allow_blocking_calls do
-                            reader.reader
+                            reader.reader(**policy)
                         end
                     end
                 end
                 reader
             end
 
+            # @api private
+            #
+            # Implementation of the {#have_no_new_sample} predicate
             class HaveNoNewSample < Roby::Test::ExecutionExpectations::Maintain
-                def initialize(reader, at_least_during, backtrace)
+                def initialize(reader, at_least_during, predicate, description, backtrace)
                     @reader = reader
                     orocos_reader = ExecutionExpectations.resolve_orocos_reader(reader)
-                    block = proc { !(@received_sample = orocos_reader.read_new) }
-                    super(at_least_during, block, "", backtrace)
-                end
-
-                def to_s
-                    "#{@reader} should not have received a new sample"
+                    block = proc do
+                        sample = orocos_reader.read_new
+                        if sample && predicate.call(sample)
+                            @received_sample = sample
+                            false
+                        else
+                            true
+                        end
+                    end
+                    super(at_least_during, block, description, backtrace)
                 end
 
                 def explain_unachievable(propagation_info)
@@ -52,18 +59,86 @@ module Syskit
             #   least that many seconds. This is a minimum.
             # @return [nil]
             def have_no_new_sample(reader, at_least_during: 0, backtrace: caller(1))
-                add_expectation(HaveNoNewSample.new(
-                                    reader, at_least_during, backtrace
-                                ))
+                description = "#{reader} should not have received a new sample"
+                add_expectation(
+                    HaveNoNewSample.new(reader, at_least_during, ->(_) { true },
+                                        description, backtrace)
+                )
+            end
+
+            # Expect that no new samples that match the given predicate arrive on
+            # the reader for a certain time period
+            #
+            # @param [Float] at_least_during no samples should arrive for at
+            #   least that many seconds. This is a minimum.
+            # @return [nil]
+            def have_no_new_sample_matching(
+                reader, at_least_during: 0, backtrace: caller(1), &predicate
+            )
+                description = "#{reader} should not have received a new sample "\
+                              "matching the given predicate"
+                add_expectation(
+                    HaveNoNewSample.new(reader, at_least_during, predicate,
+                                        description, backtrace)
+                )
             end
 
             # Expect that one sample arrives on the reader, and return the sample
             #
             # @return [Object]
             def have_one_new_sample(reader, backtrace: caller(1))
-                orocos_reader = ExecutionExpectations.resolve_orocos_reader(reader)
-                achieve(description: "#{reader} should have received a new sample",
-                        backtrace: backtrace) { orocos_reader.read_new }
+                have_new_samples(reader, 1, backtrace: backtrace) { true }
+                    .filter_result_with(&:first)
+            end
+
+            # Expect that one sample matching the given predicate arrives on the
+            # reader, and return it
+            #
+            # @return [Object]
+            def have_one_new_sample_matching(reader, backtrace: caller(1), &predicate)
+                have_new_samples_matching(
+                    reader, 1, backtrace: backtrace, &predicate
+                ).filter_result_with(&:first)
+            end
+
+            # Expect that a certain number of samples arrive on the reader,
+            # and return them
+            #
+            # @return [Array]
+            def have_new_samples(reader, count, backtrace: caller(1))
+                received_count = 0
+                description ||= proc do
+                    "#{reader} should have received #{count} new sample(s), "\
+                    "but got #{received_count}"
+                end
+                have_new_samples_matching(
+                    reader, count,
+                    description: description, backtrace: backtrace
+                ) { received_count += 1 }
+            end
+
+            # Expect that a certain number of samples matching the given predicate
+            # arrive, and return them
+            #
+            # @return [Array]
+            def have_new_samples_matching(
+                reader, count, description: nil, backtrace: caller(1), &predicate
+            )
+                orocos_reader = ExecutionExpectations.resolve_orocos_reader(
+                    reader, type: :buffer, size: count
+                )
+
+                samples = []
+                description ||= proc do
+                    "#{reader} should have received #{count} new sample(s) matching "\
+                    "the given predicate, but got #{samples.size}"
+                end
+                achieve(description: description, backtrace: backtrace) do
+                    if (sample = orocos_reader.read_new)
+                        samples << sample if predicate.call(sample)
+                        samples if samples.size == count
+                    end
+                end
             end
         end
     end

--- a/test/test/test_execution_expectations.rb
+++ b/test/test/test_execution_expectations.rb
@@ -11,15 +11,6 @@ module Syskit
             before do
                 task_m = Syskit::RubyTaskContext.new_submodel do
                     input_port "in", "/int"
-                    output_port "out", "/int"
-
-                    poll do
-                        Orocos.allow_blocking_calls do
-                            if sample = orocos_task.in.read_new
-                                orocos_task.out.write(sample)
-                            end
-                        end
-                    end
                 end
                 use_ruby_tasks task_m => "test", on: "stubs"
                 @task = syskit_deploy_configure_and_start(task_m)
@@ -28,16 +19,17 @@ module Syskit
             describe "#have_one_new_sample" do
                 it "passes if the task emits a sample and returns it" do
                     value = expect_execution { syskit_write task.in_port, 10 }
-                            .to { have_one_new_sample task.out_port }
+                            .to { have_one_new_sample task.in_port }
                     assert_equal 10, value
                 end
                 it "fails if the task does not emit a new sample" do
                     e = assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
                         expect_execution
                             .timeout(0.01)
-                            .to { have_one_new_sample task.out_port }
+                            .to { have_one_new_sample task.in_port }
                     end
-                    assert_equal "#{task.out_port} should have received a new sample",
+                    assert_equal "#{task.in_port} should have received 1 new "\
+                                 "sample(s), but got 0",
                                  e.message.split("\n")[1]
                 end
                 it "provides the backtrace from the point of call by default" do
@@ -46,7 +38,7 @@ module Syskit
                         expect_execution
                             .timeout(0.01)
                             .to do
-                                expectation = have_one_new_sample task.out_port
+                                expectation = have_one_new_sample task.in_port
                             end
                     end
                     lineno = __LINE__ - 3
@@ -60,9 +52,140 @@ module Syskit
                         expect_execution
                             .timeout(0.01)
                             .to do
-                                expectation = have_one_new_sample task.out_port,
+                                expectation = have_one_new_sample task.in_port,
                                                                   backtrace: ["bla"]
                             end
+                    end
+                    assert_equal ["bla"], expectation.backtrace
+                end
+            end
+
+            describe "#have_one_new_sample_matching" do
+                it "passes if the task emits a matching sample and returns it" do
+                    value =
+                        expect_execution { syskit_write task.in_port, 10 }
+                        .to do
+                            have_one_new_sample_matching(task.in_port) { |s| s == 10 }
+                        end
+                    assert_equal 10, value
+                end
+                it "fails if the task emits samples that do not match the predicate" do
+                    e = assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
+                        expect_execution { syskit_write task.in_port, 10 }
+                            .timeout(0.01)
+                            .to { have_one_new_sample_matching(task.in_port) { false } }
+                    end
+                    assert_equal "#{task.in_port} should have received 1 new "\
+                                 "sample(s) matching the given predicate, but got 0",
+                                 e.message.split("\n")[1]
+                end
+                it "provides the backtrace from the point of call by default" do
+                    expectation = nil
+                    assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
+                        expect_execution.timeout(0.01).to do
+                            expectation =
+                                have_one_new_sample_matching(task.in_port) { true }
+                        end
+                    end
+                    lineno = __LINE__ - 3
+                    fileline = /^([^:]+):(\d+)/.match(expectation.backtrace.first)
+                    assert_equal File.expand_path(__FILE__), File.expand_path(fileline[1])
+                    assert_equal lineno, Integer(fileline[2])
+                end
+                it "allows to override the backtrace" do
+                    expectation = nil
+                    assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
+                        expect_execution
+                            .timeout(0.01)
+                            .to do
+                                expectation = have_one_new_sample_matching(
+                                    task.in_port, backtrace: ["bla"]
+                                ) { true }
+                            end
+                    end
+                    assert_equal ["bla"], expectation.backtrace
+                end
+            end
+
+            describe "#have_new_samples" do
+                it "passes if the task emits the required number of samples "\
+                   "and returns them" do
+                    value = expect_execution { syskit_write task.in_port, 10, 20 }
+                            .to { have_new_samples task.in_port, 2 }
+                    assert_equal [10, 20], value
+                end
+                it "fails if the task does not emit enough samples" do
+                    e = assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
+                        expect_execution { syskit_write task.in_port, 10 }
+                            .timeout(0.01)
+                            .to { have_new_samples task.in_port, 2 }
+                    end
+                    assert_equal "#{task.in_port} should have received 2 new "\
+                                 "sample(s), but got 1", e.message.split("\n")[1]
+                end
+                it "provides the backtrace from the point of call by default" do
+                    expectation = nil
+                    assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
+                        expect_execution.timeout(0.01).to do
+                            expectation = have_new_samples task.in_port, 2
+                        end
+                    end
+                    lineno = __LINE__ - 3
+                    fileline = /^([^:]+):(\d+)/.match(expectation.backtrace.first)
+                    assert_equal File.expand_path(__FILE__), File.expand_path(fileline[1])
+                    assert_equal lineno, Integer(fileline[2])
+                end
+                it "allows to override the backtrace" do
+                    expectation = nil
+                    assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
+                        expect_execution.timeout(0.01).to do
+                            expectation = have_new_samples(
+                                task.in_port, 2, backtrace: ["bla"]
+                            )
+                        end
+                    end
+                    assert_equal ["bla"], expectation.backtrace
+                end
+            end
+
+            describe "#have_new_samples_matching" do
+                it "passes if the task emits enough matching samples and returns them" do
+                    value =
+                        expect_execution { syskit_write task.in_port, 1, 2, 3 }
+                        .to { have_new_samples_matching(task.in_port, 2, &:odd?) }
+                    assert_equal [1, 3], value
+                end
+                it "fails if the task does not emit enough matching samples" do
+                    e = assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
+                        expect_execution { syskit_write task.in_port, 1, 2, 3 }
+                            .timeout(0.01)
+                            .to { have_new_samples_matching(task.in_port, 2, &:even?) }
+                    end
+                    assert_match "#{task.in_port} should have received 2 new "\
+                                 "sample(s) matching the given predicate, "\
+                                 "but got 1", e.message.split("\n")[1]
+                end
+                it "provides the backtrace from the point of call by default" do
+                    expectation = nil
+                    assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
+                        expect_execution.timeout(0.01).to do
+                            expectation =
+                                have_new_samples_matching(task.in_port, 2) { true }
+                        end
+                    end
+                    lineno = __LINE__ - 3
+                    fileline = /^([^:]+):(\d+)/.match(expectation.backtrace.first)
+                    assert_equal File.expand_path(__FILE__), File.expand_path(fileline[1])
+                    assert_equal lineno, Integer(fileline[2])
+                end
+                it "allows to override the backtrace" do
+                    expectation = nil
+                    assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
+                        expect_execution.timeout(0.01).to do
+                            expectation = have_one_new_sample(
+                                task.in_port, backtrace: ["bla"]
+                            ) { true }
+                        end
                     end
                     assert_equal ["bla"], expectation.backtrace
                 end
@@ -72,15 +195,15 @@ module Syskit
                 it "validates if the task does not emit a sample" do
                     expect_execution
                         .timeout(0.01)
-                        .to { have_no_new_sample task.out_port }
+                        .to { have_no_new_sample task.in_port }
                 end
                 it "fails if the task does emit a new sample" do
                     e = assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
                         expect_execution { syskit_write task.in_port, 10 }
                             .timeout(0.01)
-                            .to { have_no_new_sample task.out_port }
+                            .to { have_no_new_sample task.in_port }
                     end
-                    assert_equal "#{task.out_port} should not have received a new "\
+                    assert_equal "#{task.in_port} should not have received a new "\
                         "sample, but it received one: 10", e.message.split("\n")[1]
                 end
                 it "provides the backtrace from the point of call by default" do
@@ -89,7 +212,7 @@ module Syskit
                         expect_execution { syskit_write task.in_port, 10 }
                             .timeout(0.01)
                             .to do
-                                expectation = have_no_new_sample task.out_port
+                                expectation = have_no_new_sample task.in_port
                             end
                     end
                     lineno = __LINE__ - 3
@@ -103,8 +226,61 @@ module Syskit
                         expect_execution { syskit_write task.in_port, 10 }
                             .timeout(0.01)
                             .to do
-                                expectation = have_no_new_sample task.out_port,
+                                expectation = have_no_new_sample task.in_port,
                                                                  backtrace: ["bla"]
+                            end
+                    end
+                    assert_equal ["bla"], expectation.backtrace
+                end
+            end
+
+            describe "#have_no_new_sample_matching" do
+                it "validates if the task does not emit a sample" do
+                    expect_execution
+                        .timeout(0.01)
+                        .to { have_no_new_sample task.in_port }
+                end
+                it "validates if the task emits samples that don't "\
+                   "match the predicate" do
+                    expect_execution { syskit_write task.in_port, 10 }
+                        .timeout(0.01)
+                        .to { have_no_new_sample_matching(task.in_port) { |s| s != 10 } }
+                end
+                it "fails if the task emits a sample that matches the predicate" do
+                    e = assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
+                        expect_execution { syskit_write task.in_port, 10 }
+                            .timeout(0.01)
+                            .to { have_no_new_sample_matching(task.in_port) { |s| s == 10 } }
+                    end
+                    assert_equal "#{task.in_port} should not have received a new sample "\
+                                 "matching the given predicate, but it received one: 10",
+                                 e.message.split("\n")[1]
+                end
+                it "provides the backtrace from the point of call by default" do
+                    expectation = nil
+                    assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
+                        expect_execution { syskit_write task.in_port, 10 }
+                            .timeout(0.01)
+                            .to do
+                                expectation = have_no_new_sample_matching(
+                                    task.in_port
+                                ) { true }
+                            end
+                    end
+                    lineno = __LINE__ - 5
+                    fileline = /^([^:]+):(\d+)/.match(expectation.backtrace.first)
+                    assert_equal File.expand_path(__FILE__), File.expand_path(fileline[1])
+                    assert_equal lineno, Integer(fileline[2])
+                end
+                it "allows to override the backtrace" do
+                    expectation = nil
+                    assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
+                        expect_execution { syskit_write task.in_port, 10 }
+                            .timeout(0.01)
+                            .to do
+                                expectation = have_no_new_sample(
+                                    task.in_port, backtrace: ["bla"]
+                                ) { true }
                             end
                     end
                     assert_equal ["bla"], expectation.backtrace

--- a/test/test/test_execution_expectations.rb
+++ b/test/test/test_execution_expectations.rb
@@ -60,12 +60,13 @@ module Syskit
                 end
             end
 
-            describe "#have_one_new_sample_matching" do
+            describe "#have_one_new_sample.matching" do
                 it "passes if the task emits a matching sample and returns it" do
                     value =
                         expect_execution { syskit_write task.in_port, 10 }
                         .to do
-                            have_one_new_sample_matching(task.in_port) { |s| s == 10 }
+                            have_one_new_sample(task.in_port)
+                                .matching { |s| s == 10 }
                         end
                     assert_equal 10, value
                 end
@@ -73,7 +74,7 @@ module Syskit
                     e = assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
                         expect_execution { syskit_write task.in_port, 10 }
                             .timeout(0.01)
-                            .to { have_one_new_sample_matching(task.in_port) { false } }
+                            .to { have_one_new_sample(task.in_port).matching { false } }
                     end
                     assert_equal "#{task.in_port} should have received 1 new "\
                                  "sample(s) matching the given predicate, but got 0",
@@ -84,7 +85,7 @@ module Syskit
                     assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
                         expect_execution.timeout(0.01).to do
                             expectation =
-                                have_one_new_sample_matching(task.in_port) { true }
+                                have_one_new_sample(task.in_port).matching { true }
                         end
                     end
                     lineno = __LINE__ - 3
@@ -98,9 +99,9 @@ module Syskit
                         expect_execution
                             .timeout(0.01)
                             .to do
-                                expectation = have_one_new_sample_matching(
+                                expectation = have_one_new_sample(
                                     task.in_port, backtrace: ["bla"]
-                                ) { true }
+                                ).matching { true }
                             end
                     end
                     assert_equal ["bla"], expectation.backtrace
@@ -148,18 +149,18 @@ module Syskit
                 end
             end
 
-            describe "#have_new_samples_matching" do
+            describe "#have_new_samples.matching" do
                 it "passes if the task emits enough matching samples and returns them" do
                     value =
                         expect_execution { syskit_write task.in_port, 1, 2, 3 }
-                        .to { have_new_samples_matching(task.in_port, 2, &:odd?) }
+                        .to { have_new_samples(task.in_port, 2).matching(&:odd?) }
                     assert_equal [1, 3], value
                 end
                 it "fails if the task does not emit enough matching samples" do
                     e = assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
                         expect_execution { syskit_write task.in_port, 1, 2, 3 }
                             .timeout(0.01)
-                            .to { have_new_samples_matching(task.in_port, 2, &:even?) }
+                            .to { have_new_samples(task.in_port, 2).matching(&:even?) }
                     end
                     assert_match "#{task.in_port} should have received 2 new "\
                                  "sample(s) matching the given predicate, "\
@@ -170,7 +171,7 @@ module Syskit
                     assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
                         expect_execution.timeout(0.01).to do
                             expectation =
-                                have_new_samples_matching(task.in_port, 2) { true }
+                                have_new_samples(task.in_port, 2).matching { true }
                         end
                     end
                     lineno = __LINE__ - 3
@@ -234,7 +235,7 @@ module Syskit
                 end
             end
 
-            describe "#have_no_new_sample_matching" do
+            describe "#have_no_new_sample.matching" do
                 it "validates if the task does not emit a sample" do
                     expect_execution
                         .timeout(0.01)
@@ -244,13 +245,16 @@ module Syskit
                    "match the predicate" do
                     expect_execution { syskit_write task.in_port, 10 }
                         .timeout(0.01)
-                        .to { have_no_new_sample_matching(task.in_port) { |s| s != 10 } }
+                        .to { have_no_new_sample(task.in_port).matching { |s| s != 10 } }
                 end
                 it "fails if the task emits a sample that matches the predicate" do
                     e = assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
                         expect_execution { syskit_write task.in_port, 10 }
                             .timeout(0.01)
-                            .to { have_no_new_sample_matching(task.in_port) { |s| s == 10 } }
+                            .to do
+                                have_no_new_sample(task.in_port)
+                                    .matching { |s| s == 10 }
+                            end
                     end
                     assert_equal "#{task.in_port} should not have received a new sample "\
                                  "matching the given predicate, but it received one: 10",
@@ -262,12 +266,11 @@ module Syskit
                         expect_execution { syskit_write task.in_port, 10 }
                             .timeout(0.01)
                             .to do
-                                expectation = have_no_new_sample_matching(
-                                    task.in_port
-                                ) { true }
+                                expectation = have_no_new_sample(task.in_port)
+                                              .matching { true }
                             end
                     end
-                    lineno = __LINE__ - 5
+                    lineno = __LINE__ - 4
                     fileline = /^([^:]+):(\d+)/.match(expectation.backtrace.first)
                     assert_equal File.expand_path(__FILE__), File.expand_path(fileline[1])
                     assert_equal lineno, Integer(fileline[2])


### PR DESCRIPTION
Depends on:
- [x] https://github.com/rock-core/tools-roby/pull/164

- create the `.matching` refinement to the predicates, allowing to filter
  the samples against a predicate, for instance because one is looking
  for an (asynchronous) state change
- create `have_new_samples` to find more than one sample