### PR TITLE
 handle plain actions in the syskit-specific predicates

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -527,6 +527,8 @@ Metrics/AbcSize:
     - 'lib/syskit/test/profile_assertions.rb'
     - 'lib/syskit/test/self.rb'
     - 'lib/syskit/test/spec.rb'
+    - 'lib/syskit/test/stubs.rb'
+    - 'lib/syskit/test/stub_network.rb'
     - 'lib/syskit/test/task_context_test.rb'
     - 'lib/yard-syskit.rb'
     - 'test/fixtures/simple_composition_model.rb'

--- a/.simplecov
+++ b/.simplecov
@@ -2,7 +2,7 @@
 
 SimpleCov.command_name "syskit"
 SimpleCov.start do
-    add_filter "/test/"
+    add_filter "^/test/"
     add_filter "/gui/"
     add_filter "/scripts/"
 end

--- a/lib/syskit/test/network_manipulation.rb
+++ b/lib/syskit/test/network_manipulation.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "syskit/test/stubs"
+require "syskit/test/stub_network"
+
 # This is essentially required by the expect_execution harness
 # rubocop:disable Style/MultilineBlockChain
 
@@ -17,28 +20,18 @@ module Syskit
             attr_predicate :syskit_stub_resolves_remote_tasks?, true
 
             def setup
-                @__test_overriden_configurations = []
                 @__test_deployment_group = Models::DeploymentGroup.new
                 @__orocos_writers = []
                 @__orocos_readers = []
                 super
+                @__stubs = Stubs.new
             end
 
             def teardown
                 @__orocos_writers.each(&:disconnect)
                 @__orocos_readers.each(&:disconnect)
                 super
-                @__test_overriden_configurations.each do |model, manager|
-                    model.configuration_manager = manager
-                end
-            end
-
-            # Ensure that any modification made to a model's configuration
-            # manager are undone at teardown
-            def syskit_protect_configuration_manager(model)
-                manager = model.configuration_manager
-                model.configuration_manager = manager.dup
-                @__test_overriden_configurations << [model, manager]
+                @__stubs.dispose
             end
 
             def use_deployment(*args, **options)
@@ -54,6 +47,11 @@ module Syskit
             def use_unmanaged_task(*args, **options)
                 Roby.sanitize_keywords_to_array(args, options)
                 @__test_deployment_group.use_unmanaged_task(*args, **options)
+            end
+
+            def syskit_stub_network(root_tasks, remote_task: false)
+                StubNetwork.apply(root_tasks, self,
+                                  stubs: @__stubs, remote_task: remote_task)
             end
 
             # @api private
@@ -284,32 +282,19 @@ module Syskit
             end
 
             def syskit_stub_configured_deployment(
-                task_model = nil, task_name = nil,
+                task_model = nil,
+                task_name = syskit_default_stub_name(task_model),
                 remote_task: syskit_stub_resolves_remote_tasks?,
                 register: true, &block
             )
-
-                task_name ||= syskit_default_stub_name(task_model)
-                deployment_model = syskit_stub_deployment_model(
-                    task_model, task_name, &block
-                )
-
-                process_server = Syskit.conf.process_server_for("stubs")
-                task_context_class =
-                    if remote_task
-                        Orocos::RubyTasks::RemoteTaskContext
-                    else
-                        process_server.task_context_class
-                    end
-
-                deployment = Models::ConfiguredDeployment.new(
-                    "stubs", deployment_model, { task_name => task_name }, task_name,
-                    Hash[task_context_class: task_context_class]
+                configured_deployment = @__stubs.stub_configured_deployment(
+                    task_model, task_name, remote_task: remote_task, &block
                 )
                 if register
-                    @__test_deployment_group.register_configured_deployment(deployment)
+                    @__test_deployment_group
+                        .register_configured_deployment(configured_deployment)
                 end
-                deployment
+                configured_deployment
             end
 
             # Create a new stub deployment model that can deploy a given task
@@ -327,21 +312,9 @@ module Syskit
             def syskit_stub_deployment_model(
                 task_model = nil, name = nil, register: true, &block
             )
-                task_model = task_model&.to_component_model
-                process_server = Syskit.conf.process_server_for("stubs")
-
-                name ||= syskit_default_stub_name(task_model)
-                deployment_model = Deployment.new_submodel(name: name) do
-                    task(name, task_model.orogen_model) if task_model
-                    instance_eval(&block) if block
-                end
-
-                if register
-                    process_server.loader.register_deployment_model(
-                        deployment_model.orogen_model
-                    )
-                end
-                deployment_model
+                @__stubs.stub_deployment_model(
+                    task_model, name, register: register, &block
+                )
             end
 
             # Create a new stub deployment instance, optionally stubbing the
@@ -358,224 +331,33 @@ module Syskit
                 task
             end
 
-            def syskit_stub_component(model, devices: true)
-                if devices
-                    syskit_stub_required_devices(model)
-                else
-                    model
-                end
-            end
-
-            # @api private
-            #
-            # Helper for {#syskit_stub_and_deploy}
-            #
-            # @param [InstanceRequirements] task_m the task context model
-            # @param [String] as the deployment name
-            def syskit_stub_task_context_requirements(
-                model, as: syskit_default_stub_name(model), devices: true
-            )
-                model = model.to_instance_requirements
-
-                task_m = model.model.to_component_model.concrete_model
-                if task_m.placeholder?
-                    superclass = if task_m.superclass <= Syskit::TaskContext
-                                     task_m.superclass
-                                 else Syskit::TaskContext
-                                 end
-
-                    services = task_m.proxied_data_service_models
-                    task_m = superclass.new_submodel(name: "#{task_m}-stub")
-                    services.each_with_index do |srv, idx|
-                        srv.each_input_port do |p|
-                            task_m.orogen_model.input_port(
-                                p.name, Orocos.find_orocos_type_name_by_type(p.type)
-                            )
-                        end
-                        srv.each_output_port do |p|
-                            task_m.orogen_model.output_port(
-                                p.name, Orocos.find_orocos_type_name_by_type(p.type)
-                            )
-                        end
-                        if srv <= Syskit::Device
-                            task_m.driver_for srv, as: "dev#{idx}"
-                        else
-                            task_m.provides srv, as: "srv#{idx}"
-                        end
-                    end
-                elsif task_m.abstract?
-                    task_m = task_m.new_submodel(name: "#{task_m.name}-stub")
-                end
-                model.add_models([task_m])
-                model = syskit_stub_component(model, devices: devices)
-
-                syskit_stub_conf(task_m, *model.arguments[:conf])
-
-                deployment = syskit_stub_configured_deployment(
-                    task_m, as, register: false
-                )
-                model.reset_deployment_selection
-                model.use_configured_deployment(deployment)
-                model
-            end
-
-            # Create empty configuration sections for the given task model
+            # (see Stubs#stub_conf)
             def syskit_stub_conf(task_m, *conf, data: {})
-                concrete_task_m = task_m.concrete_model
-                syskit_protect_configuration_manager(concrete_task_m)
-                conf.each do |conf_name|
-                    concrete_task_m.configuration_manager.add(
-                        conf_name, data, merge: true
-                    )
-                end
+                @__stubs.stub_conf(task_m, *conf, data: data)
             end
 
-            # @api private
-            #
-            # Helper for {#syskit_stub_model}
-            #
-            # @param [InstanceRequirements] model
-            def syskit_stub_composition_requirements(
-                model, recursive: true, devices: true,
-                as: syskit_default_stub_name(model)
-            )
-                model = syskit_stub_component(model, devices: devices)
-                return model unless recursive
-
-                model.each_child do |child_name, selected_child|
-                    if (selected_task = selected_child.component)
-                        deployed_child = selected_task
-                    else
-                        child_model = selected_child.selected
-                        selected_service = child_model.service
-                        child_model = child_model.to_component_model
-                        if child_model.composition_model?
-                            deployed_child = syskit_stub_composition_requirements(
-                                child_model,
-                                as: "#{as}_#{child_name}", devices: devices,
-                                recursive: true
-                            )
-                        else
-                            deployed_child = syskit_stub_task_context_requirements(
-                                child_model, as: "#{as}_#{child_name}", devices: devices
-                            )
-                        end
-                        if selected_service
-                            deployed_child.select_service(selected_service)
-                        end
-                    end
-                    model.use(child_name => deployed_child)
-                end
-                model
+            # (see Stubs#stub_device)
+            def syskit_stub_device(model, **kw)
+                @__stubs.stub_device(model, **kw)
             end
 
-            # @api private
-            #
-            # Finds a driver model for a given device model, or create one if
-            # there is none
-            def syskit_stub_driver_model_for(model)
-                syskit_stub_requirements(model.find_all_drivers.first || model,
-                                         devices: false)
-            end
-
-            # Create a stub device of the given model
-            #
-            # It is created on a new robot instance so that to avoid clashes
-            #
-            # @param [Model<Device>] model the device model
-            # @param [String] as the device name
-            # @param [Model<TaskContext>] driver the driver that should be used.
-            #   If not given, a new driver is stubbed
-            def syskit_stub_device(
-                model, driver: nil, robot: nil, as: syskit_default_stub_name(model),
-                **device_options
-            )
-                robot ||= Syskit::Robot::RobotDefinition.new
-                driver ||= syskit_stub_driver_model_for(model)
-                robot.device(model, as: as, using: driver, **device_options)
-            end
-
-            # Create a stub combus of the given model
-            #
-            # It is created on a new robot instance so that to avoid clashes
-            #
-            # @param [Model<ComBus>] model the device model
-            # @param [String] as the combus name
-            # @param [Model<TaskContext>] driver the driver that should be used.
-            #   If not given, a new driver is stubbed
-            def syskit_stub_com_bus(
-                model, driver: nil, robot: nil, as: syskit_default_stub_name(model),
-                **device_options
-            )
-                robot ||= Syskit::Robot::RobotDefinition.new
-                driver ||= syskit_stub_driver_model_for(model)
-                robot.com_bus(model, as: as, using: driver, **device_options)
-            end
-
-            # Create a stub device attached on the given bus
-            #
-            # If the bus is a device object, the new device is attached to the
-            # same robot model. Otherwise, a new robot model is created for both
-            # the bus and the device
-            #
-            # @param [Model<ComBus>,MasterDeviceInstance] bus either a bus model
-            #   or a bus object
-            # @param [String] as a name for the new device
-            # @param [Model<TaskContext>] driver the driver that should be used
-            #   for the device. If not given, syskit will look for a suitable
-            #   driver or stub one
-            def syskit_stub_attached_device(
-                bus, as: syskit_default_stub_name(bus),
-                client_to_bus: true, bus_to_client: true,
-                base_model: Syskit::Device
-            )
-                unless bus.kind_of?(Robot::DeviceInstance)
-                    bus = syskit_stub_com_bus(bus, as: "#{as}_bus")
-                end
-                bus_m = bus.model
-                client_service_m =
-                    if client_to_bus && bus_to_client
-                        bus_m::ClientSrv
-                    elsif client_to_bus
-                        bus_m::ClientOutSrv
-                    elsif bus_to_client
-                        bus_m::ClientInSrv
-                    else
-                        raise ArgumentError, "at least one of client_to_bus or "\
-                                             "bus_to_client need to be true"
-                    end
-
-                dev_m = base_model.new_submodel(name: "#{bus}-stub") do
-                    provides client_service_m
-                end
-                dev = syskit_stub_device(dev_m, as: as)
-                dev.attach_to(
-                    bus, client_to_bus: client_to_bus, bus_to_client: bus_to_client
-                )
-                dev
-            end
-
-            # Stubs the devices required by the given model
-            def syskit_stub_required_devices(model)
-                model = model.to_instance_requirements
-                model.model.to_component_model.each_master_driver_service do |srv|
-                    unless model.arguments[:"#{srv.name}_dev"]
-                        device_stub = syskit_stub_device(srv.model, driver: model.model)
-                        model.with_arguments("#{srv.name}_dev": device_stub)
-                    end
-                end
-                model
-            end
-
-            @@syskit_stub_model_id = -1
-
-            def syskit_stub_model_id
-                id = (@@syskit_stub_model_id += 1)
-                id if id != 0
+            # (see Stubs#stub_requirements)
+            def syskit_stub_requirements(model, **options, &block)
+                @__stubs.stub_requirements(model, **options, &block)
             end
 
             def syskit_default_stub_name(_model)
-                "stub#{syskit_stub_model_id}"
+                @__stubs.default_stub_name
+            end
+
+            # (see Stubs#stub_attached_device)
+            def syskit_stub_attached_device(bus, **kw)
+                @__stubs.stub_attached_device(bus, **kw)
+            end
+
+            # (see Stubs#stub_com_bus)
+            def syskit_stub_com_bus(model, **kw)
+                @__stubs.stub_com_bus(model, **kw)
             end
 
             # @deprecated use syskit_stub_requirements instead
@@ -584,325 +366,6 @@ module Syskit
                     "syskit_stub_requirements to make the difference with "\
                     "syskit_stub_network more obvious"
                 syskit_stub_requirements(*args, **options, &block)
-            end
-
-            # Create an InstanceRequirement instance that would allow to deploy
-            # the given model
-            def syskit_stub_requirements(
-                model = subject_syskit_model,
-                recursive: true, devices: true,
-                as: syskit_default_stub_name(model),
-                &block
-            )
-                if model.respond_to?(:to_str)
-                    model = syskit_stub_task_context_model(model, &block)
-                end
-                model = model.to_instance_requirements.dup
-
-                if model.composition_model?
-                    syskit_stub_composition_requirements(
-                        model, recursive: recursive, as: as, devices: devices
-                    )
-                else
-                    syskit_stub_task_context_requirements(
-                        model, as: as, devices: devices
-                    )
-                end
-            end
-
-            # Exception raised when some conditions block stubbing of a network
-            class CannotStub < RuntimeError
-                def initialize(original, stub)
-                    @original = original
-                    @stub = stub
-                    @semantic_merge_blockers =
-                        @original.arguments.semantic_merge_blockers(@stub.arguments)
-                end
-
-                def pretty_print(pp)
-                    pp.text "cannot stub "
-                    @original.pretty_print(pp)
-
-                    pp.breakable
-                    if @semantic_merge_blockers.empty?
-                        pp.text "The reason is unknown. Consider this a Syskit bug"
-                        return
-                    end
-
-                    pp.text "The following delayed arguments should be made available"
-                    pp.nest(2) do
-                        @semantic_merge_blockers.each do |name, (arg, _)|
-                            pp.breakable
-                            pp.text "#{name} "
-                            pp.nest(2) do
-                                arg.pretty_print(pp)
-                            end
-                        end
-                    end
-                end
-            end
-
-            # Stub an already existing network
-            def syskit_stub_network(
-                root_tasks, remote_task: syskit_stub_resolves_remote_tasks?
-            )
-                # Find the first Syskit task in the hierarchy
-
-
-                mapped_tasks = plan.in_transaction do |trsc|
-                    mapped_tasks = syskit_stub_network_in_transaction(
-                        trsc, root_tasks, remote_task: remote_task
-                    )
-                    trsc.commit_transaction
-                    mapped_tasks
-                end
-
-                execute do
-                    syskit_stub_network_remove_obsolete_tasks(mapped_tasks)
-                end
-                root_tasks.map { |t, _| mapped_tasks[t] || t }
-            end
-
-            def syskit_stub_network_remove_obsolete_tasks(mapped_tasks)
-                mapped_tasks.each do |old, new|
-                    plan.remove_task(old) if old != new
-                end
-            end
-
-            # @api private
-            #
-            # Helper method that returns the set of syskit tasks to work on based on
-            # an arbitrary set of tasks in the plan
-            #
-            # The method looks at the dependent subgraph of a given set of roots, and
-            # extracts the Syskit subgraph within it.
-            #
-            # @return the set of roots within the Syskit component subnet, the set of
-            #   syskit tasks and the set of non-syskit tasks
-            def syskit_stub_network_discover(trsc, root_tasks)
-                tasks = Set.new
-                dependency_graph =
-                    trsc.plan.task_relation_graph_for(Roby::TaskStructure::Dependency)
-                Array(root_tasks).map do |t|
-                    tasks << t
-                    dependency_graph.depth_first_visit(t) { |child_t| tasks << child_t }
-                end
-
-                syskit, non_syskit =
-                    tasks.partition { |t| t.kind_of?(Syskit::Component) }
-
-                syskit_roots = syskit.find_all do |t|
-                    t.each_parent_task.none? { |parent_t| syskit.include?(parent_t) }
-                end
-
-                [syskit_roots, syskit, non_syskit]
-            end
-
-            def syskit_stub_network_in_transaction(
-                trsc, root_tasks,
-                remote_task: syskit_stub_resolves_remote_tasks?
-            )
-                mapped_tasks = {}
-
-                plan = trsc.plan
-                syskit_roots, syskit_tasks, non_syskit_tasks =
-                    syskit_stub_network_discover(trsc, root_tasks)
-
-                # Save the permanent/mission status to re-apply it later
-                syskit_roots = syskit_roots.map do |t|
-                    if plan.mission_task?(t)
-                        [t, :mission_task]
-                    elsif plan.permanent_task?(t)
-                        [t, :permanent_task]
-                    else
-                        [t]
-                    end
-                end
-
-                # We don't touch non-Syskit tasks, just make them their own mapping
-                non_syskit_tasks.each { |t| mapped_tasks[t] = t }
-
-                # We need to add the parents to the transaction so as to keep
-                # the existing relationships
-                other_tasks = syskit_tasks.each_with_object(Set.new) do |t, s|
-                    s.merge(t.each_parent_task)
-                end
-                other_tasks -= syskit_tasks
-                trsc_other_tasks = other_tasks.map { |plan_t| trsc[plan_t] }
-
-                merge_solver = NetworkGeneration::MergeSolver.new(trsc)
-                trsc_tasks = syskit_tasks.map do |plan_t|
-                    trsc_t = trsc[plan_t]
-                    merge_solver.register_replacement(plan_t, trsc_t)
-                    trsc_t
-                end
-
-                trsc_tasks.each do |task|
-                    task.model.each_master_driver_service do |srv|
-                        task.arguments[:"#{srv.name}_dev"] ||=
-                            syskit_stub_device(srv.model, driver: srv)
-                    end
-                end
-
-                stubbed_tags = {}
-                merge_mappings = {}
-                trsc_tasks.find_all(&:abstract?).each do |abstract_task|
-                    # The task is required as being abstract (usually a
-                    # if_already_present tag). Do not stub that
-                    next if abstract_task.requirements.abstract?
-
-                    concrete_task =
-                        if abstract_task.kind_of?(Syskit::Actions::Profile::Tag)
-                            tag_id = [abstract_task.model.tag_name,
-                                      abstract_task.model.profile.name]
-                            stubbed_tags[tag_id] ||=
-                                syskit_stub_network_abstract_component(abstract_task)
-                        else
-                            syskit_stub_network_abstract_component(abstract_task)
-                        end
-
-                    pure_data_service_proxy =
-                        abstract_task.placeholder? &&
-                        !abstract_task.kind_of?(Syskit::TaskContext)
-                    if pure_data_service_proxy
-                        trsc.replace_task(abstract_task, concrete_task)
-                        merge_solver.register_replacement(
-                            abstract_task, concrete_task
-                        )
-                    else
-                        merge_mappings[abstract_task] = concrete_task
-                    end
-                end
-
-                # NOTE: must NOT call #apply_merge_group with merge_mappings
-                # directly. #apply_merge_group "replaces" the subnet represented
-                # by the keys with the subnet represented by the values. In
-                # other words, the connections present between two keys would
-                # NOT be copied between the corresponding values
-
-                merge_mappings.each do |original, replacement|
-                    unless replacement.can_merge?(original)
-                        raise CannotStub.new(original, replacement),
-                              "cannot stub #{original} with #{replacement}, maybe "\
-                              "some delayed arguments are not set ?"
-                    end
-                    merge_solver.apply_merge_group(original => replacement)
-                end
-                merge_solver.merge_identical_tasks
-
-                merge_mappings = {}
-                trsc_tasks.each do |original_task|
-                    concrete_task = merge_solver.replacement_for(original_task)
-                    needs_new_deployment =
-                        concrete_task.kind_of?(TaskContext) &&
-                        !concrete_task.execution_agent
-                    if needs_new_deployment
-                        merge_mappings[concrete_task] =
-                            syskit_stub_network_deployment(
-                                concrete_task, remote_task: remote_task
-                            )
-                    end
-                end
-
-                merge_mappings.each do |original, replacement|
-                    unless original.can_merge?(replacement)
-                        raise CannotStub.new(original, replacement),
-                              "cannot stub #{original} with #{replacement}, maybe "\
-                              "some delayed arguments are not set ?"
-                    end
-                    # See big comment on apply_merge_group above
-                    merge_solver.apply_merge_group(original => replacement)
-                end
-
-                syskit_tasks.each do |plan_t|
-                    replacement_t = merge_solver.replacement_for(plan_t)
-                    mapped_tasks[plan_t] = trsc.may_unwrap(replacement_t)
-                end
-
-                trsc_new_roots = Set.new
-                syskit_roots.each do |root_t, status|
-                    replacement_t = mapped_tasks[root_t] || root_t
-                    if replacement_t != root_t
-                        unless replacement_t.planning_task
-                            replacement_t.planned_by trsc[root_t.planning_task]
-                        end
-                        trsc.send("add_#{status}", replacement_t) if status
-                    end
-                    trsc_new_roots << trsc[replacement_t]
-                end
-
-                NetworkGeneration::SystemNetworkGenerator
-                    .remove_abstract_composition_optional_children(trsc)
-                trsc.static_garbage_collect(
-                    protected_roots: trsc_new_roots | trsc_other_tasks
-                )
-                NetworkGeneration::SystemNetworkGenerator
-                    .verify_task_allocation(trsc, components: trsc_tasks.find_all(&:plan))
-                mapped_tasks
-            end
-
-            def syskit_stub_placeholder(model)
-                superclass = if model.superclass <= Syskit::TaskContext
-                                 model.superclass
-                             else Syskit::TaskContext
-                             end
-
-                services = model.proxied_data_service_models
-                task_m = superclass.new_submodel(name: "#{model}-stub")
-                services.each_with_index do |srv, idx|
-                    srv.each_input_port do |p|
-                        orocos_type_name = Orocos.find_orocos_type_name_by_type(p.type)
-                        task_m.orogen_model.input_port p.name, orocos_type_name
-                    end
-                    srv.each_output_port do |p|
-                        orocos_type_name = Orocos.find_orocos_type_name_by_type(p.type)
-                        task_m.orogen_model.output_port p.name, orocos_type_name
-                    end
-                    if srv <= Syskit::Device
-                        task_m.driver_for srv, as: "dev#{idx}"
-                    else
-                        task_m.provides srv, as: "srv#{idx}"
-                    end
-                end
-                task_m
-            end
-
-            def syskit_stub_network_abstract_component(task)
-                task_m = task.concrete_model
-                if task_m.placeholder?
-                    task_m = syskit_stub_placeholder(task_m)
-                elsif task_m.abstract?
-                    task_m = task_m.new_submodel(name: "#{task_m.name}-stub")
-                end
-
-                arguments = task.arguments.dup
-                task_m.each_master_driver_service do |srv|
-                    arguments[:"#{srv.name}_dev"] ||=
-                        syskit_stub_device(srv.model, driver: task_m)
-                end
-                task_m.new(**arguments)
-            end
-
-            def syskit_stub_network_deployment(
-                task,
-                as: task.orocos_name || syskit_default_stub_name(task.model),
-                remote_task: syskit_stub_resolves_remote_tasks?
-            )
-
-                task_m = task.concrete_model
-                deployment_model = syskit_stub_configured_deployment(
-                    task_m, as, remote_task: remote_task, register: false
-                )
-                syskit_stub_conf(task_m, *task.arguments[:conf])
-                task.plan.add(deployer = deployment_model.new)
-                deployed_task = deployer.instanciate_all_tasks.first
-
-                new_args = {}
-                task.arguments.find_all do |key, arg|
-                    new_args[key] = arg if deployed_task.arguments.writable?(key, arg)
-                end
-                deployed_task.assign_arguments(**new_args)
-                deployed_task
             end
 
             def syskit_start_all_execution_agents
@@ -1280,7 +743,6 @@ module Syskit
                 model = subject_syskit_model,
                 remote_task: syskit_stub_resolves_remote_tasks?, &block
             )
-
                 if model.respond_to?(:to_str)
                     model = syskit_stub_task_context_model(model, &block)
                 end

--- a/lib/syskit/test/profile_assertions.rb
+++ b/lib/syskit/test/profile_assertions.rb
@@ -164,8 +164,8 @@ module Syskit
             #   describe MyBundle::Profiles::MyProfile do
             #     it { is_self_contained }
             #   end
-            def is_self_contained(action_or_profile = subject_syskit_model, options = {})
-                assert_is_self_contained(action_or_profile, options)
+            def is_self_contained(action_or_profile = subject_syskit_model, **options)
+                assert_is_self_contained(action_or_profile, **options)
             end
 
             # Tests that the following definition can be successfully

--- a/lib/syskit/test/spec.rb
+++ b/lib/syskit/test/spec.rb
@@ -48,20 +48,21 @@ module Syskit
 
                     @plan.syskit_apply_async_resolution_results
 
+                    root_tasks = @planning_tasks.map(&:planned_task)
+                    stub_network = StubNetwork.new(@test)
+
                     # NOTE: this is a run-planner equivalent to syskit_stub_network
                     # we will have to investigate whether we could implement one with
                     # the other (probably), but in the meantime we must keep both
                     # in sync
-                    root_tasks = @planning_tasks.map(&:planned_task)
                     mapped_tasks = @plan.in_transaction do |trsc|
-                        mapped_tasks = @test.syskit_stub_network_in_transaction(
-                            trsc, root_tasks
-                        )
+                        mapped_tasks =
+                            stub_network.apply_in_transaction(trsc, root_tasks)
                         trsc.commit_transaction
                         mapped_tasks
                     end
 
-                    @test.syskit_stub_network_remove_obsolete_tasks(mapped_tasks)
+                    stub_network.remove_obsolete_tasks(mapped_tasks)
                 end
                 @planning_tasks.all?(&:success?)
             end

--- a/lib/syskit/test/stub_network.rb
+++ b/lib/syskit/test/stub_network.rb
@@ -1,0 +1,354 @@
+# frozen_string_literal: true
+
+module Syskit
+    module Test
+        # Encapsulated implementation of the network stubbing algorithm
+        # exposed as {NetworkManipulation#syskit_stub_network}
+        #
+        # It's a fairly complex algorithm. The goal here is to avoid exposing all
+        # its parts in the test API, while making it easier to test and maintain
+        #
+        # The entrypoint is {#apply}
+        class StubNetwork < Stubs
+            # Apply stubbing on the given's test plan
+            #
+            # @param [Array<Roby::Task>] root_tasks the roots of the dependent subgraph
+            #   to consider. The tasks are within test.plan (NOT within the transaction)
+            # @param [#execute,#plan] test the test context
+            # @param [Stubs] stubs a common stubbing object
+            # @param [Boolean] remote_task if false, the stubs will be local ruby
+            #   task contexts, meaning that it is possible to read their inputs
+            #   and write their outputs. If false, they will be accessed as remote
+            #   tasks are. This is mainly used within Syskit's own test suite to
+            #   test some of the Syskit APIs
+            def self.apply(root_tasks, test, stubs: Stubs.new, remote_task: false)
+                new(test, stubs: stubs).apply(root_tasks, remote_task: remote_task)
+            end
+
+            def initialize(test, stubs: Stubs.new)
+                super()
+                @test = test
+                @plan = test.plan
+                @stubs = stubs
+            end
+
+            # Create stubs for services, tags and deployments in an existing network
+            #
+            # @param [Array<Roby::Task>] root_tasks the roots of the network to work on.
+            #   The method will work on any Syskit dependent subgraph which has these
+            #   roots, so non-Syskit tasks can be provided
+            #
+            # @return [Array<Roby::Task>] the transformed root tasks, i.e. either the
+            #   root tasks, or the tasks that replace them in the stubbed network
+            def apply(root_tasks, remote_task: false)
+                mapped_tasks = @plan.in_transaction do |trsc|
+                    mapped_tasks = apply_in_transaction(
+                        trsc, root_tasks, remote_task: remote_task
+                    )
+                    trsc.commit_transaction
+                    mapped_tasks
+                end
+
+                @test.execute do
+                    remove_obsolete_tasks(mapped_tasks)
+                end
+                root_tasks.map { |t, _| mapped_tasks[t] }
+            end
+
+            def apply_in_transaction(trsc, root_tasks, remote_task: false)
+                mapped_tasks = {}
+
+                syskit_roots, syskit_tasks, non_syskit_tasks =
+                    discover_syskit_tasks(trsc, root_tasks)
+
+                syskit_roots =
+                    save_mission_or_permanent_status(syskit_roots)
+
+                # We don't touch non-Syskit tasks, just make them their own mapping
+                non_syskit_tasks.each { |t| mapped_tasks[t] = t }
+
+                merge_solver, trsc_tasks, trsc_other_tasks =
+                    prepare_transaction(trsc, syskit_tasks)
+
+                trsc_tasks.each do |task|
+                    stub_device_arguments(task)
+                end
+                stub_abstract_tasks(
+                    trsc, merge_solver,
+                    trsc_tasks.find_all(&:abstract?)
+                )
+
+                create_missing_deployments(
+                    merge_solver, trsc_tasks, remote_task: remote_task
+                )
+
+                syskit_tasks.each do |plan_t|
+                    replacement_t = merge_solver.replacement_for(plan_t)
+                    mapped_tasks[plan_t] = trsc.may_unwrap(replacement_t)
+                end
+
+                trsc_new_roots = Set.new
+                syskit_roots.each do |root_t, status|
+                    replacement_t = mapped_tasks[root_t] || root_t
+                    if replacement_t != root_t
+                        if root_t.planning_task && !replacement_t.planning_task
+                            replacement_t.planned_by trsc[root_t.planning_task]
+                        end
+                        trsc.send("add_#{status}", replacement_t) if status
+                    end
+                    trsc_new_roots << trsc[replacement_t]
+                end
+
+                NetworkGeneration::SystemNetworkGenerator
+                    .remove_abstract_composition_optional_children(trsc)
+                trsc.static_garbage_collect(
+                    protected_roots: trsc_new_roots | trsc_other_tasks
+                )
+                NetworkGeneration::SystemNetworkGenerator
+                    .verify_task_allocation(
+                        trsc, components: trsc_tasks.find_all(&:plan)
+                    )
+                mapped_tasks
+            end
+
+            # Exception raised when some conditions block stubbing of a network
+            class CannotStub < RuntimeError
+                def initialize(original, stub)
+                    @original = original
+                    @stub = stub
+                    @semantic_merge_blockers =
+                        @original.arguments.semantic_merge_blockers(@stub.arguments)
+                end
+
+                def pretty_print(pp)
+                    pp.text "cannot stub "
+                    @original.pretty_print(pp)
+
+                    pp.breakable
+                    if @semantic_merge_blockers.empty?
+                        pp.text "The reason is unknown. Consider this a Syskit bug"
+                        return
+                    end
+
+                    pp.text "The following delayed arguments should be made available"
+                    pp.nest(2) do
+                        @semantic_merge_blockers.each do |name, (arg, _)|
+                            pp.breakable
+                            pp.text "#{name} "
+                            pp.nest(2) do
+                                arg.pretty_print(pp)
+                            end
+                        end
+                    end
+                end
+            end
+
+            # @api private
+            #
+            # Remove tasks that have been replaced by new tasks during stubbing
+            def remove_obsolete_tasks(mapped_tasks)
+                mapped_tasks.each do |old, new|
+                    @plan.remove_task(old) if old != new
+                end
+            end
+
+            # @api private
+            #
+            # Helper method that returns the set of syskit tasks to work on based on
+            # an arbitrary set of tasks in the plan
+            #
+            # The method looks at the dependent subgraph of a given set of roots, and
+            # extracts the Syskit subgraph within it.
+            #
+            # @return the set of roots within the Syskit component subnet, the set of
+            #   syskit tasks and the set of non-syskit tasks
+            def discover_syskit_tasks(trsc, root_tasks)
+                dependency_graph =
+                    trsc.plan.task_relation_graph_for(Roby::TaskStructure::Dependency)
+                tasks = root_tasks.dup
+                root_tasks.each do |t|
+                    dependency_graph.depth_first_visit(t) { |child_t| tasks << child_t }
+                end
+
+                syskit, non_syskit =
+                    tasks.partition { |t| t.kind_of?(Syskit::Component) }
+
+                syskit_roots = syskit.find_all do |t|
+                    t.each_parent_task.none? { |parent_t| syskit.include?(parent_t) }
+                end
+
+                [syskit_roots, syskit, non_syskit]
+            end
+
+            # @api private
+            #
+            # Save the mission/permanent status of the given tasks, to be restored later
+            def save_mission_or_permanent_status(tasks)
+                # Save the permanent/mission status to re-apply it later
+                tasks.map do |t|
+                    if @plan.mission_task?(t)
+                        [t, :mission_task]
+                    elsif @plan.permanent_task?(t)
+                        [t, :permanent_task]
+                    else
+                        [t]
+                    end
+                end
+            end
+
+            # @api private
+            #
+            # Prepare the transaction on which the stub_network method will work
+            def prepare_transaction(trsc, syskit_tasks)
+                # We need to add the parents to the transaction so as to keep
+                # the existing relationships
+                other_tasks = syskit_tasks.each_with_object(Set.new) do |t, s|
+                    s.merge(t.each_parent_task)
+                end
+                other_tasks -= syskit_tasks
+                trsc_other_tasks = other_tasks.map { |plan_t| trsc[plan_t] }
+
+                merge_solver = NetworkGeneration::MergeSolver.new(trsc)
+                trsc_tasks = syskit_tasks.map do |plan_t|
+                    trsc_t = trsc[plan_t]
+                    merge_solver.register_replacement(plan_t, trsc_t)
+                    trsc_t
+                end
+                [merge_solver, trsc_tasks, trsc_other_tasks]
+            end
+
+            # Create stub devices for each unset device arguments of the given task
+            #
+            # @param [Syskit::Component] task
+            # @return [void]
+            def stub_device_arguments(task)
+                task.model.each_master_driver_service do |srv|
+                    task.arguments[:"#{srv.name}_dev"] ||=
+                        stub_device(srv.model, driver: srv)
+                end
+            end
+
+            # @api private
+            #
+            # Create deployable stubs for abstract tasks (service and tag
+            # placeholders)
+            #
+            # @param [Array<Syskit::Component>] tasks the set of abstract tasks to work on
+            def stub_abstract_tasks(plan, merge_solver, tasks)
+                merge_mappings = {}
+
+                stubbed_tags = {}
+                tasks.each do |abstract_task|
+                    # The task is required as being abstract (usually a
+                    # if_already_present tag). Do not stub that
+                    next if abstract_task.requirements.abstract?
+
+                    concrete_task =
+                        if abstract_task.kind_of?(Syskit::Actions::Profile::Tag)
+                            tag_id = [abstract_task.model.tag_name,
+                                      abstract_task.model.profile.name]
+                            stubbed_tags[tag_id] ||=
+                                stub_abstract_component(abstract_task)
+                        else
+                            stub_abstract_component(abstract_task)
+                        end
+
+                    pure_data_service_proxy =
+                        abstract_task.placeholder? &&
+                        !abstract_task.kind_of?(Syskit::TaskContext)
+                    if pure_data_service_proxy
+                        plan.replace_task(abstract_task, concrete_task)
+                        merge_solver.register_replacement(
+                            abstract_task, concrete_task
+                        )
+                    else
+                        plan.add(concrete_task)
+                        merge_mappings[abstract_task] = concrete_task
+                    end
+                end
+
+                apply_merge_mappings(merge_solver, merge_mappings)
+            end
+
+            def stub_abstract_component(task)
+                task_m = task.concrete_model
+                if task_m.placeholder?
+                    task_m = stub_placeholder_model(task_m)
+                elsif task_m.abstract?
+                    task_m = stub_abstract_component_model(task_m)
+                end
+
+                arguments = task.arguments.dup
+                task_m.each_master_driver_service do |srv|
+                    arguments[:"#{srv.name}_dev"] ||=
+                        stub_device(srv.model, driver: task_m)
+                end
+                task_m.new(**arguments)
+            end
+
+            # @api private
+            #
+            # Apply a set of replacements using the merge solver
+            def apply_merge_mappings(merge_solver, merge_mappings)
+                # NOTE: must NOT call #apply_merge_group with merge_mappings
+                # directly. #apply_merge_group "replaces" the subnet represented
+                # by the keys with the subnet represented by the values. In
+                # other words, the connections present between two keys would
+                # NOT be copied between the corresponding values
+
+                merge_mappings.each do |original, replacement|
+                    unless replacement.can_merge?(original)
+                        raise CannotStub.new(original, replacement),
+                              "cannot stub #{original} with #{replacement}, maybe "\
+                              "some delayed arguments are not set ?"
+                    end
+                    merge_solver.apply_merge_group(original => replacement)
+                end
+                merge_solver.merge_identical_tasks
+            end
+
+            def create_missing_deployments(merge_solver, tasks, remote_task:)
+                merge_mappings = {}
+                tasks.each do |original_task|
+                    concrete_task = merge_solver.replacement_for(original_task)
+                    needs_new_deployment =
+                        concrete_task.kind_of?(TaskContext) &&
+                        !concrete_task.execution_agent
+                    if needs_new_deployment
+                        merge_mappings[concrete_task] =
+                            stub_deployment(concrete_task, remote_task: remote_task)
+                    end
+                end
+
+                merge_mappings.each do |original, replacement|
+                    unless original.can_merge?(replacement)
+                        raise CannotStub.new(original, replacement),
+                              "cannot stub #{original} with #{replacement}, maybe "\
+                              "some delayed arguments are not set ?"
+                    end
+                    # See big comment on apply_merge_group above
+                    merge_solver.apply_merge_group(original => replacement)
+                end
+            end
+
+            def stub_deployment(
+                task, remote_task: false, as: task.orocos_name || default_stub_name
+            )
+                task_m = task.concrete_model
+                deployment_model = @stubs.stub_configured_deployment(
+                    task_m, as, remote_task: remote_task
+                )
+                stub_conf(task_m, *task.arguments[:conf])
+                task.plan.add(deployer = deployment_model.new)
+                deployed_task = deployer.instanciate_all_tasks.first
+
+                new_args = {}
+                task.arguments.each do |key, arg|
+                    new_args[key] = arg if deployed_task.arguments.writable?(key, arg)
+                end
+                deployed_task.assign_arguments(**new_args)
+                deployed_task
+            end
+        end
+    end
+end

--- a/lib/syskit/test/stubs.rb
+++ b/lib/syskit/test/stubs.rb
@@ -1,0 +1,337 @@
+# frozen_string_literal: true
+
+module Syskit
+    module Test
+        # Common features for stub creation
+        class Stubs
+            def initialize
+                @__test_overriden_configurations = []
+            end
+
+            def dispose
+                @__test_overriden_configurations.each do |model, manager|
+                    model.configuration_manager = manager
+                end
+            end
+
+            # Generate
+            def default_stub_name
+                "stub#{Stubs.stub_model_id}"
+            end
+
+            @syskit_stub_model_id = 0
+
+            def self.stub_model_id
+                @syskit_stub_model_id += 1
+            end
+
+            # Create empty configuration sections for the given task model
+            def stub_conf(task_m, *conf, data: {})
+                concrete_task_m = task_m.concrete_model
+                protect_configuration_manager(concrete_task_m)
+                conf.each do |conf_name|
+                    concrete_task_m.configuration_manager.add(
+                        conf_name, data, merge: true
+                    )
+                end
+            end
+
+            # Ensure that any modification made to a model's configuration
+            # manager are undone at teardown
+            def protect_configuration_manager(model)
+                manager = model.configuration_manager
+                model.configuration_manager = manager.dup
+                @__test_overriden_configurations << [model, manager]
+            end
+
+            # Create a new stub deployment model that can deploy a given task
+            # context model
+            #
+            # @param [Model<Syskit::TaskContext>,nil] task_model if given, a
+            #   task model that should be deployed by this deployment model
+            # @param [String] name the name of the deployed task as well as
+            #   of the deployment. If not given, and if task_model is provided,
+            #   task_model.name is used as default
+            # @yield the deployment model context, i.e. a context in which the
+            #   same declarations than in oroGen's #deployment statement are
+            #   available
+            # @return [Models::ConfiguredDeployment] the configured deployment
+            def stub_deployment_model(
+                task_model = nil, name = default_stub_name, register: true, &block
+            )
+                task_model = task_model&.to_component_model
+                process_server = Syskit.conf.process_server_for("stubs")
+
+                deployment_model = Deployment.new_submodel(name: name) do
+                    task(name, task_model.orogen_model) if task_model
+                    instance_eval(&block) if block
+                end
+
+                if register
+                    process_server.loader.register_deployment_model(
+                        deployment_model.orogen_model
+                    )
+                end
+                deployment_model
+            end
+
+            # Create a stub device of the given model
+            #
+            # It is created on a new robot instance so that to avoid clashes
+            #
+            # @param [Model<Device>] model the device model
+            # @param [String] as the device name
+            # @param [Model<TaskContext>] driver the driver that should be used.
+            #   If not given, a new driver is stubbed
+            def stub_device(
+                model,
+                driver: stub_driver_model_for(model),
+                robot: Syskit::Robot::RobotDefinition.new,
+                as: default_stub_name,
+                **device_options
+            )
+                robot.device(model, as: as, using: driver, **device_options)
+            end
+
+            # Finds a driver model for a given device model, or create one if
+            # there is none
+            def stub_driver_model_for(model)
+                stub_requirements(model.find_all_drivers.first || model, devices: false)
+            end
+
+            # Create an InstanceRequirement instance that would allow to deploy
+            # the given model
+            def stub_requirements(
+                model,
+                recursive: true, devices: true, as: default_stub_name, &block
+            )
+                if model.respond_to?(:to_str)
+                    model = stub_task_context_model(model, &block)
+                end
+                model = model.to_instance_requirements.dup
+
+                if model.composition_model?
+                    stub_composition_requirements(
+                        model, recursive: recursive, as: as, devices: devices
+                    )
+                else
+                    stub_task_context_requirements(
+                        model, as: as, devices: devices
+                    )
+                end
+            end
+
+            # @api private
+            #
+            # Helper for {#syskit_stub_model}
+            #
+            # @param [InstanceRequirements] model
+            def stub_composition_requirements(
+                model, recursive: true, devices: true, as: default_stub_name
+            )
+                model = stub_component(model, devices: devices)
+                return model unless recursive
+
+                model.each_child do |child_name, selected_child|
+                    if (selected_task = selected_child.component)
+                        deployed_child = selected_task
+                    else
+                        child_model = selected_child.selected
+                        selected_service = child_model.service
+                        child_model = child_model.to_component_model
+                        if child_model.composition_model?
+                            deployed_child = stub_composition_requirements(
+                                child_model,
+                                as: "#{as}_#{child_name}", devices: devices,
+                                recursive: true
+                            )
+                        else
+                            deployed_child = stub_task_context_requirements(
+                                child_model, as: "#{as}_#{child_name}", devices: devices
+                            )
+                        end
+                        if selected_service
+                            deployed_child.select_service(selected_service)
+                        end
+                    end
+                    model.use(child_name => deployed_child)
+                end
+                model
+            end
+
+            # Create a stub combus of the given model
+            #
+            # It is created on a new robot instance so that to avoid clashes
+            #
+            # @param [Model<ComBus>] model the device model
+            # @param [String] as the combus name
+            # @param [Model<TaskContext>] driver the driver that should be used.
+            #   If not given, a new driver is stubbed
+            def stub_com_bus(
+                model, driver: nil, robot: nil, as: default_stub_name,
+                **device_options
+            )
+                robot ||= Syskit::Robot::RobotDefinition.new
+                driver ||= stub_driver_model_for(model)
+                robot.com_bus(model, as: as, using: driver, **device_options)
+            end
+
+            # Create a stub device attached on the given bus
+            #
+            # If the bus is a device object, the new device is attached to the
+            # same robot model. Otherwise, a new robot model is created for both
+            # the bus and the device
+            #
+            # @param [Model<ComBus>,MasterDeviceInstance] bus either a bus model
+            #   or a bus object
+            # @param [String] as a name for the new device
+            # @param [Model<TaskContext>] driver the driver that should be used
+            #   for the device. If not given, syskit will look for a suitable
+            #   driver or stub one
+            def stub_attached_device(
+                bus, as: default_stub_name,
+                client_to_bus: true, bus_to_client: true,
+                base_model: Syskit::Device
+            )
+                unless bus.kind_of?(Robot::DeviceInstance)
+                    bus = stub_com_bus(bus, as: "#{as}_bus")
+                end
+                bus_m = bus.model
+                client_service_m =
+                    if client_to_bus && bus_to_client
+                        bus_m::ClientSrv
+                    elsif client_to_bus
+                        bus_m::ClientOutSrv
+                    elsif bus_to_client
+                        bus_m::ClientInSrv
+                    else
+                        raise ArgumentError, "at least one of client_to_bus or "\
+                                             "bus_to_client need to be true"
+                    end
+
+                dev_m = base_model.new_submodel(name: "#{bus}-stub") do
+                    provides client_service_m
+                end
+                dev = stub_device(dev_m, as: as)
+                dev.attach_to(
+                    bus, client_to_bus: client_to_bus, bus_to_client: bus_to_client
+                )
+                dev
+            end
+
+            # Stubs the devices required by the given model
+            def stub_required_devices(model)
+                model = model.to_instance_requirements
+                model.model.to_component_model.each_master_driver_service do |srv|
+                    unless model.arguments[:"#{srv.name}_dev"]
+                        device_stub = stub_device(srv.model, driver: model.model)
+                        model.with_arguments("#{srv.name}_dev": device_stub)
+                    end
+                end
+                model
+            end
+
+            # @api private
+            #
+            # Helper for {#syskit_stub_requirements}
+            #
+            # @param [InstanceRequirements] task_m the task context model
+            # @param [String] as the deployment name
+            def stub_task_context_requirements(
+                model, as: default_stub_name, devices: true
+            )
+                model = model.to_instance_requirements
+
+                task_m = handle_abstract_component_model_in_requirements(model)
+                model.add_models([task_m])
+                model = stub_component(model, devices: devices)
+
+                stub_conf(task_m, *model.arguments[:conf])
+
+                deployment = stub_configured_deployment(task_m, as)
+                model.reset_deployment_selection
+                model.use_configured_deployment(deployment)
+                model
+            end
+
+            def stub_component(model, devices: true)
+                if devices
+                    stub_required_devices(model)
+                else
+                    model
+                end
+            end
+
+            # @api private
+            #
+            # Compute the concrete task model that should be used to stub an
+            # instance requirement
+            #
+            # @param [InstanceRequirements] model
+            # @return [Models::Component]
+            def handle_abstract_component_model_in_requirements(model)
+                task_m = model.model.to_component_model.concrete_model
+                if task_m.placeholder?
+                    stub_placeholder_model(task_m)
+                elsif task_m.abstract?
+                    stub_abstract_component_model(task_m)
+                else
+                    task_m
+                end
+            end
+
+            # @api private
+            #
+            # Computes a configured deployment suitable to deploy the given task model
+            def stub_configured_deployment(
+                task_model = nil, task_name = default_stub_name, remote_task: false,
+                &block
+            )
+                deployment_model = stub_deployment_model(task_model, task_name, &block)
+
+                process_server = Syskit.conf.process_server_for("stubs")
+                task_context_class =
+                    if remote_task
+                        Orocos::RubyTasks::RemoteTaskContext
+                    else
+                        process_server.task_context_class
+                    end
+
+                Models::ConfiguredDeployment.new(
+                    "stubs", deployment_model, { task_name => task_name }, task_name,
+                    Hash[task_context_class: task_context_class]
+                )
+            end
+
+            def stub_abstract_component_model(component_m)
+                component_m.new_submodel(name: "#{component_m.name}-stub")
+            end
+
+            def stub_placeholder_model(model)
+                superclass = if model.superclass <= Syskit::TaskContext
+                                 model.superclass
+                             else Syskit::TaskContext
+                             end
+
+                services = model.proxied_data_service_models
+                task_m = superclass.new_submodel(name: "#{model}-stub")
+                services.each_with_index do |srv, idx|
+                    srv.each_input_port do |p|
+                        orocos_type_name = Orocos.find_orocos_type_name_by_type(p.type)
+                        task_m.orogen_model.input_port p.name, orocos_type_name
+                    end
+                    srv.each_output_port do |p|
+                        orocos_type_name = Orocos.find_orocos_type_name_by_type(p.type)
+                        task_m.orogen_model.output_port p.name, orocos_type_name
+                    end
+                    if srv <= Syskit::Device
+                        task_m.driver_for srv, as: "dev#{idx}"
+                    else
+                        task_m.provides srv, as: "srv#{idx}"
+                    end
+                end
+                task_m
+            end
+        end
+    end
+end

--- a/lib/syskit/test/task_context_test.rb
+++ b/lib/syskit/test/task_context_test.rb
@@ -7,6 +7,7 @@ module Syskit
             # Overloaded to automatically call {#deploy_subject_syskit_model}
             def setup
                 super
+
                 task_context_m = self.class.subject_syskit_model.concrete_model
                 if app.simulation? || !task_context_m.orogen_model.abstract?
                     @deployed_subject_syskit_model = deploy_subject_syskit_model
@@ -41,7 +42,7 @@ module Syskit
             # Returns the task model under test
             def subject_syskit_model
                 model = self.class.subject_syskit_model
-                model = syskit_stub_required_devices(model)
+                model = @__stubs.stub_required_devices(model)
                 model.prefer_deployed_tasks(@deployed_subject_syskit_model)
                 model
             end

--- a/test/test/test_network_manipulation.rb
+++ b/test/test/test_network_manipulation.rb
@@ -234,6 +234,20 @@ module Syskit
                 end
             end
 
+            describe "#syskit_generate_network" do
+                it "keeps a task's mission status" do
+                end
+
+                it "keeps a task's mission status even if child of a non-Syskit task" do
+                end
+
+                it "keeps a task's permanent status" do
+                end
+
+                it "keeps a task's permanent status even if child of a non-Syskit task" do
+                end
+            end
+
             describe "#syskit_stub_and_deploy" do
                 before do
                     @task_m = Syskit::TaskContext.new_submodel(name: "Test")

--- a/test/test/test_stub_network.rb
+++ b/test/test/test_stub_network.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "syskit/test/self"
+
+module Syskit
+    module Test
+        describe StubNetwork do
+            before do
+                @task_m = Syskit::TaskContext.new_submodel(name: "Task")
+                @srv_m = Syskit::DataService.new_submodel(name: "Srv")
+                @cmp_m = Syskit::Composition.new_submodel(name: "Cmp")
+                @cmp_m.add @srv_m, as: "srv"
+                @stubs = StubNetwork.new(self)
+            end
+
+            it "stubs an abstract task model" do
+                @task_m.abstract
+                plan.add(task = @task_m.instanciate(plan))
+                task = @stubs.apply([task]).first
+
+                refute task.abstract?
+
+                # Make sure that stubbing created a network we can start
+                expect_execution.scheduler(true).to do
+                    start task
+                end
+            end
+
+            it "stubs a composition" do
+                cmp = @stubs.apply([@cmp_m.instanciate(plan)]).first
+                assert_kind_of @cmp_m, cmp
+                assert_kind_of @srv_m, cmp.srv_child
+
+                # Make sure that stubbing created a network we can start
+                expect_execution.scheduler(true).to do
+                    start cmp
+                    start cmp.srv_child
+                end
+            end
+
+            it "stubs data services" do
+                srv_m = Syskit::DataService.new_submodel(name: "Srv") do
+                    input_port "in", "/double"
+                    output_port "out", "/double"
+                end
+                cmp_m = Syskit::Composition.new_submodel do
+                    add srv_m, as: "test"
+                end
+
+                cmp = @stubs.apply([cmp_m.instanciate(plan)]).first
+
+                refute cmp.test_child.abstract?
+                assert cmp.test_child.find_data_service_from_type(srv_m)
+
+                # Make sure that stubbing created a network we can start
+                expect_execution.scheduler(true).to do
+                    start cmp
+                    start cmp.test_child
+                end
+            end
+
+            it "creates a stub device drivers when given a device" do
+                dev_m = Syskit::Device.new_submodel(name: "Dev")
+                dev_m.provides @srv_m
+
+                cmp = @stubs.apply(
+                    [@cmp_m.use("srv" => dev_m).instanciate(plan)]
+                ).first
+                assert_kind_of @cmp_m, cmp
+                assert_kind_of dev_m, cmp.srv_child
+                assert_equal dev_m, cmp.srv_child.dev0_dev.model
+
+                # Make sure that stubbing created a network we can start
+                expect_execution.scheduler(true).to do
+                    start cmp
+                    start cmp.srv_child
+                end
+            end
+
+            it "creates a stub device model for driver tasks" do
+                dev_m = Syskit::Device.new_submodel(name: "Dev")
+                dev_m.provides @srv_m
+                task_m = Syskit::TaskContext.new_submodel(name: "DevDriver")
+                task_m.driver_for dev_m, as: "dev"
+
+                cmp = @stubs.apply(
+                    [@cmp_m.use("srv" => task_m).instanciate(plan)]
+                ).first
+                assert_equal dev_m, cmp.srv_child.dev_dev.model
+
+                # Make sure that stubbing created a network we can start
+                expect_execution.scheduler(true).to do
+                    start cmp
+                    start cmp.srv_child
+                end
+            end
+
+            it "stubs tags" do
+                profile = Syskit::Actions::Profile.new "P"
+                profile.tag "test", @srv_m
+
+                cmp = @stubs.apply(
+                    [@cmp_m.use("srv" => profile.test_tag).instanciate(plan)]
+                ).first
+                assert_kind_of @srv_m, cmp.srv_child
+
+                # Make sure that stubbing created a network we can start
+                expect_execution.scheduler(true).to do
+                    start cmp
+                    start cmp.srv_child
+                end
+            end
+        end
+    end
+end

--- a/test/test/test_stubs.rb
+++ b/test/test/test_stubs.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Syskit
+    module Test
+        describe Stubs do
+        end
+    end
+end

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -976,7 +976,8 @@ module Syskit
 
             it "freezes delayed arguments" do
                 execute { plan.remove_task(task) }
-                task = syskit_stub_network_deployment(TaskContext.new_submodel.new)
+                task = Test::StubNetwork.new(self, stubs: @__stubs)
+                                        .stub_deployment(TaskContext.new_submodel.new)
                 plan.add_permanent_task(task)
                 syskit_start_execution_agents(task)
                 assert_nil task.arguments[:conf]


### PR DESCRIPTION
The predicates will now plan the actions that are non-syskit
(using Roby's own mechanism run_planners) and finally run
the predicate on what's left.