### PR TITLE
test: fix flaky test

### DIFF
--- a/test/network_generation/test_engine.rb
+++ b/test/network_generation/test_engine.rb
@@ -480,6 +480,8 @@ module Syskit
 
                 def create_deployment_model(task_count:)
                     task_m = (0...task_count).map { TaskContext.new_submodel }
+                    (@created_task_models ||= []).concat(task_m)
+
                     Deployment.new_submodel do
                         task_m.each_with_index do |m, i|
                             task "task#{i}", m.orogen_model


### PR DESCRIPTION
The create_deployment_model helper would create the tasks and the
deployments. It turns out that (unexpectedly), Syskit deployment
models would not hold a reference to the corresponding Syskit
task models (it only refers to the orogen objects), and sometimes
the syskit models would be garbage collected before they're needed.

I never saw this in the wild, but I think it is something that
should ultimately be fixed at the deployment level.