### PR TITLE
net_gen: fix merging of networks that have shared task instances

### DIFF
--- a/lib/syskit/network_generation/merge_solver.rb
+++ b/lib/syskit/network_generation/merge_solver.rb
@@ -540,7 +540,11 @@ module Syskit
                     return
                 end
 
-                [sink_port, m_source_task, source_task]
+                if m_source_task == source_task
+                    []
+                else
+                    [sink_port, m_source_task, source_task]
+                end
             end
 
             def merge_identical_tasks


### PR DESCRIPTION
If the merge solver ends up looking at two subnets that share a given task instance, it may (will ?) decide to merge the task onto itself, which triggers a sanity check.

The error was within the "needs merge" determination function, which was not checking for "strictly identical" cases.