### PR TITLE
define deploy_current_plan

### DIFF
--- a/lib/syskit/test/instance_requirement_planning_handler.rb
+++ b/lib/syskit/test/instance_requirement_planning_handler.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require "roby/test/spec"
+require "syskit/test/execution_expectations"
+
+module Syskit
+    module Test # :nodoc:
+        # Planning handler for #roby_run_planner that handles
+        # InstanceRequirementsTask
+        class InstanceRequirementPlanningHandler
+            # @param [Spec] test
+            def initialize(test)
+                @test = test
+            end
+
+            def start(tasks)
+                @plan, @planning_tasks = prepare(tasks)
+
+                starting_tasks = @planning_tasks.find_all do |t|
+                    t.start! if t.pending?
+                    t.starting?
+                end
+                return apply_requirements if starting_tasks.empty?
+
+                starting_tasks.each do |t|
+                    t.start_event.on do |_|
+                        apply_requirements if starting_tasks.all?(&:running?)
+                    end
+                end
+            end
+
+            # @api private
+            #
+            # Validate the argument to {#start} and return the plan and planning
+            # tasks the handler should work on
+            def prepare(tasks)
+                plan = tasks.first.plan
+                planning_tasks = tasks.map do |t|
+                    unless (planning_task = t.planning_task)
+                        raise ArgumentError, "#{t} does not have a planning task"
+                    end
+
+                    planning_task
+                end
+
+                [plan, planning_tasks]
+            end
+
+            def apply_requirements
+                @plan.syskit_start_async_resolution(
+                    @planning_tasks,
+                    validate_generated_network:
+                        @test.syskit_run_planner_validate_network?,
+                    compute_deployments:
+                        @test.syskit_run_planner_deploy_network?
+                )
+            end
+
+            def finished?
+                Thread.pass
+
+                if @plan.syskit_has_async_resolution?
+                    return unless @plan.syskit_finished_async_resolution?
+
+                    error = @plan.syskit_apply_async_resolution_results
+                    return true if error
+                    return unless @test.syskit_run_planner_stub?
+
+                    root_tasks = @planning_tasks.map(&:planned_task)
+                    stub_network = StubNetwork.new(@test)
+
+                    # NOTE: this is a run-planner equivalent to syskit_stub_network
+                    # we will have to investigate whether we could implement one with
+                    # the other (probably), but in the meantime we must keep both
+                    # in sync
+                    mapped_tasks = @plan.in_transaction do |trsc|
+                        mapped_tasks =
+                            stub_network.apply_in_transaction(trsc, root_tasks)
+                        trsc.commit_transaction
+                        mapped_tasks
+                    end
+
+                    stub_network.remove_obsolete_tasks(mapped_tasks)
+                end
+                @planning_tasks.all?(&:finished?)
+            end
+
+            # Module that should be included in all classes meant to use the
+            # run_planners method with Syskit
+            #
+            # It defines the options that allow to tune what happens during
+            # Syskit network generation.
+            module Options
+                def setup
+                    @syskit_run_planner_stub = true
+                    @syskit_run_planner_validate_network = false
+                    @syskit_run_planner_deploy_network = false
+
+                    super
+                end
+
+                # Whether the network should be stubbed, that is any abstract
+                # task, missing device or argument be generated for the duration
+                # of the test
+                #
+                # The default is true
+                def syskit_run_planner_stub?
+                    @syskit_run_planner_stub
+                end
+
+                # Control {#syskit_run_planner_stub?}
+                attr_writer :syskit_run_planner_stub
+
+                # Whether the network should be validated for e.g. duplicate
+                # device use or abstract tasks
+                #
+                # The default is false
+                def syskit_run_planner_validate_network?
+                    @syskit_run_planner_validate_network
+                end
+
+                # Control {#syskit_run_planner_validate_network?}
+                attr_writer :syskit_run_planner_validate_network
+
+                # Whether the network should be deployed
+                #
+                # The default is false
+                def syskit_run_planner_deploy_network?
+                    @syskit_run_planner_deploy_network
+                end
+
+                # Control {#syskit_run_planner_deploy_network?}
+                attr_writer :syskit_run_planner_deploy_network
+
+                # Set deployment and validation option for the duration of its
+                # given block
+                #
+                # @param [Boolean] stub if false, turn off stubbing as well
+                def syskit_run_planner_with_full_deployment(stub: true)
+                    flags = [@syskit_run_planner_deploy_network,
+                             @syskit_run_planner_validate_network,
+                             @syskit_run_planner_stub]
+
+                    @syskit_run_planner_deploy_network = true
+                    @syskit_run_planner_validate_network = true
+                    @syskit_run_planner_stub = stub
+                    yield
+                ensure
+                    @syskit_run_planner_deploy_network,
+                        @syskit_run_planner_validate_network,
+                        @syskit_run_planner_stub = *flags
+                end
+            end
+        end
+        Roby::Test::Spec.roby_plan_with(
+            Component.match.with_child(InstanceRequirementsTask),
+            InstanceRequirementPlanningHandler
+        )
+
+        Roby::Test::ExecutionExpectations.include ExecutionExpectations
+    end
+end

--- a/lib/syskit/test/self.rb
+++ b/lib/syskit/test/self.rb
@@ -3,6 +3,8 @@
 require "syskit/test/base"
 require "roby/test/self"
 require "syskit/test/network_manipulation"
+require "syskit/test/execution_expectations"
+require "syskit/test/spec"
 
 module Syskit
     module Test
@@ -10,8 +12,8 @@ module Syskit
         module Self
             include Roby::Test
             include Roby::Test::Assertions
-            include Test::Base
-            include Test::NetworkManipulation
+            include Base
+            include NetworkManipulation
 
             # A RobotDefinition object that allows to create new device models
             # easily

--- a/lib/syskit/test/spec.rb
+++ b/lib/syskit/test/spec.rb
@@ -1,129 +1,14 @@
 # frozen_string_literal: true
 
 require "roby/test/spec"
+require "syskit/test/base"
+require "syskit/test/instance_requirement_planning_handler"
 
 module Syskit
     module Test
-        # Planning handler for #roby_run_planner that handles
-        # InstanceRequirementsTask
-        class InstanceRequirementPlanningHandler
-            # @param [Spec] test
-            def initialize(test)
-                @test = test
-            end
-
-            def start(tasks)
-                @plan = tasks.first.plan
-                @planning_tasks = tasks.map do |t|
-                    unless (planning_task = t.planning_task)
-                        raise ArgumentError, "#{t} does not have a planning task"
-                    end
-
-                    planning_task
-                end
-
-                starting_tasks = @planning_tasks.find_all do |t|
-                    t.start! if t.pending?
-                    t.starting?
-                end
-                return apply_requirements if starting_tasks.empty?
-
-                starting_tasks.each do |t|
-                    t.start_event.on do |_|
-                        apply_requirements if starting_tasks.all?(&:running?)
-                    end
-                end
-            end
-
-            def apply_requirements
-                @plan.syskit_start_async_resolution(
-                    @planning_tasks,
-                    validate_generated_network:
-                        @test.syskit_run_planner_validate_network?,
-                    compute_deployments:
-                        @test.syskit_run_planner_deploy_network?
-                )
-            end
-
-            def finished?
-                if @plan.syskit_has_async_resolution?
-                    return unless @plan.syskit_finished_async_resolution?
-
-                    @plan.syskit_apply_async_resolution_results
-                    return unless @test.syskit_run_planner_stub?
-
-                    root_tasks = @planning_tasks.map(&:planned_task)
-                    stub_network = StubNetwork.new(@test)
-
-                    # NOTE: this is a run-planner equivalent to syskit_stub_network
-                    # we will have to investigate whether we could implement one with
-                    # the other (probably), but in the meantime we must keep both
-                    # in sync
-                    mapped_tasks = @plan.in_transaction do |trsc|
-                        mapped_tasks =
-                            stub_network.apply_in_transaction(trsc, root_tasks)
-                        trsc.commit_transaction
-                        mapped_tasks
-                    end
-
-                    stub_network.remove_obsolete_tasks(mapped_tasks)
-                end
-                @planning_tasks.all?(&:finished?)
-            end
-        end
-        Roby::Test::Spec.roby_plan_with(
-            Component.match.with_child(InstanceRequirementsTask),
-            InstanceRequirementPlanningHandler
-        )
-
-        Roby::Test::ExecutionExpectations.include ExecutionExpectations
-
-        module InstanceRequirementPlanningHandlerOptions
-            def setup
-                @syskit_run_planner_stub = true
-                @syskit_run_planner_validate_network = false
-                @syskit_run_planner_deploy_network = false
-
-                super
-            end
-
-            def syskit_run_planner_stub?
-                @syskit_run_planner_stub
-            end
-
-            attr_writer :syskit_run_planner_stub
-
-            def syskit_run_planner_validate_network?
-                @syskit_run_planner_validate_network
-            end
-
-            attr_writer :syskit_run_planner_validate_network
-
-            def syskit_run_planner_deploy_network?
-                @syskit_run_planner_deploy_network
-            end
-
-            attr_writer :syskit_run_planner_deploy_network
-
-            def syskit_run_planner_with_full_deployment(stub: true)
-                flags = [@syskit_run_planner_deploy_network,
-                         @syskit_run_planner_validate_network,
-                         @syskit_run_planner_stub]
-
-                @syskit_run_planner_deploy_network = true
-                @syskit_run_planner_validate_network = true
-                @syskit_run_planner_stub = stub
-                yield
-            ensure
-                @syskit_run_planner_deploy_network,
-                    @syskit_run_planner_validate_network,
-                    @syskit_run_planner_stub = *flags
-            end
-        end
-
         class Spec < Roby::Test::Spec
             include Test::Base
-            include InstanceRequirementPlanningHandlerOptions
+            include InstanceRequirementPlanningHandler::Options
 
             def setup
                 NetworkGeneration::Engine.on_error = :save

--- a/test/test/test_spec.rb
+++ b/test/test/test_spec.rb
@@ -6,7 +6,7 @@ require "syskit/test"
 module Syskit
     module Test
         describe InstanceRequirementPlanningHandler do
-            include InstanceRequirementPlanningHandlerOptions
+            include InstanceRequirementPlanningHandler::Options
 
             before do
                 @task_m = Syskit::TaskContext.new_submodel(name: "Task")

--- a/test/test/test_spec.rb
+++ b/test/test/test_spec.rb
@@ -6,6 +6,8 @@ require "syskit/test"
 module Syskit
     module Test
         describe InstanceRequirementPlanningHandler do
+            include InstanceRequirementPlanningHandlerOptions
+
             before do
                 @task_m = Syskit::TaskContext.new_submodel(name: "Task")
                 @srv_m = Syskit::DataService.new_submodel(name: "Srv")
@@ -80,6 +82,48 @@ module Syskit
                     start cmp
                     start cmp.srv_child
                 end
+            end
+
+            it "handles a planning error" do
+                plan.add(cmp = @cmp_m.as_plan)
+
+                error = syskit_run_planner_with_full_deployment do
+                    expect_execution { cmp = run_planners(cmp) }
+                        .to { have_error_matching Roby::PlanningFailedError.match }
+                end
+
+                assert_equal cmp.to_task, error.origin
+            end
+
+            it "optionally attempts to deploy the network" do
+                plan.add(cmp = @cmp_m.as_plan)
+
+                syskit_run_planner_with_full_deployment do
+                    assert syskit_run_planner_deploy_network?
+                    assert syskit_run_planner_validate_network?
+                    assert syskit_run_planner_stub?
+
+                    expect_execution { run_planners(cmp) }
+                        .to { have_error_matching Roby::PlanningFailedError.match }
+                end
+                refute syskit_run_planner_deploy_network?
+                refute syskit_run_planner_validate_network?
+                assert syskit_run_planner_stub?
+            end
+
+            it "stubs the result by default" do
+                plan.add(cmp = @cmp_m.as_plan)
+
+                cmp = run_planners(cmp)
+                refute cmp.srv_child.abstract?
+            end
+
+            it "optionally does not stub the result" do
+                plan.add(cmp = @cmp_m.as_plan)
+
+                self.syskit_run_planner_stub = false
+                cmp = run_planners(cmp)
+                assert cmp.srv_child.abstract?
             end
 
             PlanningState = Struct.new(


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-roby/pull/181

It runs the deployer on the complete plan. It uses run_planners,
and is therefore able to run method or state machine actions
before it checks for the deployment state.

It returns a mapping from the missions as they currently are to
the deployed missions

