### PR TITLE
test: fix components not being properly tracked by plan services during stubbing

### DIFF
--- a/lib/syskit/test/instance_requirement_planning_handler.rb
+++ b/lib/syskit/test/instance_requirement_planning_handler.rb
@@ -80,6 +80,7 @@ module Syskit
                         mapped_tasks
                     end
 
+                    stub_network.announce_replacements(mapped_tasks)
                     stub_network.remove_obsolete_tasks(mapped_tasks)
                 end
                 @planning_tasks.all?(&:finished?)

--- a/lib/syskit/test/stub_network.rb
+++ b/lib/syskit/test/stub_network.rb
@@ -50,6 +50,7 @@ module Syskit
                 end
 
                 @test.execute do
+                    announce_replacements(mapped_tasks)
                     remove_obsolete_tasks(mapped_tasks)
                 end
                 root_tasks.map { |t, _| mapped_tasks[t] }
@@ -149,6 +150,16 @@ module Syskit
             def remove_obsolete_tasks(mapped_tasks)
                 mapped_tasks.each do |old, new|
                     @plan.remove_task(old) if old != new
+                end
+            end
+
+            # @api private
+            #
+            # Call Plan#replaced for stubbed tasks so that they can be tracked with
+            # plan services
+            def announce_replacements(mapped_tasks)
+                mapped_tasks.each do |old, new|
+                    @plan.replaced(old, new) if old != new
                 end
             end
 

--- a/test/test/test_stub_network.rb
+++ b/test/test/test_stub_network.rb
@@ -59,6 +59,24 @@ module Syskit
                 end
             end
 
+            it "lets toplevel tasks be tracked using plan services" do
+                task = @cmp_m.instanciate(plan)
+                service = task.as_service
+                final = @stubs.apply([task]).first
+
+                assert_same final, service.to_task
+            end
+
+            it "lets non-toplevel tasks be tracked using plan services" do
+                task = @cmp_m.instanciate(plan)
+                task_child = task.srv_child
+                service = task_child.as_service
+                final = @stubs.apply([task]).first
+
+                refute_same task_child, task.srv_child
+                assert_same final.srv_child, service.to_task
+            end
+
             it "creates a stub device drivers when given a device" do
                 dev_m = Syskit::Device.new_submodel(name: "Dev")
                 dev_m.provides @srv_m


### PR DESCRIPTION
The components' replacement would not be propagated, which leads to
the plan services not tracking them properly.

Plan services are in particular used by the Syskit `run_planners` handler to track what is being deployed.
This fixes `deploy_current_plan` when some missions become children of others during deployment.