### PR TITLE
net_gen: carry options passed to Async.start/.prepare to the apply step

### DIFF
--- a/test/network_generation/test_async.rb
+++ b/test/network_generation/test_async.rb
@@ -70,7 +70,12 @@ module Syskit
                     engine = flexmock(resolution.engine, :strict)
                     engine.should_receive(:resolve_system_network)
                           .with(requirements, any).once.and_return(ret = flexmock)
-                    engine.should_receive(:apply_system_network_to_plan).with(ret).once
+
+                    if RUBY_VERSION >= "2.7"
+                        engine.should_receive(:apply_system_network_to_plan).with(ret).once
+                    else
+                        engine.should_receive(:apply_system_network_to_plan).with(ret, {}).once
+                    end
                     resolution.execute
                     subject.join
                     assert subject.finished?

--- a/test/network_generation/test_async.rb
+++ b/test/network_generation/test_async.rb
@@ -70,8 +70,24 @@ module Syskit
                     engine = flexmock(resolution.engine, :strict)
                     engine.should_receive(:resolve_system_network)
                           .with(requirements, any).once.and_return(ret = flexmock)
+                    engine.should_receive(:apply_system_network_to_plan).with(ret).once
+                    resolution.execute
+                    subject.join
+                    assert subject.finished?
+                    subject.apply
+                end
+
+                it "carries forward options passed to prepare "\
+                   "that are relevant to the apply step" do
+                    requirements = Set[flexmock]
+                    resolution = subject.prepare(
+                        requirements, compute_deployments: false
+                    )
+                    engine = flexmock(resolution.engine, :strict)
+                    engine.should_receive(:resolve_system_network)
+                          .with(requirements, any).once.and_return(ret = flexmock)
                     engine.should_receive(:apply_system_network_to_plan)
-                          .with(ret).once
+                          .with(ret, compute_deployments: false).once
                     resolution.execute
                     subject.join
                     assert subject.finished?


### PR DESCRIPTION
Some of these options (namely, compute_deployments) control whether
apply has to finalize things that were prepared in the async phase.
When set incorrectly, they can lead to failures in the deployment
phase.

Note that this does not impact the normal flow (as it uses only
default options, which are coherent). It led to failures during
tests.