### PR TITLE
rework Deployment's stop handling

### DIFF
--- a/lib/syskit/deployment.rb
+++ b/lib/syskit/deployment.rb
@@ -16,7 +16,7 @@ module Syskit
     # of task contexts. This Roby task represents the unix process itself.
     # Once it gets instanciated, the associated task contexts can be
     # accessed with #task(name)
-    class Deployment < ::Roby::Task
+    class Deployment < ::Roby::Task # rubocop:disable Metrics/ClassLength
         extend Models::Deployment
         extend Logger::Hierarchy
         include Logger::Hierarchy
@@ -692,37 +692,80 @@ module Syskit
         end
 
         ##
+        # method: kill!
+        #
+        # Hard-kill the process, without attempting to stop or cleanup the tasks
+        # it supports
+        event :kill, terminal: true do |_context|
+            remote_task_handles = stop_prepare
+            promise = self.promise(description: "#{self}#kill")
+            stop_kill(promise, remote_task_handles)
+            stop_event.achieve_asynchronously(promise, emit_on_success: false)
+        end
+
+        ##
         # method: stop!
         #
         # Stops all tasks that are running on top of this deployment, and
         # kill the deployment
         event :stop do |_context|
+            remote_task_handles = stop_prepare
+            promise = self.promise(description: "#{self}#stop")
+
+            # This is a heuristic added after the introduction of the kill
+            # event command. It's meant to guess whether the caller is trying
+            # to kill or cleanly stop the deployment. We basically assume
+            # 'kill' if some executed tasks are still in the plan (meaning it's
+            # not being stopped through garbage collection)
+            if each_executed_task.any? { true }
+                stop_kill(promise, remote_task_handles)
+            else
+                stop_cleanly(promise, remote_task_handles)
+            end
+
+            stop_event.achieve_asynchronously(promise, emit_on_success: false)
+        end
+
+        def stop_prepare
             quit_ready_event_monitor.set
-            promise = execution_engine.promise(description: "#{self}.stop_event.on") do
-                begin
-                    remote_task_handles.each_value do |remote_task|
-                        remote_task.state_getter.disconnect
+            remote_task_handles = self.remote_task_handles.dup
+            remote_task_handles.each_value do |remote_task|
+                remote_task.state_getter.disconnect
+            end
+            remote_task_handles
+        end
+
+        def stop_cleanly(promise, remote_task_handles)
+            promise.then(description: "#{self}.stop_event - cleaning RTT tasks") do
+                remote_task_handles.each_value do |remote_task|
+                    begin
                         if remote_task.handle.rtt_state == :STOPPED
                             remote_task.handle.cleanup(false)
                         end
+                    rescue Orocos::ComError
+                        # Assume that the process is killed as it is not reachable
                     end
-                    remote_task_handles.each_value do |remote_task|
-                        remote_task.state_getter.join
-                    end
-                rescue Orocos::ComError
-                    # Assume that the process is killed as it is not reachable
                 end
-            end.on_success(description: "#{self}#stop_event#command#dead!") do
+            end
+
+            stop_kill(promise, remote_task_handles, hard: false)
+        end
+
+        def stop_kill(promise, remote_task_handles, hard: true)
+            promise.then(description: "#{self}.stop_event - join state getters") do
+                remote_task_handles.each_value do |remote_task|
+                    remote_task.state_getter.join
+                end
+            end.on_success(description: "#{self}#stop_event - kill") do
                 ready_to_die!
                 begin
-                    orocos_process.kill(false)
+                    orocos_process.kill(false, cleanup: false, hard: hard)
                 rescue Orocos::ComError
                     # The underlying process server cannot be reached. Just emit
                     # failed ourselves
                     dead!(nil)
                 end
             end
-            stop_event.achieve_asynchronously(promise, emit_on_success: false)
         end
 
         # Called when the process is finished.

--- a/lib/syskit/roby_app/unmanaged_process.rb
+++ b/lib/syskit/roby_app/unmanaged_process.rb
@@ -159,7 +159,7 @@ module Syskit
             # "Kill" this process
             #
             # It shuts down the tasks that are part of it
-            def kill(wait = false)
+            def kill(_wait = false, **)
                 # Announce we're quitting to #monitor_thread. It's used in
                 # #dead? directly if there is no monitoring thread
                 @quitting.set


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-orocosrb/pull/138

The current implementation of Deployment's stop command was a
hornet's nest. Really. No kidding. It would basically have a 50-50
chance to do something wrong if called outside the normal flow (i.e.
outside of Roby's garbage collection mechanism)

1. STOPPED/RUNNING race condition

The cleanup loop was testing for rtt_state to check if the task
is STOPPED before attempting to clean it up. If, at the same time,
Syskit is itself trying to configure or start it, this races.
It would sometime abort the deployment's stop.

2. Blocking behavior because of task cleanup

The current flow would cleanup the tasks *and* let the orocos.rb's
implementation of Process also clean them up. It's OK-ish in normal
circumstances, but is rather obviously sub-optimal in basically
every non-nominal situation.

Syskit does assume that tasks should already be stopped before
reaching Deployment#stop. This is why we only check for cleaning
up tasks that are in STOPPED state. orocos.rb does not and also
attempts to stop them. This basically means that Process#kill
might block (and block Syskit) for an indefinite amount of time.

However, we do need to cleanup components before we stop the process
in the nominal situation. So, to account for both, the following
has been implemented:

- the stop! command "guesses" whether it is in a nominal and non-nominal
  situation by checking whether the deployment still supports tasks
  in the plan (i.e. whether we're in something that looks like an
  orderly shutdown or an emergency one)
- If there are tasks in the plan, we assume stop! was called to kill
  the deployment quickly (emergency !) and thus we bypass the cleanup.
  We also call kill with the new 'hard' argument to true (which
  internally causes the process to be SIGKILL'ed)
- If it does not, we assume stop! was called in the normal workflow
  and attempt to cleanup (in Syskit, not in orocos.rb)
- A new 'kill' event may be used to force the usage of the kill workflow.