### PR TITLE
test: implement together_with argument for assert_can_instanciate and _deploy

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -107,7 +107,6 @@ Layout/LineLength:
     - 'lib/syskit/task_configuration_manager.rb'
     - 'lib/syskit/task_context.rb'
     - 'lib/syskit/test/base.rb'
-    - 'lib/syskit/test/profile_assertions.rb'
     - 'lib/syskit/test/profile_test.rb'
     - 'lib/syskit/test/ruby_task_context_test.rb'
     - 'lib/syskit/test/self.rb'
@@ -294,7 +293,6 @@ Lint/RescueException:
     - 'lib/syskit/runtime/update_deployment_states.rb'
     - 'lib/syskit/task_context.rb'
     - 'lib/syskit/test/base.rb'
-    - 'lib/syskit/test/profile_assertions.rb'
     - 'lib/syskit/test/self.rb'
 
 # Offense count: 11
@@ -307,7 +305,6 @@ Lint/ShadowingOuterLocalVariable:
     - 'lib/syskit/gui/runtime_state.rb'
     - 'lib/syskit/models/deployment.rb'
     - 'lib/syskit/models/specialization_manager.rb'
-    - 'lib/syskit/test/profile_assertions.rb'
     - 'test/models/test_specialization_manager.rb'
 
 # Offense count: 16
@@ -386,7 +383,6 @@ Lint/UnusedMethodArgument:
     - 'lib/syskit/test/base.rb'
     - 'lib/syskit/test/execution_expectations.rb'
     - 'lib/syskit/test/network_manipulation.rb'
-    - 'lib/syskit/test/profile_assertions.rb'
     - 'test/test_deployment.rb'
 
 # Offense count: 184
@@ -407,7 +403,6 @@ Lint/UselessAssignment:
     - 'lib/syskit/scripts/ide.rb'
     - 'lib/syskit/scripts/instanciate.rb'
     - 'lib/syskit/scripts/instanciate_gui.rb'
-    - 'lib/syskit/test/profile_assertions.rb'
     - 'test/actions/test_interface_model_extension.rb'
     - 'test/coordination/test_data_monitoring_table.rb'
     - 'test/coordination/test_task_script.rb'
@@ -944,7 +939,6 @@ Style/Documentation:
     - 'lib/syskit/test/execution_expectations.rb'
     - 'lib/syskit/test/flexmock_extension.rb'
     - 'lib/syskit/test/network_manipulation.rb'
-    - 'lib/syskit/test/profile_assertions.rb'
     - 'lib/syskit/test/ruby_task_context_test.rb'
     - 'lib/syskit/test/self.rb'
     - 'lib/syskit/test/spec.rb'
@@ -1057,7 +1051,6 @@ Style/GuardClause:
     - 'lib/syskit/test/action_interface_test.rb'
     - 'lib/syskit/test/action_test.rb'
     - 'lib/syskit/test/component_test.rb'
-    - 'lib/syskit/test/profile_assertions.rb'
     - 'lib/syskit/test/profile_test.rb'
     - 'lib/syskit/test/task_context_test.rb'
     - 'lib/yard-syskit.rb'
@@ -1161,7 +1154,6 @@ Style/IfUnlessModifier:
     - 'lib/syskit/task_context.rb'
     - 'lib/syskit/test/base.rb'
     - 'lib/syskit/test/flexmock_extension.rb'
-    - 'lib/syskit/test/profile_assertions.rb'
     - 'lib/syskit/test/self.rb'
     - 'lib/yard-syskit.rb'
     - 'test/network_generation/test_async.rb'
@@ -1227,7 +1219,6 @@ Style/RedundantBegin:
     - 'lib/syskit/runtime/connection_management.rb'
     - 'lib/syskit/shell_interface.rb'
     - 'lib/syskit/task_context.rb'
-    - 'lib/syskit/test/profile_assertions.rb'
     - 'lib/syskit/test/self.rb'
     - 'test/coordination/test_task_script.rb'
     - 'test/models/test_composition.rb'

--- a/lib/syskit/test/profile_assertions.rb
+++ b/lib/syskit/test/profile_assertions.rb
@@ -102,11 +102,15 @@ module Syskit
                 end
 
                 actions.each do |act|
-                    syskit_assert_action_is_self_contained(act, **instanciate_options)
+                    syskit_assert_action_is_self_contained(
+                        act, message: message, **instanciate_options
+                    )
                 end
             end
 
-            def syskit_assert_action_is_self_contained(action, **instanciate_options)
+            def syskit_assert_action_is_self_contained(
+                action, message: "%s is not self contained", **instanciate_options
+            )
                 self.assertions += 1
                 syskit_engine = Syskit::NetworkGeneration::Engine.new(plan)
                 task = syskit_deploy(

--- a/test/test/test_profile_assertions.rb
+++ b/test/test/test_profile_assertions.rb
@@ -62,6 +62,11 @@ module Syskit
                         e.message
                     )
                 end
+
+                it "handles plain instance requirements" do
+                    @test_profile.tag "test", @srv_m
+                    assert_is_self_contained(@cmp_m.use(@srv_m => @test_profile.test_tag))
+                end
             end
 
             describe "assert_can_instanciate" do
@@ -119,6 +124,21 @@ module Syskit
                         /cannot find a concrete implementation.*profile:Other.test_tag/m,
                         e.message
                     )
+                end
+
+                it "handles plain instance requirements" do
+                    assert_can_instanciate(@cmp_m.use(@srv_m => @task_m))
+                end
+
+                it "allows deploying together with the actions or profile" do
+                    @task_m.argument :bla
+                    @test_profile.define "test", @cmp_m.use(@srv_m => @task_m)
+                    assert_can_instanciate(
+                        @test_profile, together_with: @task_m.with_arguments(bla: 9)
+                    ) do
+                        t = plan.find_tasks(@cmp_m).first.test_child
+                        assert_equal 9, t.bla
+                    end
                 end
             end
 
@@ -192,6 +212,24 @@ module Syskit
                     assert_match(
                         /cannot find a concrete implementation.*profile:Other.test_tag/m,
                         e.message
+                    )
+                end
+
+                it "handles plain instance requirements" do
+                    assert_can_deploy(
+                        @cmp_m
+                        .to_instance_requirements
+                        .use_deployment(@deployment_m)
+                        .use(@srv_m => @task_m)
+                    )
+                end
+
+                it "allows deploying together with the actions or profile" do
+                    @test_profile.define("test", @cmp_m.use(@srv_m => @task_m))
+                    assert_can_deploy(
+                        @test_profile.test_def,
+                        together_with: @task_m.to_instance_requirements
+                                              .use_deployment(@deployment_m)
                     )
                 end
             end

--- a/test/test/test_profile_assertions.rb
+++ b/test/test/test_profile_assertions.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require "syskit/test/self"
+require "syskit/test"
+
+module Syskit
+    module Test
+        describe ProfileAssertions do
+            before do
+                @cmp_m = Syskit::Composition.new_submodel(name: "Cmp")
+                @task_m = Syskit::TaskContext.new_submodel(name: "Task")
+                @srv_m = Syskit::DataService.new_submodel(name: "Srv")
+                @task_m.provides @srv_m, as: "test"
+                @cmp_m.add @task_m, as: "child"
+                @cmp_m.add @srv_m, as: "test"
+            end
+
+            describe "assert_is_self_contained" do
+                include ProfileAssertions
+
+                # Needed by ProfileAssertions
+                attr_reader :subject_syskit_model
+
+                before do
+                    @test_profile = Actions::Profile.new
+                    @subject_syskit_model = @test_profile
+                end
+
+                it "passes for definitions that have no services" do
+                    @test_profile.define "test", @cmp_m.use(@srv_m => @task_m)
+                    assert_is_self_contained(@test_profile)
+                end
+
+                it "passes for definitions whose services are represented by tags" do
+                    @test_profile.tag "test", @srv_m
+                    @test_profile.define(
+                        "test", @cmp_m.use(@srv_m => @test_profile.test_tag)
+                    )
+                    assert_is_self_contained(@test_profile)
+                end
+
+                it "fails for definitions with abstract elements that are not tags" do
+                    @test_profile.define "test", @cmp_m
+                    e = assert_raises(ProfileAssertions::ProfileAssertionFailed) do
+                        assert_is_self_contained(@test_profile)
+                    end
+                    assert_match(/test_def.*is not self contained/, e.message)
+                end
+
+                it "fails for definitions that use tags from other profiles" do
+                    other_profile = Actions::Profile.new
+                    other_profile.tag "test", @srv_m
+                    @test_profile.define(
+                        "test", @cmp_m.use(@srv_m => other_profile.test_tag)
+                    )
+
+                    e = assert_raises(ProfileAssertions::ProfileAssertionFailed) do
+                        assert_is_self_contained(@test_profile)
+                    end
+                    assert_match(
+                        /test_def.*contains tags from another profile/,
+                        e.message
+                    )
+                end
+            end
+
+            describe "assert_can_instanciate" do
+                include ProfileAssertions
+
+                # Needed by ProfileAssertions
+                attr_reader :subject_syskit_model
+
+                before do
+                    @test_profile = Actions::Profile.new("TestProfile")
+                    @subject_syskit_model = @test_profile
+                end
+
+                it "passes for definitions that have no services or tags" do
+                    @test_profile.define "test", @cmp_m.use(@srv_m => @task_m)
+                    assert_can_instanciate(@test_profile)
+                end
+
+                it "fails for definitions whose services are represented by tags" do
+                    @test_profile.tag "test", @srv_m
+                    @test_profile.define(
+                        "test", @cmp_m.use(@srv_m => @test_profile.test_tag)
+                    )
+                    e = assert_raises(ProfileAssertions::ProfileAssertionFailed) do
+                        assert_can_instanciate(@test_profile)
+                    end
+                    assert_match(
+                        /cannot\ find\ a\ concrete\ implementation.*
+                         TestProfile.test_tag/mx, e.message
+                    )
+                end
+
+                it "fails for definitions with abstract elements that are not tags" do
+                    @test_profile.define "test", @cmp_m
+                    e = assert_raises(ProfileAssertions::ProfileAssertionFailed) do
+                        assert_can_instanciate(@test_profile)
+                    end
+                    assert_match(
+                        /cannot\ find\ a\ concrete\ implementation.*
+                         Models::Placeholder<Srv>/mx, e.message
+                    )
+                end
+
+                it "fails for definitions that use tags from other profiles" do
+                    other_profile = Actions::Profile.new("Other")
+                    other_profile.tag "test", @srv_m
+                    @test_profile.define(
+                        "test", @cmp_m.use(@srv_m => other_profile.test_tag)
+                    )
+
+                    e = assert_raises(ProfileAssertions::ProfileAssertionFailed) do
+                        assert_can_instanciate(@test_profile)
+                    end
+                    assert_match(
+                        /cannot find a concrete implementation.*profile:Other.test_tag/m,
+                        e.message
+                    )
+                end
+            end
+
+            describe "assert_can_deploy" do
+                include ProfileAssertions
+
+                # Needed by ProfileAssertions
+                attr_reader :subject_syskit_model
+
+                before do
+                    @test_profile = Actions::Profile.new("TestProfile")
+                    @deployment_m = syskit_stub_deployment_model(@task_m)
+                    @subject_syskit_model = @test_profile
+                end
+
+                it "passes for definitions that refer to deployed tasks" do
+                    @test_profile.use_deployment @deployment_m
+                    @test_profile.define(
+                        "test", @cmp_m.use(@srv_m => @task_m)
+                    )
+                    assert_can_deploy(@test_profile)
+                end
+
+                it "fails for definitions that have tasks that are not deployed" do
+                    @test_profile.define "test", @cmp_m.use(@srv_m => @task_m)
+                    e = assert_raises(ProfileAssertions::ProfileAssertionFailed) do
+                        assert_can_deploy(@test_profile)
+                    end
+
+                    assert_match(
+                        /cannot deploy the following tasks.*Task.*child test of Cmp/m,
+                        e.message
+                    )
+                end
+
+                it "fails for definitions whose services are represented by tags" do
+                    @test_profile.tag "test", @srv_m
+                    @test_profile.define(
+                        "test", @cmp_m.use(@srv_m => @test_profile.test_tag)
+                    )
+                    e = assert_raises(ProfileAssertions::ProfileAssertionFailed) do
+                        assert_can_deploy(@test_profile)
+                    end
+                    assert_match(
+                        /cannot\ find\ a\ concrete\ implementation.*
+                         TestProfile.test_tag/mx, e.message
+                    )
+                end
+
+                it "fails for definitions with abstract elements that are not tags" do
+                    @test_profile.define "test", @cmp_m
+                    e = assert_raises(ProfileAssertions::ProfileAssertionFailed) do
+                        assert_can_deploy(@test_profile)
+                    end
+                    assert_match(
+                        /cannot\ find\ a\ concrete\ implementation.*
+                         Models::Placeholder<Srv>/mx, e.message
+                    )
+                end
+
+                it "fails for definitions that use tags from other profiles" do
+                    other_profile = Actions::Profile.new("Other")
+                    other_profile.tag "test", @srv_m
+                    @test_profile.define(
+                        "test", @cmp_m.use(@srv_m => other_profile.test_tag)
+                    )
+
+                    e = assert_raises(ProfileAssertions::ProfileAssertionFailed) do
+                        assert_can_deploy(@test_profile)
+                    end
+                    assert_match(
+                        /cannot find a concrete implementation.*profile:Other.test_tag/m,
+                        e.message
+                    )
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
ProfileAssertion iterates on the first argument to the assertion, i.e.
tests them in isolation. There was so far no way to test "check that
this or these actions can be deployed/instanciated along with this/these
other actions and compositions.

This can be used e.g. to test that "permanent services" that always
run do not interfere with the deployment of definitions from other
profiles.