### PR TITLE
fix replacement of a placeholder task

### DIFF
--- a/lib/syskit/placeholder.rb
+++ b/lib/syskit/placeholder.rb
@@ -22,5 +22,66 @@ module Syskit
         def provided_models
             [model.proxied_component_model, model.proxied_data_service_models]
         end
+
+        # @api private
+        #
+        # Create a port mapping hash to replace self by object
+        #
+        # @return [{String=>String}]
+        # @raise AmbiguousPortOnCompositeModel if two of the proxied services have
+        #   ports with the same name. We can't port-map in this case.
+        def find_replacement_port_mappings(object)
+            provided_models.flatten.inject({}) do |mappings, m|
+                mappings.merge(object.model.port_mappings_for(m)) do |k, _|
+                    raise AmbiguousPortOnCompositeModel,
+                          "#{self}'s #{k} port is ambiguous, cannot port-map to #{object}"
+                end
+            end
+        end
+
+        # @api private
+        #
+        # Hook into the replacement computations to apply port mappings from services
+        # to tasks
+        def compute_task_replacement_operation(object, filter)
+            mapping = find_replacement_port_mappings(object)
+            added, removed = super
+            [map_replacement_ports(object, added, mapping), removed]
+        end
+
+        # @api private
+        #
+        # Hook into the replacement computations to apply port mappings from services
+        # to tasks
+        def compute_subplan_replacement_operation(object, filter)
+            mapping = find_replacement_port_mappings(object)
+            added, removed = super
+            [map_replacement_ports(object, added, mapping), removed]
+        end
+
+        # @api private
+        #
+        # Transform the 'added' replacement operations to apply port mappings
+        def map_replacement_ports(object, added, mapping)
+            added.map do |op|
+                next(op) unless op[0].kind_of?(Syskit::Flows::DataFlow)
+
+                g, source, sink, connections = *op
+                connections =
+                    if source == object
+                        connections.transform_keys do |source_port, sink_port|
+                            [mapping.fetch(source_port), sink_port]
+                        end
+                    elsif sink == object
+                        connections.transform_keys do |source_port, sink_port|
+                            [source_port, mapping.fetch(sink_port)]
+                        end
+                    else
+                        raise
+                    end
+
+                [g, source, sink, connections]
+            end
+        end
     end
 end

--- a/test/test_placeholder.rb
+++ b/test/test_placeholder.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "syskit/test/self"
+
+module Syskit
+    describe Placeholder do
+        before do
+            @srv_out_m = Syskit::DataService.new_submodel { output_port "out", "/double" }
+            @srv_in_m = Syskit::DataService.new_submodel { input_port "in", "/double" }
+        end
+
+        describe "handling of replacements" do
+            before do
+                @parent_task_m = Syskit::TaskContext.new_submodel do
+                    input_port "in_parent_task", "/float"
+                    output_port "out_parent_task", "/float"
+                end
+                @task_m = @parent_task_m.new_submodel do
+                    input_port "in_task", "/double"
+                    output_port "out_task", "/double"
+                end
+                @task_m.provides @srv_out_m, as: "out"
+                @task_m.provides @srv_in_m, as: "in"
+
+                @cmp_m = Syskit::Composition.new_submodel
+                @cmp_m.add @task_m, as: "task"
+                @cmp_m.add @srv_out_m, as: "out_test"
+                @cmp_m.add @srv_in_m, as: "in_test"
+
+                @cmp_m.task_child.out_task_port.connect_to @cmp_m.in_test_child.in_port
+                @cmp_m.out_test_child.out_port.connect_to @cmp_m.task_child.in_task_port
+                @cmp = @cmp_m.instanciate(plan)
+            end
+
+            describe "#replace_task" do
+                it "port-maps when replacing a placeholder for only data services" do
+                    plan.add(task = @task_m.new)
+                    plan.replace_task(@cmp.out_test_child, task)
+                    plan.replace_task(@cmp.in_test_child, task)
+
+                    assert task.out_task_port.connected_to?(@cmp.task_child.in_task_port)
+                    assert @cmp.task_child.out_task_port.connected_to?(task.in_task_port)
+                end
+
+                it "port-maps when replacing a placeholder that has a component base" do
+                    cmp_m = @cmp_m.new_submodel
+                    cmp_m.overload "out_test", @parent_task_m
+                    cmp_m.overload "in_test", @parent_task_m
+                    cmp_m.task_child.out_parent_task_port
+                         .connect_to cmp_m.in_test_child.in_parent_task_port
+                    cmp_m.out_test_child.out_parent_task_port
+                         .connect_to cmp_m.task_child.in_parent_task_port
+
+                    cmp = cmp_m.instanciate(plan)
+
+                    plan.add(task = @task_m.new)
+                    plan.replace_task(cmp.out_test_child, task)
+                    plan.replace_task(cmp.in_test_child, task)
+
+                    assert task.out_parent_task_port.connected_to?(
+                        cmp.task_child.in_parent_task_port
+                    )
+                    assert cmp.task_child.out_parent_task_port.connected_to?(
+                        task.in_parent_task_port
+                    )
+                    assert task.out_task_port.connected_to?(cmp.task_child.in_task_port)
+                    assert cmp.task_child.out_task_port.connected_to?(task.in_task_port)
+                end
+            end
+
+            describe "#replace" do
+                it "port-maps when replacing a placeholder for only data services" do
+                    plan.add(task = @task_m.new)
+                    plan.replace(@cmp.out_test_child, task)
+                    plan.replace(@cmp.in_test_child, task)
+
+                    assert task.out_task_port.connected_to?(@cmp.task_child.in_task_port)
+                    assert @cmp.task_child.out_task_port.connected_to?(task.in_task_port)
+                end
+
+                it "port-maps when replacing a placeholder that has a component base" do
+                    cmp_m = @cmp_m.new_submodel
+                    cmp_m.overload "out_test", @parent_task_m
+                    cmp_m.overload "in_test", @parent_task_m
+                    cmp_m.task_child.out_parent_task_port
+                         .connect_to cmp_m.in_test_child.in_parent_task_port
+                    cmp_m.out_test_child.out_parent_task_port
+                         .connect_to cmp_m.task_child.in_parent_task_port
+
+                    cmp = cmp_m.instanciate(plan)
+
+                    plan.add(task = @task_m.new)
+                    plan.replace(cmp.out_test_child, task)
+                    plan.replace(cmp.in_test_child, task)
+
+                    assert task.out_parent_task_port.connected_to?(
+                        cmp.task_child.in_parent_task_port
+                    )
+                    assert cmp.task_child.out_parent_task_port.connected_to?(
+                        task.in_parent_task_port
+                    )
+                    assert task.out_task_port.connected_to?(cmp.task_child.in_task_port)
+                    assert cmp.task_child.out_task_port.connected_to?(task.in_task_port)
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
While replacing "real" tasks do not involve port mappings (the
names are stable in the model hierarchy), replacing a placeholder
task involved port mapping the services to the actual names. This
commit implements that.