### PR TITLE
net_gen: when instanciating, set fullfilled_model only with meaningful arguments

### DIFF
--- a/lib/syskit/network_generation/system_network_generator.rb
+++ b/lib/syskit/network_generation/system_network_generator.rb
@@ -102,17 +102,13 @@ module Syskit
                     # #static_garbage_collect to cleanup #plan.
                     plan.add_permanent_task(task)
 
-                    fullfilled_task_m, fullfilled_modules, fullfilled_args =
+                    fullfilled_task_m, fullfilled_modules, req_args =
                         requirements.fullfilled_model
-                    fullfilled_args =
-                        fullfilled_args.each_key.each_with_object({}) do |arg_name, h|
-                            if task.arguments.set?(arg_name)
-                                h[arg_name] = task.arguments[arg_name]
-                            end
-                        end
+                    meaningful_args = task.meaningful_arguments.dup
+                    meaningful_args.delete_if { |k, _| !req_args.key?(k) }
 
                     task.fullfilled_model = [
-                        fullfilled_task_m, fullfilled_modules, fullfilled_args
+                        fullfilled_task_m, fullfilled_modules, meaningful_args
                     ]
                     log_timepoint "task-#{i}"
                     task

--- a/test/network_generation/test_system_network_generator.rb
+++ b/test/network_generation/test_system_network_generator.rb
@@ -42,6 +42,15 @@ module Syskit
                     assert_equal [[task_m, AbstractComponent], Hash[arg: 10]],
                                  task.fullfilled_model
                 end
+                it "only sets the arguments that are meaningful to the task" do
+                    task_m = Syskit::TaskContext.new_submodel
+                    task_m.argument :arg
+                    task = subject.instanciate(
+                        [task_m.with_arguments(arg: 10, other: 20)]
+                    ).first
+                    assert_equal [[task_m, AbstractComponent], Hash[arg: 10]],
+                                 task.fullfilled_model
+                end
                 it "use the arguments as filtered by the task in #fullfilled_model" do
                     task_m = Syskit::TaskContext.new_submodel
                     task_m.argument :arg


### PR DESCRIPTION
"meaningful arguments" are the arguments that are actually declared
in the task model (with the `argument`) property. These arguments
are constrain what can e.g. replace the task, or if the task may
or may not start (when they are unset).

However, it is possible to pass other arguments, which are useful
to the task, but e.g. should not constrain the replacements

However, during instanciation, syskit would set {#fullfilled_model}
explicitely with all arguments given to the InstanceRequirement object
Since an explicit #fullfilled_model takes precedence, these not-meaningful
arguments were affecting replacement checks.