### PR TITLE
fix cancellation of asynchronous plan generation

### DIFF
--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -693,6 +693,10 @@ module Syskit
                 commit_work_plan
             end
 
+            def discard_work_plan
+                work_plan.discard_transaction
+            end
+
             def commit_work_plan
                 work_plan.commit_transaction
                 log_timepoint "commit_transaction"

--- a/lib/syskit/network_generation/system_network_generator.rb
+++ b/lib/syskit/network_generation/system_network_generator.rb
@@ -96,8 +96,7 @@ module Syskit
             def instanciate(instance_requirements)
                 log_timepoint "instanciate_requirements"
                 toplevel_tasks = instance_requirements.each_with_index.map do |requirements, i|
-                    task = requirements.instanciate(plan)
-                                       .to_task
+                    task = requirements.instanciate(plan).to_task
                     # We add all these tasks as permanent tasks, to use
                     # #static_garbage_collect to cleanup #plan.
                     plan.add_permanent_task(task)

--- a/test/network_generation/test_async.rb
+++ b/test/network_generation/test_async.rb
@@ -56,10 +56,9 @@ module Syskit
                     subject.cancel
                     latch.set true
                     future.value
-                    # The discard is queued in the execution engine thread ...
-                    # won't be processed until we call process_workers
-                    assert !work_plan.finalized?
-                    expect_execution.to { achieve { assert work_plan.finalized? } }
+                    subject.apply
+
+                    assert work_plan.finalized?
                 end
             end
 

--- a/test/runtime/test_apply_requirement_modifications.rb
+++ b/test/runtime/test_apply_requirement_modifications.rb
@@ -7,12 +7,12 @@ module Syskit
         describe ".apply_requirement_modifications" do
             it "does nothing by default" do
                 Runtime.apply_requirement_modifications(plan)
-                assert !plan.syskit_current_resolution
+                refute plan.syskit_current_resolution
             end
 
             it "starts an async resolution when new IR tasks are started" do
                 cmp_m = Composition.new_submodel
-                plan.add_permanent_task(requirement_task = cmp_m.to_instance_requirements.as_plan)
+                requirement_task = plan.add_permanent_task(cmp_m)
                 execute { requirement_task.planning_task.start! }
                 execute { Runtime.apply_requirement_modifications(plan) }
                 assert plan.syskit_current_resolution
@@ -20,17 +20,17 @@ module Syskit
                              plan.syskit_current_resolution.future.requirement_tasks
             end
 
-            it "restarts the current async resolution if a new IR task appeared" do
+            it "restarts the current async resolution if a new IR task appears" do
                 cmp_m = Composition.new_submodel
                 requirement_tasks = []
-                requirement_tasks << plan.add_permanent_task(cmp_m.to_instance_requirements.as_plan)
+                requirement_tasks << plan.add_permanent_task(cmp_m)
                 execute { requirement_tasks[0].planning_task.start! }
                 execute { Runtime.apply_requirement_modifications(plan) }
 
-                requirement_tasks << plan.add_permanent_task(cmp_m.to_instance_requirements.as_plan)
-                execute { requirement_tasks[1].planning_task.start! }
-                flexmock(plan.syskit_current_resolution).should_receive(:cancel).once
-                execute { Runtime.apply_requirement_modifications(plan) }
+                requirement_tasks << plan.add_permanent_task(cmp_m)
+                assert_resolution_cancelled do
+                    execute { requirement_tasks[1].planning_task.start! }
+                end
 
                 assert plan.syskit_current_resolution
                 assert_equal Set[*requirement_tasks.map(&:planning_task)],
@@ -43,44 +43,45 @@ module Syskit
                 execute { requirement_task.planning_task.start! }
                 execute { Runtime.apply_requirement_modifications(plan) }
 
-                flexmock(plan.syskit_current_resolution).should_receive(:cancel).once
-                plan.unmark_permanent_task(requirement_task)
-                execute { Runtime.apply_requirement_modifications(plan) }
+                assert_resolution_cancelled do
+                    execute { plan.unmark_permanent_task(requirement_task) }
+                end
 
-                assert !plan.syskit_current_resolution
+                refute plan.syskit_current_resolution
             end
 
             it "restarts an async resolution if one of the IR tasks became useless" do
                 cmp_m = Composition.new_submodel
                 requirement_tasks = []
-                requirement_tasks << plan.add_permanent_task(cmp_m.to_instance_requirements.as_plan)
-                requirement_tasks << plan.add_permanent_task(cmp_m.to_instance_requirements.as_plan)
+                requirement_tasks << plan.add_permanent_task(cmp_m)
+                requirement_tasks << plan.add_permanent_task(cmp_m)
                 execute do
                     requirement_tasks.each { |t| t.planning_task.start! }
                 end
                 Runtime.apply_requirement_modifications(plan)
 
-                flexmock(plan.syskit_current_resolution).should_receive(:cancel).once
-                plan.unmark_permanent_task(requirement_tasks[1])
-                Runtime.apply_requirement_modifications(plan)
+                assert_resolution_cancelled do
+                    execute { plan.unmark_permanent_task(requirement_tasks[1]) }
+                end
 
                 assert plan.syskit_current_resolution
                 assert_equal Set[requirement_tasks[0].planning_task],
                              plan.syskit_current_resolution.future.requirement_tasks
             end
 
-            it "cancels an async resolution if one of the IR tasks has been interrupted" do
+            it "cancels an async resolution if one of the IR tasks "\
+               "has been interrupted" do
                 cmp_m = Composition.new_submodel
-                plan.add_permanent_task(requirement_task = cmp_m.to_instance_requirements.as_plan)
+                requirement_task = plan.add_permanent_task(cmp_m)
                 execute { requirement_task.planning_task.start! }
                 execute { Runtime.apply_requirement_modifications(plan) }
 
-                flexmock(plan.syskit_current_resolution).should_receive(:cancel).once
-                expect_execution { requirement_task.planning_task.stop! }
-                    .to { have_error_matching Roby::PlanningFailedError }
-                execute { Runtime.apply_requirement_modifications(plan) }
+                assert_resolution_cancelled do
+                    expect_execution { requirement_task.planning_task.stop! }
+                        .to { have_error_matching Roby::PlanningFailedError }
+                end
 
-                assert !plan.syskit_current_resolution
+                refute plan.syskit_current_resolution
             end
 
             it "applies the computed network and emits the planning task's success event" do
@@ -106,6 +107,28 @@ module Syskit
                 assert requirement_task.failed?
                 assert_kind_of Syskit::MissingDeployments, requirement_task.failed_event.last.context.first
                 assert_exception_can_be_pretty_printed(requirement_task.failed_event.last.context.first)
+            end
+
+            def assert_resolution_cancelled
+                flexmock(plan.syskit_current_resolution)
+                    .should_receive(:cancel).at_least.once
+                    .pass_thru
+
+                yield
+
+                execute do
+                    # This one triggers the cancellation
+                    Runtime.apply_requirement_modifications(plan)
+
+                    # This one is necessary if the future has started to be processed
+                    if plan.syskit_has_async_resolution?
+                        assert plan.syskit_current_resolution&.cancelled?
+                        plan.syskit_join_current_resolution
+                    end
+
+                    refute plan.syskit_current_resolution
+                    Runtime.apply_requirement_modifications(plan)
+                end
             end
         end
     end


### PR DESCRIPTION
The current implementation had a race condition in case the
generation was already in progress. It was queueing the transaction
discard using a execution_engine.once block, but that was not
guaranteed to be executed before the next apply_require_modification
call. When apply_require_modification was called first, it would
apply the changes.

Moreover, the applied transaction would have been generated while
(1) the syskit_current_resolution_keepalive transaction had been
discarded, and (2) while another resolution could have been in
progress.

A.k.a. recipe for disaster.

Simplify the execution flow by only "cancelling" in #cancel, letting
the generation finish (or, in case the future was pending, being
cancelled - which is also transitioning to finished), and handle
the cancellation in Async#apply. This makes sure we follow the same
execution flow in all cases, and guarantees that we serialize the
generation(s).