### PR TITLE
Fix random bug related to ssl in ci

### DIFF
--- a/lib/syskit/roby_app/remote_processes/server.rb
+++ b/lib/syskit/roby_app/remote_processes/server.rb
@@ -135,7 +135,12 @@ module Syskit
 
                 def exec
                     open
-                    listen
+
+                    begin
+                        listen
+                    ensure
+                        close
+                    end
                 end
 
                 INTERNAL_SIGCHLD_TRIGGERED = "S"
@@ -153,13 +158,19 @@ module Syskit
                     server.fcntl(Fcntl::FD_CLOEXEC, 1)
                     @port = server.addr[1]
 
-                    com_r, com_w = IO.pipe
+                    com_r, @com_w = IO.pipe
                     @all_ios.clear
                     @all_ios << server << com_r
 
                     trap "SIGCHLD" do
-                        com_w.write INTERNAL_SIGCHLD_TRIGGERED
+                        @com_w.write INTERNAL_SIGCHLD_TRIGGERED
                     end
+                end
+
+                def close
+                    @com_w.close
+                    @all_ios.each(&:close)
+                    trap("SIGCHLD", "DEFAULT")
                 end
 
                 # Main server loop. This will block and only return when CTRL+C is hit.

--- a/lib/syskit/roby_app/remote_processes/server.rb
+++ b/lib/syskit/roby_app/remote_processes/server.rb
@@ -442,6 +442,7 @@ module Syskit
 
                             Net::FTP.open(
                                 host,
+                                private_data_connection: false,
                                 port: port,
                                 ssl: { verify_mode: OpenSSL::SSL::VERIFY_PEER,
                                        ca_file: cert_io.path }


### PR DESCRIPTION
Randomly - but rather often - CI would fail with "426 Connection closed; transfer aborted."

I could pinpoint the problem with the Net::FTP library closing the connection after the transfer is finished, but the remote side (ftpd) ending up getting a CONNRESET instead of a plain EOF. This would happen on SSL, I'm guessing because the SSL shutdown probably does a back-and-forth between client and server.

While I could reliably reproduce the bug on our CI's containers (Ubuntu 18.04, Ruby 2.5.1p57), I could not get it to trigger on my dev machine (Ubuntu 20.04, Ruby 2.7.0p0 and 2.7.1p83 compiled with rbenv). Even 2.5.0p0 and 2.5.1 do not trigger here.

So, there's something fishy here. I'm disabling TLS for the data connection for now, as it is unusable as it is. It's only half-bad as the ports are negotiated through the secure command connection, but we'll have to revisit the problem at some point