### PR TITLE
net_gen: fix plan merge for compositions without children

### DIFF
--- a/lib/syskit/network_generation/merge_solver.rb
+++ b/lib/syskit/network_generation/merge_solver.rb
@@ -18,7 +18,7 @@ module Syskit
             # The dataflow graph for {#plan}
             attr_reader :dataflow_graph
 
-            # The dataflow graph for {#plan}
+            # The dependency graph for {#plan}
             attr_reader :dependency_graph
 
             # A graph that holds all replacements done during resolution
@@ -386,7 +386,7 @@ module Syskit
                 queue   = []
                 topsort = []
                 degrees = {}
-                dependency_graph.each_vertex do |task|
+                plan.each_task do |task|
                     d = dependency_graph.out_degree(task)
                     queue << task if d == 0
                     degrees[task] = d

--- a/test/network_generation/test_engine.rb
+++ b/test/network_generation/test_engine.rb
@@ -590,6 +590,14 @@ module Syskit
                     assert !diff, diff.to_s
                 end
 
+                it "does not change anything if asked to deploy an empty "\
+                   "composition twice" do
+                    composition_m = Syskit::Composition.new_submodel(name: "Cmp")
+                    cmp1 = syskit_deploy(composition_m)
+                    cmp2 = syskit_deploy(composition_m)
+                    assert_same cmp1, cmp2
+                end
+
                 it "applies connections from compositions to the final plan" do
                     task_model = Syskit::TaskContext.new_submodel do
                         output_port "out", "/double"


### PR DESCRIPTION
The composition merge step would use dependency_graph.each_vertex,
but tasks that never had dependency relationships are not included
in the graph.

Simply iterate over plan.each_task instead.