### PR TITLE
in dynamic port binding updates, ignore composition ports that can't be resolved

### DIFF
--- a/lib/syskit/dynamic_port_binding.rb
+++ b/lib/syskit/dynamic_port_binding.rb
@@ -297,6 +297,13 @@ module Syskit
             def update
                 port = @matcher.each_in_plan(@plan).first
                 port&.to_actual_port
+                # Whenever a replacement happens, or before we have deployed a
+                # task, the ports won't be resolvable because children are not
+                # there yet
+                #
+                # Ignore the port when it happens. This is consistent with the
+                # data reader's purpose
+            rescue Roby::NoSuchChild # rubocop:disable Lint/SuppressedException
             end
 
             def self.instanciate(task, model)


### PR DESCRIPTION
The symptom would be an error looking like

~~~
${TASK} has no child with the role '${CHILD_NAME}', actually, it has no child at all
~~~