### PR TITLE
Fix reconfiguration logic

### DIFF
--- a/lib/syskit/deployment.rb
+++ b/lib/syskit/deployment.rb
@@ -554,8 +554,14 @@ module Syskit
         # The currently applied configuration for the given task
         def configuration_changed?(orocos_name, conf, dynamic_services)
             current = remote_task_handles[orocos_name].current_configuration
-            current.conf != conf ||
-                current.dynamic_services != dynamic_services.to_set
+            return true if current.conf != conf
+
+            current_services = current.dynamic_services.group_by(&:name)
+            dynamic_services.each do |srv|
+                return true unless (current_srv = current_services.delete(srv.name))
+                return true unless current_srv.first.same_service?(srv)
+            end
+            false
         end
 
         # @api private

--- a/lib/syskit/deployment.rb
+++ b/lib/syskit/deployment.rb
@@ -499,7 +499,7 @@ module Syskit
                 state_reader, state_getter = create_state_access(remote_task, distance: distance_to_syskit)
                 properties = remote_task.property_names.map do |p_name|
                     p = remote_task.raw_property(p_name)
-                    [p, p.raw_read]
+                    [p, p.raw_read.freeze]
                 end
                 current_configuration = CurrentTaskConfiguration.new(nil, [], Set.new)
                 RemoteTaskHandles.new(remote_task, state_reader, state_getter, properties, false, current_configuration)

--- a/lib/syskit/models/task_context.rb
+++ b/lib/syskit/models/task_context.rb
@@ -130,6 +130,33 @@ module Syskit
             # enters a new state.
             inherited_attribute(:state_event, :state_events, map: true) { {} }
 
+            # Determine whether this component's configuration should use the
+            # {#update_properties} mechanism
+            #
+            # @see https://www.rock-robotics.org/rock-and-syskit/deprecations/update_properties.html
+            def use_update_properties?
+                return @use_update_properties unless @use_update_properties.nil?
+
+                @use_update_properties = compute_use_update_properties
+            end
+
+            # @api private
+            #
+            # Compute {#use_update_properties?}
+            #
+            # The actual method is memoizing the result
+            def compute_use_update_properties
+                return true if Roby.app.syskit_use_update_properties?
+
+                update_properties = instance_method(:update_properties)
+                return true if update_properties.owner != Syskit::TaskContext
+
+                configure = instance_method(:configure)
+                return true if configure.owner == Syskit::TaskContext
+
+                false
+            end
+
             # Create a new TaskContext model
             #
             # @option options [String] name (nil) forcefully set a name for the model.

--- a/lib/syskit/models/task_context.rb
+++ b/lib/syskit/models/task_context.rb
@@ -151,8 +151,11 @@ module Syskit
                 # Find where is update_properties defined, exclusing modules
                 # Modules are assumed to be "behind-the-scene" extensions, such
                 # as plugins, that should not affect the decision
+                #
+                # TODO: use method_defined?(name, false) when we drop support
+                # TODO: for 2.5
                 this = self
-                until this.method_defined?(:update_properties, false)
+                until this.instance_methods(false).include?(:update_properties)
                     this = this.superclass
                 end
                 return true if this != Syskit::TaskContext

--- a/lib/syskit/models/task_context.rb
+++ b/lib/syskit/models/task_context.rb
@@ -148,9 +148,18 @@ module Syskit
             def compute_use_update_properties
                 return true if Roby.app.syskit_use_update_properties?
 
-                update_properties = instance_method(:update_properties)
-                return true if update_properties.owner != Syskit::TaskContext
+                # Find where is update_properties defined, exclusing modules
+                # Modules are assumed to be "behind-the-scene" extensions, such
+                # as plugins, that should not affect the decision
+                this = self
+                until this.method_defined?(:update_properties, false)
+                    this = this.superclass
+                end
+                return true if this != Syskit::TaskContext
 
+                # For configure, we use the old behavior as soon as we find
+                # a configure, even if a plugin might have defined. It's
+                # the conservative thing to do
                 configure = instance_method(:configure)
                 return true if configure.owner == Syskit::TaskContext
 

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -33,6 +33,15 @@ module Syskit
         #   loaded models. In addition, a text notification is sent to inform
         #   a shell user
         module Plugin
+            attr_writer :syskit_use_update_properties
+
+            # Assume all component models have been migrated to use update_properties
+            #
+            # See https://www.rock-robotics.org/rock-and-syskit/deprecations/update_properties.html
+            def syskit_use_update_properties?
+                @syskit_use_update_properties
+            end
+
             # Hook called by the main application in Application#load_base_config
             def self.load_base_config(app)
                 options = app.options

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -592,7 +592,7 @@ module Syskit
         # you are doing
         def setup_successful!
             execution_agent.update_current_configuration(
-                orocos_name, model, conf.dup, each_required_dynamic_service.to_set
+                orocos_name, model, conf.dup, each_required_dynamic_service.map(&:model).to_set
             )
             execution_agent.finished_configuration(orocos_name)
 
@@ -714,7 +714,7 @@ module Syskit
 
                 needs_reconfiguration = needs_reconfiguration? ||
                     execution_agent.configuration_changed?(
-                        orocos_name, conf, each_required_dynamic_service.to_set
+                        orocos_name, conf, each_required_dynamic_service.map(&:model).to_set
                     ) ||
                     self.properties.each.any?(&:needs_commit?)
 

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -712,6 +712,8 @@ module Syskit
                     syskit_p.update_remote_value(remote_value)
                 end
 
+                update_properties if model.use_update_properties?
+
                 needs_reconfiguration = needs_reconfiguration? ||
                     execution_agent.configuration_changed?(
                         orocos_name, conf, each_required_dynamic_service.to_set
@@ -742,6 +744,7 @@ module Syskit
         # (see Component#perform_setup)
         def perform_setup(promise)
             prepare_for_setup(promise)
+
             # This calls #configure
             super(promise)
 
@@ -1019,14 +1022,14 @@ module Syskit
             state_reader.pause if state_reader.respond_to?(:pause)
         end
 
-        # Default implementation of the configure method.
+        # Default implementation of the update_properties method.
         #
         # This default implementation takes its configuration from
         # State.config.task_name, where +task_name+ is the CORBA task name
         # (i.e. the global name of the task).
         #
         # It then sets the task properties using the values found there
-        def configure
+        def update_properties
             # First, set configuration from the configuration files
             # Note: it can only set properties
             if model.configuration_manager.apply(self, override: true)
@@ -1059,6 +1062,13 @@ module Syskit
                     actual_property.write(property_override.read)
                 end
             end
+
+            super if defined? super
+        end
+
+        # Default implementation of the configure method
+        def configure
+            update_properties unless model.use_update_properties?
 
             super if defined? super
         end

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -66,11 +66,9 @@ module Syskit
             remote_handles.default_properties.each do |p, p_value|
                 syskit_p = property(p.name)
                 syskit_p.remote_property = p
-                syskit_p.update_remote_value(p_value)
+                syskit_p.update_remote_value(p_value&.dup)
                 syskit_p.update_log_metadata(p.log_metadata)
-                unless syskit_p.has_value?
-                    syskit_p.write(p_value)
-                end
+                syskit_p.write(p_value&.dup) unless syskit_p.has_value?
             end
         end
 

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -710,7 +710,17 @@ module Syskit
                     syskit_p.update_remote_value(remote_value)
                 end
 
-                update_properties if model.use_update_properties?
+                if model.use_update_properties?
+                    freeze_delayed_arguments
+                    update_properties
+                else
+                    warn "#{model.concrete_model} does not define "\
+                         "the #update_properties method, but does define"
+                    warn "#configure. It will be needlessly reconfigured when "\
+                         "stopped."
+                    warn "See https://www.rock-robotics.org/rock-and-syskit/"\
+                         "deprecations/update_properties.html"
+                end
 
                 needs_reconfiguration = needs_reconfiguration? ||
                     execution_agent.configuration_changed?(

--- a/test/models/test_task_context.rb
+++ b/test/models/test_task_context.rb
@@ -600,17 +600,22 @@ describe Syskit::Models::TaskContext do
 
         it "returns false if the submodel defines #configure" do
             task_m = Syskit::TaskContext.new_submodel
-            task_m.class_eval do
-                def configure; end
-            end
+            task_m.class_eval { def configure; end }
+            refute task_m.use_update_properties?
+        end
+
+        it "ignores an update_properties methods defined by a module injected in "\
+           "the hierarchy" do
+            task_m = Syskit::TaskContext.new_submodel
+            task_m.class_eval { def configure; end }
+            mod = Module.new { def update_properties; end }
+            task_m.prepend mod
             refute task_m.use_update_properties?
         end
 
         it "returns true if the submodel defines #update_properties" do
             task_m = Syskit::TaskContext.new_submodel
-            task_m.class_eval do
-                def update_properties; end
-            end
+            task_m.class_eval { def update_properties; end }
             assert task_m.use_update_properties?
         end
 

--- a/test/models/test_task_context.rb
+++ b/test/models/test_task_context.rb
@@ -591,4 +591,38 @@ describe Syskit::Models::TaskContext do
             common_behavior(self)
         end
     end
+
+    # Control of the update_properties backward-compatible behavior
+    describe "#use_update_properties?" do
+        it "returns true for a plain submodel of TaskContext" do
+            assert Syskit::TaskContext.new_submodel.use_update_properties?
+        end
+
+        it "returns false if the submodel defines #configure" do
+            task_m = Syskit::TaskContext.new_submodel
+            task_m.class_eval do
+                def configure; end
+            end
+            refute task_m.use_update_properties?
+        end
+
+        it "returns true if the submodel defines #update_properties" do
+            task_m = Syskit::TaskContext.new_submodel
+            task_m.class_eval do
+                def update_properties; end
+            end
+            assert task_m.use_update_properties?
+        end
+
+        it "returns true if the submodel defines both #configure and "\
+           "#update_properties" do
+            task_m = Syskit::TaskContext.new_submodel
+            task_m.class_eval do
+                def update_properties; end
+
+                def configure; end
+            end
+            assert task_m.use_update_properties?
+        end
+    end
 end

--- a/test/test_deployment.rb
+++ b/test/test_deployment.rb
@@ -729,37 +729,6 @@ module Syskit
             end
         end
 
-        describe "runtime state tracking" do
-            attr_reader :orocos_task
-            before do
-                @orocos_task = Orocos.allow_blocking_calls do
-                    Orocos::RubyTasks::TaskContext.new "#{Process.pid}-test"
-                end
-                process.should_receive(:resolve_all_tasks)
-                       .and_return("mapped_task_name" => orocos_task)
-                expect_execution { deployment_task.start! }
-                    .to { emit deployment_task.ready_event }
-            end
-            after do
-                orocos_task.dispose
-            end
-
-            describe "current configuration" do
-                it "returns true if the configuration list differs" do
-                    deployment_task.update_current_configuration("mapped_task_name", nil, ["test"], Set.new)
-                    assert deployment_task.configuration_changed?("mapped_task_name", ["other"], Set.new)
-                end
-                it "returns true if the set of dynamic services differ" do
-                    deployment_task.update_current_configuration("mapped_task_name", nil, ["test"], Set[1])
-                    assert deployment_task.configuration_changed?("mapped_task_name", ["test"], Set[2])
-                end
-                it "returns false if both the configuration and the set of dynamic services are identical" do
-                    deployment_task.update_current_configuration("mapped_task_name", nil, ["test"], Set[1])
-                    refute deployment_task.configuration_changed?("mapped_task_name", ["test"], Set[1])
-                end
-            end
-        end
-
         describe "#mark_changed_configuration_as_non_reusable" do
             before do
                 @task_m = Syskit::TaskContext.new_submodel

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -1353,12 +1353,12 @@ module Syskit
                 it "calls the task's configure method if the task's state is PRE_OPERATIONAL" do
                     orocos_task.should_receive(:rtt_state).and_return(:PRE_OPERATIONAL)
                     orocos_task.should_receive(:configure).once.ordered
-                    setup_task(expected_messages: ["applied configuration [\"default\"] to #{task.orocos_name}", "setting up #{task}"])
+                    setup_task(expected_messages: ["setting up #{task}"])
                 end
                 it "does not call the task's configure method if the task's state is not PRE_OPERATIONAL" do
                     orocos_task.should_receive(:rtt_state).and_return(:STOPPED)
                     orocos_task.should_receive(:configure).never
-                    setup_task(expected_messages: ["applied configuration [\"default\"] to #{task.orocos_name}", "#{task} was already configured"])
+                    setup_task(expected_messages: ["#{task} was already configured"])
                 end
                 it "does not call the task's configure method if the user-provided configure method raises" do
                     task.should_receive(:configure).and_raise(error_m)

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -1622,7 +1622,6 @@ module Syskit
                 @double_t = double_t = stub_type "/double"
                 @task_m = RubyTaskContext.new_submodel do
                     property "test", double_t
-                    property "test_v", "/std/vector</double>"
                 end
                 @task = syskit_deploy(task_m.deployed_as(name, on: "stubs"))
             end
@@ -1643,7 +1642,11 @@ module Syskit
             end
 
             it "disassociates the default value from the property's" do
-                syskit_start_execution_agents(@task)
+                task_m = RubyTaskContext.new_submodel do
+                    property "test_v", "/std/vector</double>"
+                end
+                task = syskit_deploy(task_m.deployed_as(name, on: "stubs"))
+                syskit_start_execution_agents(task)
                 task.properties.test_v << 10
 
                 expect_execution { plan.make_useless(task) }

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -1365,16 +1365,18 @@ module Syskit
                 end
             end
         end
-        describe "#configure" do
+        describe "configuration" do
             it "applies the selected configuration" do
                 task_m = TaskContext.new_submodel name: "Task" do
                     property "v", "/int"
                 end
                 task = syskit_stub_and_deploy(task_m.with_conf("my", "conf"))
-                flexmock(task.model.configuration_manager).should_receive(:conf)
-                                                          .with(%w[my conf], true)
-                                                          .once
-                                                          .and_return("v" => 10)
+                flexmock(task.model.configuration_manager)
+                    .should_receive(:conf)
+                    .with(%w[my conf], true)
+                    .once
+                    .and_return("v" => 10)
+
                 syskit_configure(task)
                 Orocos.allow_blocking_calls do
                     assert_equal 10, task.orocos_task.v


### PR DESCRIPTION
On top of https://github.com/rock-core/tools-syskit/pull/289

The title sums it up ... it's embarrassing.

The reconfiguration logic was completely broken. Essentially, Syskit would always reconfigure, except if a component is configured with its default parameters. And also if it has no dynamic services.

The bad part is that fixing this required user-facing changes. This pull request require components to define a `update_properties` method in which the property updates are made. This method must be idempotent, and will be called in all cases. `configure` is called after the `cleanup` for non-idempotent configuration, as e.g. calling operations (the `canbus` component needs that for instance).

This change is forward and backward compatible though. Current orogen classes that do not define a configure method will be transparently using the new scheme. Tasks that do define `#configure` have to be migrated explictely to get the proper reconfiguration behavior, but will retain the current behavior if they do not.

This is documented by https://github.com/rock-core/rock-and-syskit/pull/72