### PR TITLE
test: fix have_no_new_sample/have_new_samples for boolean ports

### DIFF
--- a/lib/syskit/test/execution_expectations.rb
+++ b/lib/syskit/test/execution_expectations.rb
@@ -47,7 +47,9 @@ module Syskit
                     orocos_reader = ExecutionExpectations.resolve_orocos_reader(reader)
                     block = proc do
                         sample = orocos_reader.read_new
-                        if sample && (!@predicate || @predicate.call(sample))
+                        if sample.nil?
+                            true
+                        elsif !@predicate || @predicate.call(sample)
                             @received_sample = sample
                             false
                         else
@@ -114,11 +116,12 @@ module Syskit
                     )
 
                     block = proc do
-                        if (sample = orocos_reader.read_new)
-                            if !@predicate || @predicate.call(sample)
-                                @received_samples << sample
-                                @received_samples.size == count
-                            end
+                        sample = orocos_reader.read_new
+                        if sample.nil?
+                            false
+                        elsif !@predicate || @predicate.call(sample)
+                            @received_samples << sample
+                            @received_samples.size == count
                         end
                     end
                     description = proc do

--- a/lib/syskit/test/execution_expectations.rb
+++ b/lib/syskit/test/execution_expectations.rb
@@ -42,21 +42,28 @@ module Syskit
             #
             # Implementation of the {#have_no_new_sample} predicate
             class HaveNoNewSample < Roby::Test::ExecutionExpectations::Maintain
-                def initialize(reader, at_least_during, description, backtrace)
+                DEFAULT_BUFFER_SIZE = 100
+
+                def initialize(
+                    reader, at_least_during, description, buffer_size, backtrace
+                )
                     @reader = reader
-                    orocos_reader = ExecutionExpectations.resolve_orocos_reader(reader)
-                    block = proc do
-                        sample = orocos_reader.read_new
-                        if sample.nil?
-                            true
-                        elsif !@predicate || @predicate.call(sample)
+                    orocos_reader = ExecutionExpectations.resolve_orocos_reader(
+                        reader, type: :buffer, size: buffer_size
+                    )
+
+                    block = ->(_) { process_samples(orocos_reader) }
+                    super(at_least_during, block, description, backtrace)
+                end
+
+                def process_samples(reader)
+                    until (sample = reader.read_new).nil?
+                        if !@predicate || @predicate.call(sample)
                             @received_sample = sample
-                            false
-                        else
-                            true
+                            return false
                         end
                     end
-                    super(at_least_during, block, description, backtrace)
+                    true
                 end
 
                 def explain_unachievable(propagation_info)
@@ -92,11 +99,22 @@ module Syskit
             #
             # @param [Float] at_least_during no samples should arrive for at
             #   least that many seconds. This is a minimum.
+            # @param [Integer] buffer_size the size of the reading buffer, only
+            #   needed when using {HaveNoNewSample#matching}. The default is 100,
+            #   which should be big enough for most test cases. Tune if you are
+            #   sending more than 100 samples and expect the test to filter out
+            #   all of them
             # @return [nil]
-            def have_no_new_sample(reader, at_least_during: 0, backtrace: caller(1))
+            def have_no_new_sample(
+                reader,
+                buffer_size: HaveNoNewSample::DEFAULT_BUFFER_SIZE,
+                at_least_during: 0, backtrace: caller(1)
+            )
                 description = "#{reader} should not have received a new sample"
                 add_expectation(
-                    HaveNoNewSample.new(reader, at_least_during, description, backtrace)
+                    HaveNoNewSample.new(
+                        reader, at_least_during, description, buffer_size, backtrace
+                    )
                 )
             end
 
@@ -107,29 +125,33 @@ module Syskit
             # It is basically #achieve, but with the ability to add a #matching
             # block
             class HaveNewSamples < Roby::Test::ExecutionExpectations::Achieve
-                def initialize(reader, count, backtrace)
+                DEFAULT_BUFFER_SIZE = 100
+
+                def initialize(reader, count, buffer_size, backtrace)
                     @received_samples = []
                     @predicate = nil
 
                     orocos_reader = ExecutionExpectations.resolve_orocos_reader(
-                        reader, type: :buffer, size: count
+                        reader, type: :buffer, size: buffer_size
                     )
 
-                    block = proc do
-                        sample = orocos_reader.read_new
-                        if sample.nil?
-                            false
-                        elsif !@predicate || @predicate.call(sample)
-                            @received_samples << sample
-                            @received_samples.size == count
-                        end
-                    end
                     description = proc do
                         matching = " matching the given predicate" if @predicate
                         "#{reader} should have received #{count} new sample(s)"\
                         "#{matching}, but got #{@received_samples.size}"
                     end
+                    block = ->(_) { process_samples(orocos_reader, count) }
                     super(block, description, backtrace)
+                end
+
+                def process_samples(reader, count)
+                    until (sample = reader.read_new).nil?
+                        if !@predicate || @predicate.call(sample)
+                            @received_samples << sample
+                            return true if @received_samples.size == count
+                        end
+                    end
+                    false
                 end
 
                 def return_object
@@ -154,10 +176,18 @@ module Syskit
             #   have_one_new_sample(reader)
             #       .matching { |s| s > 10 }
             #
+            # @param [Integer] buffer_size the size of the reading buffer. The default
+            #   is 100, which should be big enough for most test cases. Tune if you
+            #   are sure the samples are sent, but only partially read (and if you are
+            #   sending more than 100 of them)
             # @return [Object]
-            def have_one_new_sample(reader, backtrace: caller(1))
-                have_new_samples(reader, 1, backtrace: backtrace)
-                    .filter_result_with(&:first)
+            def have_one_new_sample(
+                reader, buffer_size: HaveNewSamples::DEFAULT_BUFFER_SIZE,
+                backtrace: caller(1)
+            )
+                have_new_samples(
+                    reader, 1, buffer_size: buffer_size, backtrace: backtrace
+                ).filter_result_with(&:first)
             end
 
             # Expect that a certain number of sample arrives on the reader, and
@@ -169,10 +199,17 @@ module Syskit
             #   have_new_samples(reader, 10)
             #       .matching(&:odd?)
             #
+            # @param [Integer] buffer_size the size of the reading buffer. The default
+            #   is 100, which should be big enough for most test cases. Tune if you
+            #   are sure the samples are sent, but only partially read (and if you are
+            #   sending more than 100 of them)
             # @return [Object]
-            def have_new_samples(reader, count, backtrace: caller(1))
+            def have_new_samples(
+                reader, count, buffer_size: HaveNewSamples::DEFAULT_BUFFER_SIZE,
+                backtrace: caller(1)
+            )
                 add_expectation(
-                    HaveNewSamples.new(reader, count, backtrace)
+                    HaveNewSamples.new(reader, count, buffer_size, backtrace)
                 )
             end
         end

--- a/test/test/test_execution_expectations.rb
+++ b/test/test/test_execution_expectations.rb
@@ -70,6 +70,17 @@ module Syskit
                     end
                     assert_equal ["bla"], expectation.backtrace
                 end
+                it "passes for sample that is 'false'" do
+                    task_m = Syskit::RubyTaskContext.new_submodel do
+                        output_port "out", "/bool"
+                    end
+                    use_ruby_tasks task_m => "testbool", on: "stubs"
+                    @task = syskit_deploy_configure_and_start(task_m)
+
+                    value = expect_execution { syskit_write task.out_port, false }
+                            .to { have_one_new_sample task.out_port }
+                    assert_equal false, value
+                end
             end
 
             describe "#have_one_new_sample.matching" do
@@ -184,6 +195,18 @@ module Syskit
                     end
                     assert_equal ["bla"], expectation.backtrace
                 end
+                it "passes for samples that are 'false'" do
+                    task_m = Syskit::RubyTaskContext.new_submodel do
+                        output_port "out", "/bool"
+                    end
+                    use_ruby_tasks task_m => "testbool", on: "stubs"
+                    @task = syskit_deploy_configure_and_start(task_m)
+
+                    value =
+                        expect_execution { syskit_write task.out_port, *([false] * 5) }
+                        .to { have_new_samples task.out_port, 5 }
+                    assert_equal [false] * 5, value
+                end
             end
 
             describe "#have_new_samples.matching" do
@@ -237,6 +260,18 @@ module Syskit
                     end
                     assert_equal ["bla"], expectation.backtrace
                 end
+                it "passes for samples that are 'false'" do
+                    task_m = Syskit::RubyTaskContext.new_submodel do
+                        output_port "out", "/bool"
+                    end
+                    use_ruby_tasks task_m => "testbool", on: "stubs"
+                    @task = syskit_deploy_configure_and_start(task_m)
+
+                    flipflop = [true, false, true, false, true]
+                    value = expect_execution { syskit_write task.out_port, *flipflop }
+                            .to { have_new_samples(task.out_port, 2).matching(&:!) }
+                    assert_equal [false] * 2, value
+                end
             end
 
             describe "#have_no_new_sample" do
@@ -279,6 +314,18 @@ module Syskit
                             end
                     end
                     assert_equal ["bla"], expectation.backtrace
+                end
+                it "fails if receiving 'false'" do
+                    task_m = Syskit::RubyTaskContext.new_submodel do
+                        output_port "out", "/bool"
+                    end
+                    use_ruby_tasks task_m => "testbool", on: "stubs"
+                    @task = syskit_deploy_configure_and_start(task_m)
+
+                    assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
+                        expect_execution { syskit_write task.out_port, false }
+                            .to { have_no_new_sample task.out_port }
+                    end
                 end
             end
 
@@ -334,6 +381,19 @@ module Syskit
                             end
                     end
                     assert_equal ["bla"], expectation.backtrace
+                end
+                it "handles 'false' samples well" do
+                    task_m = Syskit::RubyTaskContext.new_submodel do
+                        output_port "out", "/bool"
+                    end
+                    use_ruby_tasks task_m => "testbool", on: "stubs"
+                    @task = syskit_deploy_configure_and_start(task_m)
+
+                    flipflop = [true, false, true, false, true]
+                    assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
+                        expect_execution { syskit_write task.out_port, *flipflop }
+                            .to { have_no_new_sample(task.out_port).matching(&:!) }
+                    end
                 end
             end
         end

--- a/test/test/test_execution_expectations.rb
+++ b/test/test/test_execution_expectations.rb
@@ -101,6 +101,18 @@ module Syskit
                              end
                     assert_equal 10, sample
                 end
+                it "allows tuning the reading buffer size" do
+                    default_size =
+                        ExecutionExpectations::HaveNewSamples::DEFAULT_BUFFER_SIZE
+                    samples = (0...(default_size + 1)).to_a
+                    expect_execution { syskit_write task.out_port, *samples }
+                        .to do
+                            have_one_new_sample(
+                                task.out_port,
+                                buffer_size: default_size + 1
+                            ).matching { |v| v >= default_size }
+                        end
+                end
                 it "accepts a data reader as input and uses its policy" do
                     reader = task.out_port.reader(type: :buffer, size: 10)
                     sample = expect_execution { syskit_write task.out_port, 10, 5 }
@@ -226,6 +238,18 @@ module Syskit
                             .to { have_new_samples(reader, 1).matching(&:odd?) }
                     assert_equal [3], value
                 end
+                it "allows tuning the reading buffer size" do
+                    default_size =
+                        ExecutionExpectations::HaveNewSamples::DEFAULT_BUFFER_SIZE
+                    samples = (0...(default_size + 5)).to_a
+                    expect_execution { syskit_write task.out_port, *samples }
+                        .to do
+                            have_new_samples(
+                                task.out_port,
+                                5, buffer_size: default_size + 5
+                            ).matching { |v| v >= default_size }
+                        end
+                end
                 it "fails if the task does not emit enough matching samples" do
                     e = assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
                         expect_execution { syskit_write task.in_port, 1, 2, 3 }
@@ -340,6 +364,20 @@ module Syskit
                     expect_execution { syskit_write task.in_port, 10 }
                         .timeout(0.01)
                         .to { have_no_new_sample(task.in_port).matching { |s| s != 10 } }
+                end
+                it "allows tuning the reading buffer size" do
+                    default_size =
+                        ExecutionExpectations::HaveNoNewSample::DEFAULT_BUFFER_SIZE
+                    samples = (0...(default_size + 1)).to_a
+                    assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
+                        expect_execution { syskit_write task.out_port, *samples }
+                            .to do
+                                have_no_new_sample(
+                                    task.out_port,
+                                    buffer_size: default_size + 1
+                                ).matching { |v| v >= default_size }
+                            end
+                    end
                 end
                 it "fails if the task emits a sample that matches the predicate" do
                     e = assert_raises(Roby::Test::ExecutionExpectations::Unmet) do


### PR DESCRIPTION
They return 'false' which was interpreted by the implementation as
"no new sample"