### PR TITLE
Handle dark corners of component execution

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,10 +38,18 @@ Rake::TestTask.new("test:core") do |t|
     test_files = test_files
                  .exclude("test/ros/**/*.rb")
                  .exclude("test/gui/**/*.rb")
+                 .exclude("test/live/**/*.rb")
     t.test_files = test_files
     t.warning = false
 end
 
+task "test:live" do
+    tests = Dir.enum_for(:glob, "test/live/test_*.rb").to_a
+    unless system(File.join("test", "live", "run"), *tests)
+        $stderr.puts "live tests failed"
+        exit 1
+    end
+end
 Rake::TestTask.new("test:gui") do |t|
     t.libs << "."
     t.libs << "lib"
@@ -51,7 +59,7 @@ Rake::TestTask.new("test:gui") do |t|
     t.warning = false
 end
 
-task "test" => ["test:gui", "test:core"]
+task "test" => ["test:gui", "test:core", "test:live"]
 
 if USE_RUBOCOP
     begin

--- a/lib/syskit/cli/gen/syskit_app/config/init.rb
+++ b/lib/syskit/cli/gen/syskit_app/config/init.rb
@@ -13,7 +13,7 @@ Roby.app.backward_compatible_naming = false
 
 # Automatically restart deployments that have components either in FATAL_ERROR,
 # or that failed to stop
-Syskit.conf.auto_restart_deployments_with_quarantined_task_contexts = true
+Syskit.conf.auto_restart_deployments_with_quarantines = true
 
 # Set the module's name. It is normally inferred from the app name, and the app
 # name is inferred from the base directory name (e.g. an app located in

--- a/lib/syskit/cli/gen/syskit_app/config/init.rb
+++ b/lib/syskit/cli/gen/syskit_app/config/init.rb
@@ -11,6 +11,10 @@
 # toplevel as well as within the OroGen namespace
 Roby.app.backward_compatible_naming = false
 
+# Automatically restart deployments that have components either in FATAL_ERROR,
+# or that failed to stop
+Syskit.conf.auto_restart_deployments_with_quarantined_task_contexts = true
+
 # Set the module's name. It is normally inferred from the app name, and the app
 # name is inferred from the base directory name (e.g. an app located in
 # bundles/flat_fish would have an app name of flat_fish and a module name of

--- a/lib/syskit/component.rb
+++ b/lib/syskit/component.rb
@@ -169,11 +169,6 @@ module Syskit
             object.add_syskit_configuration_precedence(start_event)
         end
 
-        # Whether this task context will ever configurable
-        def will_never_setup?
-            false
-        end
-
         def meets_configurationg_precedence_constraints?
             waiting_precedence_relation =
                 start_event

--- a/lib/syskit/deployment.rb
+++ b/lib/syskit/deployment.rb
@@ -722,7 +722,7 @@ module Syskit
             # to kill or cleanly stop the deployment. We basically assume
             # 'kill' if some executed tasks are still in the plan (meaning it's
             # not being stopped through garbage collection)
-            if each_executed_task.any? { true }
+            if each_executed_task.any? { |t| !t.finished? }
                 stop_kill(promise, remote_task_handles)
             else
                 stop_cleanly(promise, remote_task_handles)

--- a/lib/syskit/deployment.rb
+++ b/lib/syskit/deployment.rb
@@ -583,6 +583,15 @@ module Syskit
             each_executed_task.any?(&:quarantined?)
         end
 
+        # Whether this deployment should be reused in newly generated networks
+        def reusable?
+            if Syskit.conf.auto_restart_deployments_with_quarantined_task_contexts?
+                return false if has_quarantined_task_contexts? || has_fatal_errors?
+            end
+
+            super
+        end
+
         # @api private
         #
         # The currently applied configuration for the given task

--- a/lib/syskit/deployment.rb
+++ b/lib/syskit/deployment.rb
@@ -720,10 +720,7 @@ module Syskit
         # Called asynchronously to initialize the {RemoteTaskHandles} object
         # once and for all
         def create_state_access(remote_task, distance: TaskContext::D_UNKNOWN)
-            state_getter = RemoteStateGetter.new(
-                remote_task,
-                initial_state: remote_task.rtt_state
-            )
+            state_getter = RemoteStateGetter.new(remote_task)
 
             if remote_task.model.extended_state_support?
                 state_port = remote_task.raw_port("state")

--- a/lib/syskit/exceptions.rb
+++ b/lib/syskit/exceptions.rb
@@ -1038,4 +1038,18 @@ module Syskit
             failure_point.pretty_print(pp)
         end
     end
+
+    class TaskContextInFatal < Roby::ExceptionBase
+        def initialize(deployment, name)
+            super()
+
+            @deployment = deployment
+            @name = name
+        end
+
+        def pretty_print(pp)
+            pp.text "attempting to use component in FATAL_ERROR: #{@name} from "
+            @deployment.pretty_print(pp)
+        end
+    end
 end

--- a/lib/syskit/instance_requirements.rb
+++ b/lib/syskit/instance_requirements.rb
@@ -1244,13 +1244,17 @@ module Syskit
             to_action_model.new
         end
 
-        # Return the instance requirement object that runs this task
-        # model with the given name
         # Request to run this task model with the given name
         def deployed_as(name, **options)
             use_deployment_group(
                 model.to_deployment_group(name, **options)
             )
+            self
+        end
+
+        # Deploy the network represented by self using the given deployment(s)
+        def deploy_with(*names, **options)
+            use_deployment(*names, **options)
             self
         end
 

--- a/lib/syskit/models/task_context.rb
+++ b/lib/syskit/models/task_context.rb
@@ -254,6 +254,12 @@ module Syskit
             end
 
             # Return the instance requirement object that runs this task
+            # model with the given deployment
+            def deploy_with(*names, **options)
+                to_instance_requirements.use_deployment(*names, **options)
+            end
+
+            # Return the instance requirement object that runs this task
             # model with the given name
             def deployed_as(name, **options)
                 to_instance_requirements.deployed_as(name, **options)

--- a/lib/syskit/models/task_context.rb
+++ b/lib/syskit/models/task_context.rb
@@ -68,6 +68,8 @@ module Syskit
             def make_state_events
                 with_superclass = !supermodel || !supermodel.respond_to?(:orogen_model) || (supermodel.orogen_model != orogen_model.superclass)
                 orogen_model.each_state(with_superclass: with_superclass) do |name, type|
+                    next if name == "PRE_OPERATIONAL"
+
                     event_name = name.snakecase.downcase.to_sym
                     if type == :toplevel
                         event event_name,

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -436,7 +436,7 @@ module Syskit
             #   plan that is being considered
             def existing_deployment_needs_restart?(required, existing)
                 restart_enabled =
-                    Syskit.conf.auto_restart_deployments_with_quarantined_task_contexts?
+                    Syskit.conf.auto_restart_deployments_with_quarantines?
                 return unless restart_enabled
                 return unless existing.has_fatal_errors? || existing.has_quarantines?
 

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -453,7 +453,7 @@ module Syskit
                 finishing_deployments = {}
                 existing_deployments = {}
                 deployments.each do |task|
-                    if task.finishing?
+                    if !task.reusable?
                         finishing_deployments[task.process_name] = task
                     elsif !used_deployments.include?(task)
                         (existing_deployments[task.process_name] ||= []) << task

--- a/lib/syskit/remote_state_getter.rb
+++ b/lib/syskit/remote_state_getter.rb
@@ -61,6 +61,10 @@ module Syskit
             resume
         end
 
+        def started?
+            @poll_thread
+        end
+
         # The internal polling loop
         def poll_loop
             # Analysis to avoid deadlocking in {#wait}

--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -46,6 +46,11 @@ module Syskit
             # The default is false for historical reasons. We strongly recommend turning
             # this on globally
             attr_predicate :auto_restart_deployments_with_quarantines?, true
+            # How long Syskit will allow a component to take to transition to EXCEPTION
+            #
+            # This usually includes the time needed to stop and cleanup. The default
+            # is 20s
+            attr_accessor :exception_transition_timeout
 
             # Data logging configuration
             #
@@ -99,6 +104,7 @@ module Syskit
                 @use_only_model_pack = false
                 @opportunistic_recovery_from_quarantine = true
                 @auto_restart_deployments_with_quarantines = false
+                @exception_transition_timeout = 20.0
                 clear
 
                 self.export_types = true

--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -34,6 +34,12 @@ module Syskit
             # Controls whether the orogen types should be exported as Ruby
             # constants
             attr_predicate :export_types?, true
+            # Controls whether Syskit should restart deployments that have components
+            # in FATAL_ERROR, or that failed to stop
+            #
+            # The default is false for historical reasons. We strongly recommend turning
+            # this on globally
+            attr_predicate :auto_restart_deployments_with_quarantined_task_contexts?, true
 
             # Data logging configuration
             #
@@ -85,6 +91,7 @@ module Syskit
                 @ignore_load_errors = false
                 @buffer_size_margin = 0.1
                 @use_only_model_pack = false
+                @auto_restart_deployments_with_quarantined_task_contexts = false
                 clear
 
                 self.export_types = true

--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -39,7 +39,7 @@ module Syskit
             #
             # The default is false for historical reasons. We strongly recommend turning
             # this on globally
-            attr_predicate :auto_restart_deployments_with_quarantined_task_contexts?, true
+            attr_predicate :auto_restart_deployments_with_quarantines?, true
 
             # Data logging configuration
             #
@@ -91,7 +91,7 @@ module Syskit
                 @ignore_load_errors = false
                 @buffer_size_margin = 0.1
                 @use_only_model_pack = false
-                @auto_restart_deployments_with_quarantined_task_contexts = false
+                @auto_restart_deployments_with_quarantines = false
                 clear
 
                 self.export_types = true

--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -34,6 +34,12 @@ module Syskit
             # Controls whether the orogen types should be exported as Ruby
             # constants
             attr_predicate :export_types?, true
+            # Controls whether Syskit should kill deployments that have a component
+            # in FATAL_ERROR or quarantined (e.g. failed to stop) when there are no
+            # other components running on it
+            #
+            # The default is true
+            attr_predicate :opportunistic_recovery_from_quarantine?, true
             # Controls whether Syskit should restart deployments that have components
             # in FATAL_ERROR, or that failed to stop
             #
@@ -91,6 +97,7 @@ module Syskit
                 @ignore_load_errors = false
                 @buffer_size_margin = 0.1
                 @use_only_model_pack = false
+                @opportunistic_recovery_from_quarantine = true
                 @auto_restart_deployments_with_quarantines = false
                 clear
 

--- a/lib/syskit/roby_app/remote_processes/server.rb
+++ b/lib/syskit/roby_app/remote_processes/server.rb
@@ -252,7 +252,10 @@ module Syskit
                     Server.warn "stopping process server"
                     processes.each_value do |p|
                         Server.warn "killing #{p.name}"
-                        p.kill
+                        # Kill the process hard. If there are still processes,
+                        # it means that the normal cleanup procedure did not
+                        # work.  Not the time to call stop or whatnot
+                        p.kill(false, cleanup: false, hard: true)
                     end
 
                     each_client do |socket|

--- a/lib/syskit/runtime/update_task_states.rb
+++ b/lib/syskit/runtime/update_task_states.rb
@@ -11,6 +11,7 @@ module Syskit
             scheduler = plan.execution_engine.scheduler
             plan.find_tasks(Syskit::TaskContext).not_finished.each do |task|
                 next if task.failed_to_start?
+                next unless handle_task_state_updates?(scheduler, task)
 
                 handle_single_task_state_update(scheduler, task)
             end
@@ -20,7 +21,7 @@ module Syskit
         #
         # Handle state changes for a single task
         def self.handle_single_task_state_update(scheduler, task)
-            return unless handle_task_state_updates?(scheduler, task)
+            task.validate_state_reader_connected
 
             handle_task_configuration(scheduler, task) unless task.setup?
             return if !task.running? && !task.starting?
@@ -81,10 +82,12 @@ module Syskit
             )
         end
 
-        # Check if the task is in a state that allow us to process its state updates
+        # Check if the task is in a state that allow us to process its state
+        # updates
         #
-        # Of notice, we stop looking at tasks when we know the underlying process is
-        # being killed. It has caused some deep freeze in OmniORB in the past.
+        # Of notice, we stop looking at tasks when we know the underlying
+        # process is being killed. It has caused some deep freeze in OmniORB in
+        # the past.
         def self.handle_task_state_updates?(scheduler, task)
             execution_agent = task.execution_agent
 

--- a/lib/syskit/runtime/update_task_states.rb
+++ b/lib/syskit/runtime/update_task_states.rb
@@ -23,7 +23,7 @@ module Syskit
             return unless handle_task_state_updates?(scheduler, task)
 
             handle_task_configuration(scheduler, task) unless task.setup?
-            return if !task.running? && !task.starting? || task.aborted_event.pending?
+            return if !task.running? && !task.starting?
 
             handle_task_runtime_states(task)
         end

--- a/lib/syskit/runtime/update_task_states.rb
+++ b/lib/syskit/runtime/update_task_states.rb
@@ -70,8 +70,6 @@ module Syskit
             end
 
             warn_state_reader_overrun(state_count)
-        rescue Orocos::CORBA::ComError => e
-            task.aborted_event.emit e
         end
 
         def self.warn_state_reader_overrun(state_count)

--- a/lib/syskit/runtime/update_task_states.rb
+++ b/lib/syskit/runtime/update_task_states.rb
@@ -41,19 +41,7 @@ module Syskit
             return unless task.meets_configurationg_precedence_constraints?
 
             task.freeze_delayed_arguments
-            if task.will_never_setup?
-                unless task.kill_execution_agent_if_alone
-                    task.failed_to_start!(
-                        Roby::CommandFailed.new(
-                            InternalError.exception(
-                                "#{task} reports that it cannot be configured "\
-                                "(FATAL_ERROR ?)"
-                            ),
-                            task.start_event
-                        )
-                    )
-                end
-            elsif task.ready_for_setup?
+            if task.ready_for_setup?
                 task.setup.execute
             else
                 scheduler.report_holdoff("did not configure, not ready for setup", task)

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -1054,6 +1054,7 @@ module Syskit
         def quarantined!(reason: nil)
             super
 
+            execution_agent.register_task_context_quarantined(orocos_name)
             execution_agent.opportunistic_recovery_from_quarantine
         end
 

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -1055,13 +1055,21 @@ module Syskit
             super
 
             execution_agent.register_task_context_quarantined(orocos_name)
-            execution_agent.opportunistic_recovery_from_quarantine
+            if Syskit.conf.opportunistic_recovery_from_quarantine?
+                execution_agent.opportunistic_recovery_from_quarantine
+            end
+
+            nil
         end
 
         on :stop do |_event|
             info "stopped #{self}"
             state_reader.pause if state_reader.respond_to?(:pause)
-            execution_agent.opportunistic_recovery_from_quarantine
+            if Syskit.conf.opportunistic_recovery_from_quarantine?
+                execution_agent.opportunistic_recovery_from_quarantine
+            end
+
+            nil
         end
 
         # Default implementation of the update_properties method.

--- a/test/live/run
+++ b/test/live/run
@@ -1,0 +1,6 @@
+#! /bin/sh
+
+dir=$(mktemp -d)
+syskit gen app "$dir/app"
+syskit orogen-test --workdir "$dir/app" --logs="$dir/app/logs" "$@"
+rm -rf $dir

--- a/test/live/test_blocking_hooks.rb
+++ b/test/live/test_blocking_hooks.rb
@@ -1,0 +1,410 @@
+# frozen_string_literal: true
+
+using_task_library "logger"
+using_task_library "orogen_syskit_tests"
+
+module Syskit
+    class BlockingHooksTests < Syskit::Test::ComponentTest
+        run_live
+
+        before do
+            @orig_connect_timeout = Orocos::CORBA.connect_timeout
+            @orig_call_timeout = Orocos::CORBA.call_timeout
+            @orig_opportunistic_recovery =
+                Syskit.conf.opportunistic_recovery_from_quarantine?
+            @orig_auto_restart_flag =
+                Syskit.conf.auto_restart_deployments_with_quarantines?
+
+            Orocos::CORBA.connect_timeout = 100
+            Syskit.conf.opportunistic_recovery_from_quarantine = false
+            Syskit.conf.auto_restart_deployments_with_quarantines = false
+        end
+
+        after do
+            Orocos::CORBA.connect_timeout = @orig_connect_timeout
+            Orocos::CORBA.call_timeout = @orig_call_timeout
+            Syskit.conf.opportunistic_recovery_from_quarantine =
+                @orig_opportunistic_recovery
+            Syskit.conf.auto_restart_deployments_with_quarantines =
+                @orig_auto_restart_flag
+        end
+
+        describe "system handling of blocking hooks" do
+            attr_reader :task, :deployment
+
+            before do
+                @task_m = OroGen.orogen_syskit_tests.BlockingHooks
+                                .deployed_as("blocking_hooks")
+                @task = syskit_deploy(@task_m)
+                @task.properties.time = 10
+                @deployment = @task.execution_agent
+                remove_logger
+            end
+
+            describe "#configure" do
+                before do
+                    @task.properties.hook = "configure"
+                end
+
+                it "waits for a long call to finish" do
+                    @task.properties.time = 2
+                    Orocos::CORBA.call_timeout = 5000
+                    syskit_configure(@task)
+                    assert_equal :STOPPED, rtt_state
+                    refute @deployment.task_context_in_fatal?(@task.orocos_name)
+                end
+
+                it "marks a task whose call timed out as 'fatal' on the deployment" do
+                    @task.properties.time = 10
+                    Orocos::CORBA.call_timeout = 1000
+                    expect_execution.scheduler(true).timeout(5).to do
+                        fail_to_start task
+                    end
+                    assert @deployment.task_context_in_fatal?(@task.orocos_name)
+                end
+
+                it "handles the task being killed in the middle of a long call" do
+                    @task.properties.time = 10
+                    Orocos::CORBA.call_timeout = 2_000
+                    start = Time.now
+
+                    expect_execution.scheduler(true).join_all_waiting_work(false).to do
+                        poll do
+                            if task.setting_up? && (Time.now - start) > 1
+                                task.execution_agent.kill!
+                            end
+                        end
+                        fail_to_start task
+                        emit deployment.stop_event
+                    end
+                end
+            end
+
+            describe "#start" do
+                before do
+                    @task.properties.hook = "start"
+                    syskit_configure(@task)
+                end
+
+                it "waits for a long call to finish" do
+                    @task.properties.time = 2
+                    Orocos::CORBA.call_timeout = 5000
+                    syskit_start(@task)
+                    assert_equal :RUNNING, rtt_state
+                    refute @deployment.task_context_in_fatal?(@task.orocos_name)
+                end
+
+                it "marks a task whose call timed out as 'fatal' on the deployment" do
+                    @task.properties.time = 10
+                    Orocos::CORBA.call_timeout = 1000
+                    expect_execution.scheduler(true).timeout(5).to do
+                        fail_to_start task
+                    end
+                    assert @deployment.task_context_in_fatal?(@task.orocos_name)
+                end
+
+                it "handles the task being killed in the middle of a long call" do
+                    @task.properties.time = 10
+                    Orocos::CORBA.call_timeout = 2_000
+                    start = Time.now
+
+                    expect_execution.scheduler(true).join_all_waiting_work(false).to do
+                        poll do
+                            if task.start_event.pending? && (Time.now - start) > 1
+                                task.execution_agent.kill!
+                            end
+                        end
+                        fail_to_start task
+                        emit deployment.stop_event
+                    end
+                end
+            end
+
+            describe "#stop (blocking in update)" do
+                before do
+                    @task.properties.hook = "update"
+                end
+
+                after do
+                    cleanup_running_tasks
+                end
+
+                it "waits for a long call to finish" do
+                    @task.properties.time = 1
+                    Orocos::CORBA.call_timeout = 4_000
+                    syskit_configure_and_start(@task)
+
+                    syskit_stop(@task)
+                    assert_equal :STOPPED, rtt_state
+                    refute @deployment.task_context_in_fatal?(@task.orocos_name)
+                end
+
+                it "quarantines a task whose call timed out" do
+                    @task.properties.time = 10
+                    Orocos::CORBA.call_timeout = 1_000
+                    syskit_configure(@task)
+
+                    synchronize_on_sleep(task) { task.start! }
+
+                    expect_execution { task.stop! }.timeout(5).to do
+                        quarantine task
+                    end
+                    refute @deployment.task_context_in_fatal?(@task.orocos_name)
+                end
+
+                it "stops the task if the stop eventually works" do
+                    Orocos::CORBA.call_timeout = 1_000
+                    @task.properties.time = 4
+                    syskit_configure(@task)
+
+                    synchronize_on_sleep(task) { task.start! }
+
+                    expect_execution { task.stop! }
+                        .timeout(1.5).join_all_waiting_work(false)
+                        .to { quarantine task }
+                    expect_execution.to { emit task.stop_event }
+                    refute @deployment.task_context_in_fatal?(@task.orocos_name)
+                end
+
+                it "handles the task being killed in the middle of a long call" do
+                    @task.properties.time = 10
+                    Orocos::CORBA.call_timeout = 2_000
+                    syskit_configure(task)
+
+                    synchronize_on_sleep(task) { task.start! }
+
+                    start = Time.now
+                    expect_execution { task.stop! }.join_all_waiting_work(false).to do
+                        poll do
+                            task.execution_agent.kill! if (Time.now - start) > 1
+                        end
+                        quarantine task
+                        emit task.aborted_event
+                        emit deployment.stop_event
+                    end
+                end
+            end
+
+            describe "#stop (blocking in stop)" do
+                before do
+                    @task.properties.hook = "stop"
+                end
+
+                after do
+                    cleanup_running_tasks
+                end
+
+                it "waits for a long call to finish" do
+                    @task.properties.time = 1
+                    Orocos::CORBA.call_timeout = 4_000
+                    syskit_configure_and_start(@task)
+
+                    syskit_stop(@task)
+                    assert_equal :STOPPED, rtt_state
+                    refute @deployment.task_context_in_fatal?(@task.orocos_name)
+                end
+
+                it "quarantines a task whose call timed out" do
+                    @task.properties.time = 10
+                    Orocos::CORBA.call_timeout = 1_000
+                    syskit_configure_and_start(@task)
+
+                    expect_execution { task.stop! }.timeout(5).to do
+                        quarantine task
+                    end
+                    refute @deployment.task_context_in_fatal?(@task.orocos_name)
+                end
+
+                it "stops the task if the stop eventually works" do
+                    Orocos::CORBA.call_timeout = 1_000
+                    @task.properties.time = 4
+                    syskit_configure_and_start(@task)
+
+                    expect_execution { task.stop! }
+                        .timeout(1.5).join_all_waiting_work(false)
+                        .to { quarantine task }
+                    expect_execution.to { emit task.stop_event }
+                    refute @deployment.task_context_in_fatal?(@task.orocos_name)
+                end
+
+                it "handles the task being killed in the middle of a long call" do
+                    @task.properties.time = 10
+                    Orocos::CORBA.call_timeout = 2_000
+                    syskit_configure_and_start(task)
+
+                    start = Time.now
+                    expect_execution { task.stop! }.join_all_waiting_work(false).to do
+                        poll do
+                            task.execution_agent.kill! if (Time.now - start) > 1
+                        end
+                        quarantine task
+                        emit task.aborted_event
+                        emit deployment.stop_event
+                    end
+                end
+            end
+
+            describe "#exception" do
+                it "waits for a long call to finish" do
+                end
+
+                it "quarantines a task whose call timed out" do
+                end
+
+                it "stops the task if the stop eventually works" do
+                end
+
+                it "handles the task being killed in the middle of a long call" do
+                end
+            end
+
+            describe "#cleanup (reconfiguration)" do
+                it "waits for a long call to finish" do
+                    @task.properties.time = 2
+                    Orocos::CORBA.call_timeout = 5000
+                    prepare_cleanup
+                    syskit_configure(@task)
+                    assert_equal :STOPPED, rtt_state
+                    refute @deployment.task_context_in_fatal?(@task.orocos_name)
+                end
+
+                it "marks a task whose call timed out as 'fatal' on the deployment" do
+                    @task.properties.time = 10
+                    Orocos::CORBA.call_timeout = 1000
+                    prepare_cleanup
+                    expect_execution.scheduler(true).timeout(5).to do
+                        fail_to_start task
+                    end
+                    assert @deployment.task_context_in_fatal?(@task.orocos_name)
+                end
+
+                it "handles the task being killed in the middle of a long call" do
+                    @task.properties.time = 10
+                    Orocos::CORBA.call_timeout = 2_000
+                    prepare_cleanup
+                    start = Time.now
+
+                    expect_execution.scheduler(true).join_all_waiting_work(false).to do
+                        poll do
+                            if task.setting_up? && (Time.now - start) > 1
+                                task.execution_agent.kill!
+                            end
+                        end
+                        fail_to_start task
+                        emit deployment.stop_event
+                    end
+                end
+
+                def prepare_cleanup
+                    @task.properties.hook = "cleanup"
+                    syskit_configure_and_start(@task)
+                    syskit_stop(@task)
+                    # trigger reconfiguration, but the `cleanup` hook will still see
+                    # the old value
+                    @task = syskit_deploy(@task_m)
+                    remove_logger
+                end
+            end
+
+            describe "#cleanup (after a property change in #configure)" do
+                it "waits for a long call to finish" do
+                    @task.properties.time = 2
+                    Orocos::CORBA.call_timeout = 5000
+                    prepare_cleanup
+                    syskit_configure(@task)
+                    assert_equal :STOPPED, rtt_state
+                    refute @deployment.task_context_in_fatal?(@task.orocos_name)
+                end
+
+                it "marks a task whose call timed out as 'fatal' on the deployment" do
+                    @task.properties.time = 10
+                    Orocos::CORBA.call_timeout = 1000
+                    prepare_cleanup
+                    expect_execution.scheduler(true).timeout(5).to do
+                        fail_to_start task
+                    end
+                    assert @deployment.task_context_in_fatal?(@task.orocos_name)
+                end
+
+                it "handles the task being killed in the middle of a long call" do
+                    @task.properties.time = 10
+                    Orocos::CORBA.call_timeout = 2_000
+                    prepare_cleanup
+                    start = Time.now
+
+                    expect_execution.scheduler(true).join_all_waiting_work(false).to do
+                        poll do
+                            if task.setting_up? && (Time.now - start) > 1
+                                task.execution_agent.kill!
+                            end
+                        end
+                        fail_to_start task
+                        emit deployment.stop_event
+                    end
+                end
+
+                def prepare_cleanup
+                    time = @task.properties.time
+                    @task.properties.hook = ""
+                    syskit_configure(@task)
+                    execute { plan.remove_task(@task) }
+                    @task = syskit_deploy(@task_m)
+                    @task.properties.hook = ""
+                    @task.properties.time = time
+                    def task.configure
+                        super
+                        properties.hook = "cleanup"
+                    end
+                    remove_logger
+                end
+            end
+        end
+
+        def trigger_fatal_error(task, &block)
+            expect_execution { task.stop! }.to do
+                emit task.fatal_error_event
+                emit task.exception_event
+                instance_eval(&block) if block
+            end
+        end
+
+        def default_task_name
+            "#{name}-#{Process.pid}"
+        end
+
+        def rtt_state(task = @task)
+            Orocos.allow_blocking_calls { task.orocos_task.rtt_state }
+        end
+
+        def find_logger
+            logger_m = Syskit::TaskContext.find_model_from_orogen_name("logger::Logger")
+            plan.find_tasks(logger_m).first
+        end
+
+        def cleanup_running_tasks
+            return unless @deployment.running?
+
+            executed_tasks =
+                deployment.each_executed_task.find_all(&:running?)
+            expect_execution { deployment.stop! }
+                .to do
+                    emit deployment.stop_event
+                    executed_tasks.each { |t| emit t.aborted_event }
+                end
+        end
+
+        def synchronize_on_sleep(task, &block)
+            expect_execution(&block).join_all_waiting_work(false).to do
+                have_one_new_sample task.sleep_start_port
+            end
+        end
+
+        def remove_logger
+            execute do
+                logger = find_logger
+                plan.unmark_permanent_task(logger)
+                plan.remove_task(logger)
+            end
+        end
+    end
+end

--- a/test/live/test_blocking_hooks.rb
+++ b/test/live/test_blocking_hooks.rb
@@ -178,7 +178,7 @@ module Syskit
                         poll do
                             task.execution_agent.kill! if (Time.now - start) > 1
                         end
-                        quarantine task
+                        ignore_errors_from quarantine(task)
                         emit task.aborted_event
                         emit deployment.stop_event
                     end
@@ -237,7 +237,7 @@ module Syskit
                         poll do
                             task.execution_agent.kill! if (Time.now - start) > 1
                         end
-                        quarantine task
+                        ignore_errors_from quarantine(task)
                         emit task.aborted_event
                         emit deployment.stop_event
                     end

--- a/test/live/test_fatal_error.rb
+++ b/test/live/test_fatal_error.rb
@@ -7,173 +7,204 @@ module Syskit
     class SyskitFatalErrorTests < Syskit::Test::ComponentTest
         run_live
 
-        attr_reader :task, :task2, :deployment
+        describe "system handling of fatal error and quarantined tasks" do
+            attr_reader :task, :task2, :deployment
 
-        before do
-            @auto_restart_flag =
-                Syskit.conf.auto_restart_deployments_with_quarantined_task_contexts?
+            before do
+                @auto_restart_flag =
+                    Syskit.conf.auto_restart_deployments_with_quarantines?
 
+                deployment_m = OroGen::Deployments.syskit_fatal_error_recovery_test
+                @task_m = OroGen.orogen_syskit_tests.FatalError
+                                .deploy_with(deployment_m => Process.pid.to_s)
+                @task = syskit_deploy_configure_and_start(@task_m)
 
-            deployment_m = OroGen::Deployments.syskit_fatal_error_recovery_test
-            @task_m = OroGen.orogen_syskit_tests.FatalError
-                            .deploy_with(deployment_m => Process.pid.to_s)
-            @task = syskit_deploy_configure_and_start(@task_m)
-
-            @task2_m = OroGen.orogen_syskit_tests.Empty
-                             .deploy_with(deployment_m => Process.pid.to_s)
-            @task2 = syskit_deploy_configure_and_start(@task2_m)
-            @deployment = @task.execution_agent
-        end
-
-        after do
-            Syskit.conf.auto_restart_deployments_with_quarantined_task_contexts =
-                @auto_restart_flag
-        end
-
-        it "emits fatal_error" do
-            trigger_fatal_error
-        end
-
-        it "marks itself as being in FATAL on its deployment" do
-            # Avoid killing the deployment altogether
-            trigger_fatal_error
-
-            assert @deployment.has_fatal_errors?
-            assert @deployment.task_context_in_fatal?("#{Process.pid}a")
-        end
-
-        it "does not allow respawning a task that has gone into FATAL_ERROR" do
-            trigger_fatal_error
-
-            assert_raises(TaskContextInFatal) do
-                @deployment.task("#{Process.pid}a")
+                @task2_m = OroGen.orogen_syskit_tests.Empty
+                                 .deploy_with(deployment_m => Process.pid.to_s)
+                @task2 = syskit_deploy_configure_and_start(@task2_m)
+                @deployment = @task.execution_agent
             end
-        end
 
-        it "fails during network generation when attempting "\
-           "to deploy a component that is in FATAL_ERROR" do
-            # Avoid killing the deployment altogether
-            Syskit.conf.auto_restart_deployments_with_quarantined_task_contexts = false
-            trigger_fatal_error
-
-            e = assert_raises(Roby::Test::ExecutionExpectations::UnexpectedErrors) do
-                syskit_deploy(@task_m)
+            after do
+                Syskit.conf.auto_restart_deployments_with_quarantines =
+                    @auto_restart_flag
             end
-            assert_kind_of Roby::PlanningFailedError,
-                           e.each_execution_exception.first.exception
-        end
 
-        it "auto-restarts deployments with a task in FATAL_ERROR "\
-           "if configured to do so" do
-            Syskit.conf.auto_restart_deployments_with_quarantined_task_contexts = true
+            it "does not allow respawning a task that has gone into FATAL_ERROR" do
+                trigger_fatal_error(task)
 
-            trigger_fatal_error
-
-            # DO NOT use syskit_configure_and_start, it forcefully starts the execution
-            # agent, which does not work here.
-            new_task = syskit_deploy(@task_m)
-
-            refute_equal @deployment, new_task.execution_agent
-            assert_equal "#{Process.pid}a", new_task.orocos_name
-            expect_execution.scheduler(true).garbage_collect(true)
-                            .to { emit new_task.start_event }
-
-            # Make sure task2 got restarted too
-            assert @task2.finished?
-            assert plan.find_tasks.with_arguments(orocos_name: "#{Process.pid}b")
-                       .running.first
-        end
-
-        it "does not auto-restart the deployment if the tasks "\
-           "in FATAL_ERROR are not involved in the new network" do
-            Syskit.conf.auto_restart_deployments_with_quarantined_task_contexts = true
-
-            trigger_fatal_error
-
-            new_task = syskit_deploy(@task2_m)
-            assert_same @task2, new_task
-        end
-
-        it "auto-restarts deployments with a quarantined task "\
-           "if configured to do so" do
-            Syskit.conf.auto_restart_deployments_with_quarantined_task_contexts = true
-
-            @task.quarantined!
-
-            # DO NOT use syskit_configure_and_start, it forcefully starts the execution
-            # agent, which does not work here.
-            new_task = syskit_deploy(@task_m)
-
-            refute_equal @deployment, new_task.execution_agent
-            assert_equal "#{Process.pid}a", new_task.orocos_name
-            expect_execution
-                .scheduler(true).garbage_collect(true)
-                .to do
-                    emit task.aborted_event
-                    emit new_task.start_event
+                assert_raises(TaskContextInFatal) do
+                    @deployment.task("#{Process.pid}a")
                 end
+            end
 
-            # Make sure task2 got restarted too
-            assert @task2.finished?
-            assert plan.find_tasks.with_arguments(orocos_name: "#{Process.pid}b")
-                       .running.first
-        end
+            it "fails during network generation when attempting "\
+               "to deploy a component that is in FATAL_ERROR" do
+                # Avoid killing the deployment altogether
+                Syskit.conf.auto_restart_deployments_with_quarantines = false
+                trigger_fatal_error(@task)
 
-        it "does not auto-restart the deployment if quarantined "\
-           "tasks are not involved in the new network" do
-            Syskit.conf.auto_restart_deployments_with_quarantined_task_contexts = true
+                e = assert_raises(Roby::Test::ExecutionExpectations::UnexpectedErrors) do
+                    syskit_deploy(@task_m)
+                end
+                assert_kind_of Roby::PlanningFailedError,
+                               e.each_execution_exception.first.exception
+            end
 
-            @task.quarantined!
+            it "auto-restarts deployments with a task in FATAL_ERROR "\
+               "if configured to do so" do
+                Syskit.conf.auto_restart_deployments_with_quarantines = true
 
-            new_task = syskit_deploy(@task2_m)
-            assert_same @task2, new_task
-            # Kill the deployment ourselves to avoid warnings on teardown
-            expect_execution { task.execution_agent.stop! }
-                .to do
+                trigger_fatal_error(@task)
+
+                # DO NOT use syskit_configure_and_start, it forcefully starts
+                # the execution agent, which does not work here.
+                new_task = syskit_deploy(@task_m)
+
+                refute_equal @deployment, new_task.execution_agent
+                assert_equal "#{Process.pid}a", new_task.orocos_name
+                expect_execution.scheduler(true).garbage_collect(true)
+                                .to { emit new_task.start_event }
+
+                # Make sure task2 got restarted too
+                assert @task2.finished?
+                assert plan.find_tasks.with_arguments(orocos_name: "#{Process.pid}b")
+                           .running.first
+            end
+
+            it "does not auto-restart the deployment if the tasks "\
+            "in FATAL_ERROR are not involved in the new network" do
+                Syskit.conf.auto_restart_deployments_with_quarantines = true
+
+                trigger_fatal_error(@task)
+
+                new_task = syskit_deploy(@task2_m)
+                assert_same @task2, new_task
+            end
+
+            it "auto-restarts deployments with a quarantined task "\
+            "if configured to do so" do
+                Syskit.conf.auto_restart_deployments_with_quarantines = true
+
+                @task.quarantined!
+
+                # DO NOT use syskit_configure_and_start, it forcefully starts
+                # the execution agent, which does not work here.
+                new_task = syskit_deploy(@task_m)
+
+                refute_equal @deployment, new_task.execution_agent
+                assert_equal "#{Process.pid}a", new_task.orocos_name
+                expect_execution
+                    .scheduler(true).garbage_collect(true)
+                    .to do
+                        emit task.aborted_event
+                        emit new_task.start_event
+                    end
+
+                # Make sure task2 got restarted too
+                assert @task2.finished?
+                assert plan.find_tasks.with_arguments(orocos_name: "#{Process.pid}b")
+                           .running.first
+            end
+
+            it "does not auto-restart the deployment if quarantined "\
+            "tasks are not involved in the new network" do
+                Syskit.conf.auto_restart_deployments_with_quarantines = true
+
+                @task.quarantined!
+
+                new_task = syskit_deploy(@task2_m)
+                assert_same @task2, new_task
+                # Kill the deployment ourselves to avoid warnings on teardown
+                expect_execution { task.execution_agent.stop! }
+                    .to do
+                        emit task.aborted_event
+                        emit task2.aborted_event
+                    end
+            end
+
+            it "kills the deployment if the only non-utility tasks are in quarantine" do
+                expect_execution do
+                    task.quarantined!
+                    task2.quarantined!
+                end.to do
                     emit task.aborted_event
                     emit task2.aborted_event
-                end
-        end
-
-        it "kills the deployment if the only non-utility tasks are in quarantine" do
-            expect_execution do
-                task.quarantined!
-                task2.quarantined!
-            end.to do # rubocop:disable Style/MultilineBlockChain
-                emit task.aborted_event
-                emit task2.aborted_event
-                emit deployment.kill_event
-                emit deployment.signaled_event
-            end
-        end
-
-        it "kills the deployment if the task was the only one running on it apart "\
-           "from loggers" do
-            expect_execution { task2.stop! }.to { emit task2.stop_event }
-            trigger_fatal_error do
-                emit deployment.kill_event
-                emit deployment.signaled_event
-            end
-        end
-
-        it "does kill a deployment with a fatal-errored task "\
-           "once all non-utility tasks have stopped" do
-            trigger_fatal_error
-
-            expect_execution { task2.stop! }
-                .to do
-                    emit task2.stop_event
                     emit deployment.kill_event
                     emit deployment.signaled_event
                 end
+            end
+
+            it "kills the deployment if the task was the only one running on it apart "\
+               "from loggers" do
+                expect_execution { task2.stop! }.to { emit task2.stop_event }
+                trigger_fatal_error(@task) do
+                    emit deployment.kill_event
+                    emit deployment.signaled_event
+                end
+            end
+
+            it "does kill a deployment with a fatal-errored task "\
+               "once all non-utility tasks have stopped" do
+                trigger_fatal_error(@task)
+
+                expect_execution { task2.stop! }
+                    .to do
+                        emit task2.stop_event
+                        emit deployment.kill_event
+                        emit deployment.signaled_event
+                    end
+            end
         end
 
-        def trigger_fatal_error(&block)
+        describe "the fatal error event" do
+            it "emits fatal_error" do
+                task_m = OroGen.orogen_syskit_tests.FatalError
+                               .deployed_as(default_deployment_name)
+                task = syskit_deploy_configure_and_start(task_m)
+                flexmock(task.execution_agent)
+                    .should_receive(:opportunistic_recovery_from_quarantine)
+                trigger_fatal_error(task)
+            end
+
+            it "marks itself as being in FATAL on its deployment" do
+                task_m = OroGen.orogen_syskit_tests.FatalError
+                               .deployed_as(default_deployment_name)
+                task = syskit_deploy_configure_and_start(task_m)
+                deployment = task.execution_agent
+                flexmock(deployment)
+                    .should_receive(:opportunistic_recovery_from_quarantine)
+                trigger_fatal_error(task)
+
+                assert deployment.has_fatal_errors?
+                assert deployment.task_context_in_fatal?(default_deployment_name)
+            end
+
+            it "handles the asynchronicity between a possible exception event and a "\
+               "fatal error" do
+                task_m = OroGen.orogen_syskit_tests.FatalErrorAfterExceptionAndDelay
+                               .deployed_as(default_deployment_name)
+                task = syskit_deploy_and_configure(task_m)
+                flexmock(task.execution_agent)
+                    .should_receive(:opportunistic_recovery_from_quarantine)
+                expect_execution { task.start! }
+                    .to do
+                        emit task.exception_event
+                        emit task.fatal_error_event
+                    end
+            end
+        end
+
+        def trigger_fatal_error(task, &block)
             expect_execution { task.stop! }.to do
                 emit task.fatal_error_event
                 emit task.exception_event
                 instance_eval(&block) if block
             end
+        end
+
+        def default_deployment_name
+            "#{name}-#{Process.pid}"
         end
     end
 end

--- a/test/live/test_fatal_error.rb
+++ b/test/live/test_fatal_error.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+using_task_library "logger"
+using_task_library "orogen_syskit_tests"
+
+module Syskit
+    class SyskitFatalErrorTests < Syskit::Test::ComponentTest
+        run_live
+
+        attr_reader :task, :deployment
+
+        before do
+            @task = syskit_deploy_configure_and_start(
+                OroGen.orogen_syskit_tests.FatalError
+                        .deployed_as("syskit-tests-fatal-error")
+            )
+            @deployment = @task.execution_agent
+        end
+
+        it "emits fatal_error" do
+            trigger_fatal_error
+        end
+
+        it "marks itself as being in FATAL on its deployment" do
+            # Avoid killing the deployment altogether
+            flexmock(@deployment).should_receive(:opportunistic_recovery_from_quarantine)
+            trigger_fatal_error
+
+            assert @deployment.has_fatal_errors?
+            assert @deployment.task_context_in_fatal?("syskit-tests-fatal-error")
+        end
+
+        it "does not allow respawning a task that has gone into FATAL_ERROR" do
+            # Avoid killing the deployment altogether
+            flexmock(@deployment).should_receive(:opportunistic_recovery_from_quarantine)
+            trigger_fatal_error
+
+            assert_raises(TaskContextInFatal) do
+                @deployment.task("syskit-tests-fatal-error")
+            end
+        end
+
+        it "fails during network generation when attempting "\
+           "to deploy a component that is in FATAL_ERROR" do
+            # Avoid killing the deployment altogether
+            flexmock(@deployment).should_receive(:opportunistic_recovery_from_quarantine)
+            trigger_fatal_error
+
+            e = assert_raises(Roby::Test::ExecutionExpectations::UnexpectedErrors) do
+                syskit_deploy(
+                    OroGen.orogen_syskit_tests.FatalError
+                            .deployed_as("syskit-tests-fatal-error")
+                )
+            end
+            assert_kind_of Roby::PlanningFailedError,
+                           e.each_execution_exception.first.exception
+        end
+
+        it "kills the deployment if the only non-utility tasks are in quarantine" do
+            expect_execution do
+                task.quarantined!
+            end.to do
+                emit task.stop_event
+                emit deployment.kill_event
+                emit deployment.signaled_event
+            end
+        end
+
+        it "kills the deployment if the task was the only one running on it apart "\
+           "from loggers" do
+            trigger_fatal_error do
+                emit deployment.kill_event
+                emit deployment.signaled_event
+            end
+        end
+
+        it "does kill a deployment with a fatal-errored task "\
+           "once all non-utility tasks have stopped" do
+            flexmock(Roby.app).should_receive(:syskit_utility_component?)
+                              .and_return(false)
+            trigger_fatal_error
+
+            logger = @deployment.each_executed_task.first
+            syskit_configure_and_start(logger)
+            expect_execution { logger.stop! }
+                .to do
+                    emit deployment.kill_event
+                    emit deployment.signaled_event
+                end
+        end
+
+        it "does kill a deployment with a fatal-errored task "\
+           "once all non-utility tasks have stopped" do
+            flexmock(Roby.app).should_receive(:syskit_utility_component?)
+                              .and_return(false)
+            trigger_fatal_error
+
+            logger = @deployment.each_executed_task.first
+            syskit_configure_and_start(logger)
+            expect_execution { logger.stop! }
+                .to do
+                    emit deployment.kill_event
+                    emit deployment.signaled_event
+                end
+        end
+
+        it "kills the deployment if the task was the only one running on it" do
+            trigger_fatal_error do
+                emit deployment.kill_event
+                emit deployment.signaled_event
+            end
+        end
+
+        def trigger_fatal_error(&block)
+            expect_execution { task.stop! }.to do
+                emit task.fatal_error_event
+                emit task.exception_event
+                instance_eval(&block) if block
+            end
+        end
+    end
+end

--- a/test/live/test_fatal_error.rb
+++ b/test/live/test_fatal_error.rb
@@ -7,14 +7,27 @@ module Syskit
     class SyskitFatalErrorTests < Syskit::Test::ComponentTest
         run_live
 
-        attr_reader :task, :deployment
+        attr_reader :task, :task2, :deployment
 
         before do
-            @task = syskit_deploy_configure_and_start(
-                OroGen.orogen_syskit_tests.FatalError
-                        .deployed_as("syskit-tests-fatal-error")
-            )
+            @auto_restart_flag =
+                Syskit.conf.auto_restart_deployments_with_quarantined_task_contexts?
+
+
+            deployment_m = OroGen::Deployments.syskit_fatal_error_recovery_test
+            @task_m = OroGen.orogen_syskit_tests.FatalError
+                            .deploy_with(deployment_m => Process.pid.to_s)
+            @task = syskit_deploy_configure_and_start(@task_m)
+
+            @task2_m = OroGen.orogen_syskit_tests.Empty
+                             .deploy_with(deployment_m => Process.pid.to_s)
+            @task2 = syskit_deploy_configure_and_start(@task2_m)
             @deployment = @task.execution_agent
+        end
+
+        after do
+            Syskit.conf.auto_restart_deployments_with_quarantined_task_contexts =
+                @auto_restart_flag
         end
 
         it "emits fatal_error" do
@@ -23,44 +36,64 @@ module Syskit
 
         it "marks itself as being in FATAL on its deployment" do
             # Avoid killing the deployment altogether
-            flexmock(@deployment).should_receive(:opportunistic_recovery_from_quarantine)
             trigger_fatal_error
 
             assert @deployment.has_fatal_errors?
-            assert @deployment.task_context_in_fatal?("syskit-tests-fatal-error")
+            assert @deployment.task_context_in_fatal?("#{Process.pid}a")
         end
 
         it "does not allow respawning a task that has gone into FATAL_ERROR" do
-            # Avoid killing the deployment altogether
-            flexmock(@deployment).should_receive(:opportunistic_recovery_from_quarantine)
             trigger_fatal_error
 
             assert_raises(TaskContextInFatal) do
-                @deployment.task("syskit-tests-fatal-error")
+                @deployment.task("#{Process.pid}a")
             end
         end
 
         it "fails during network generation when attempting "\
            "to deploy a component that is in FATAL_ERROR" do
             # Avoid killing the deployment altogether
-            flexmock(@deployment).should_receive(:opportunistic_recovery_from_quarantine)
+            Syskit.conf.auto_restart_deployments_with_quarantined_task_contexts = false
             trigger_fatal_error
 
             e = assert_raises(Roby::Test::ExecutionExpectations::UnexpectedErrors) do
-                syskit_deploy(
-                    OroGen.orogen_syskit_tests.FatalError
-                            .deployed_as("syskit-tests-fatal-error")
-                )
+                syskit_deploy(@task_m)
             end
             assert_kind_of Roby::PlanningFailedError,
                            e.each_execution_exception.first.exception
         end
 
+        it "auto-restarts deployments with fatal/quarantined tasks "\
+           "if configured to do so" do
+            # Make sure we let the deployer restart the deployment. Can't mock
+            # opportunistic_recovery_from_quarantine as it is needed for the
+            # method to work.
+            Syskit.conf.auto_restart_deployments_with_quarantined_task_contexts = true
+
+            trigger_fatal_error
+
+            # DO NOT use syskit_configure_and_start, it forcefully starts the execution
+            # agent, which does not work here.
+            new_task = syskit_deploy(@task_m)
+
+            refute_equal @deployment, new_task.execution_agent
+            assert_equal "#{Process.pid}a", new_task.orocos_name
+            expect_execution.scheduler(true).garbage_collect(true)
+                            .to { emit new_task.start_event }
+
+            # Make sure task2 got restarted too
+            assert @task2.finished?
+            assert plan.find_tasks.with_arguments(orocos_name: "#{Process.pid}b")
+                       .running.first
+        end
+
         it "kills the deployment if the only non-utility tasks are in quarantine" do
             expect_execution do
                 task.quarantined!
-            end.to do
-                emit task.stop_event
+                task2.quarantined!
+            end.to do # rubocop:disable Style/MultilineBlockChain
+                emit task.aborted_event
+                emit task2.aborted_event
                 emit deployment.kill_event
                 emit deployment.signaled_event
             end
@@ -68,6 +101,7 @@ module Syskit
 
         it "kills the deployment if the task was the only one running on it apart "\
            "from loggers" do
+            expect_execution { task2.stop! }.to { emit task2.stop_event }
             trigger_fatal_error do
                 emit deployment.kill_event
                 emit deployment.signaled_event
@@ -76,39 +110,14 @@ module Syskit
 
         it "does kill a deployment with a fatal-errored task "\
            "once all non-utility tasks have stopped" do
-            flexmock(Roby.app).should_receive(:syskit_utility_component?)
-                              .and_return(false)
             trigger_fatal_error
 
-            logger = @deployment.each_executed_task.first
-            syskit_configure_and_start(logger)
-            expect_execution { logger.stop! }
+            expect_execution { task2.stop! }
                 .to do
+                    emit task2.stop_event
                     emit deployment.kill_event
                     emit deployment.signaled_event
                 end
-        end
-
-        it "does kill a deployment with a fatal-errored task "\
-           "once all non-utility tasks have stopped" do
-            flexmock(Roby.app).should_receive(:syskit_utility_component?)
-                              .and_return(false)
-            trigger_fatal_error
-
-            logger = @deployment.each_executed_task.first
-            syskit_configure_and_start(logger)
-            expect_execution { logger.stop! }
-                .to do
-                    emit deployment.kill_event
-                    emit deployment.signaled_event
-                end
-        end
-
-        it "kills the deployment if the task was the only one running on it" do
-            trigger_fatal_error do
-                emit deployment.kill_event
-                emit deployment.signaled_event
-            end
         end
 
         def trigger_fatal_error(&block)

--- a/test/live/test_state_reader_disconnection.rb
+++ b/test/live/test_state_reader_disconnection.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+using_task_library "logger"
+using_task_library "orogen_syskit_tests"
+
+module Syskit
+    class StateReaderDisconnectionTests < Syskit::Test::ComponentTest
+        run_live
+
+        attr_reader :task, :deployment
+
+        before do
+            @orig_connect_timeout = Orocos::CORBA.connect_timeout
+            @orig_call_timeout = Orocos::CORBA.call_timeout
+            @orig_opportunistic_recovery =
+                Syskit.conf.opportunistic_recovery_from_quarantine?
+            @orig_auto_restart_flag =
+                Syskit.conf.auto_restart_deployments_with_quarantines?
+
+            Orocos::CORBA.connect_timeout = 100
+            Syskit.conf.opportunistic_recovery_from_quarantine = false
+            Syskit.conf.auto_restart_deployments_with_quarantines = false
+
+            @task_m = OroGen.orogen_syskit_tests.BlockingHooks
+                            .deployed_as("blocking_hooks")
+            @task = syskit_deploy(@task_m)
+            Orocos::CORBA.call_timeout = 5000
+            @task.properties.time = 2
+            @deployment = @task.execution_agent
+            remove_logger
+        end
+
+        after do
+            Orocos::CORBA.connect_timeout = @orig_connect_timeout
+            Orocos::CORBA.call_timeout = @orig_call_timeout
+            Syskit.conf.opportunistic_recovery_from_quarantine =
+                @orig_opportunistic_recovery
+            Syskit.conf.auto_restart_deployments_with_quarantines =
+                @orig_auto_restart_flag
+        end
+
+        describe "when losing the state reader while configuring" do
+            it "quarantines the task" do
+                task.properties.hook = "configure"
+                syskit_start_execution_agents(task)
+                expect_execution.scheduler(true).join_all_waiting_work(false).to do
+                    have_one_new_sample task.sleep_start_port
+                end
+                expect_execution { task.state_reader.disconnect }
+                    .to { quarantine(task) }
+
+                assert task.setup?
+            end
+        end
+
+        describe "when losing the state reader while starting" do
+            before do
+                task.properties.hook = "start"
+                syskit_configure(task)
+                synchronize_on_sleep(task, execute: -> { task.start! })
+            end
+
+            it "goes into quarantine and falls back to the remote state getter" do
+                expect_execution { task.state_reader.disconnect }
+                    .to do
+                        quarantine(task)
+                        emit task.start_event
+                    end
+
+                syskit_stop(task)
+            end
+
+            it "does nothing more if the remote getter is lost as well" do
+                mock_disconnected_remote_state_getter
+                expect_execution { task.state_reader.disconnect }
+                    .to do
+                        quarantine task
+                        fail_to_start task
+                    end
+
+                deployment_kill
+            end
+        end
+
+        describe "when losing the state reader while running" do
+            before do
+                task.properties.hook = "update"
+                syskit_configure(task)
+                synchronize_on_sleep(
+                    task,
+                    execute: -> { task.start! },
+                    predicates: ->(_) { emit task.start_event }
+                )
+            end
+
+            it "goes into quarantine, falls back to the remote state getter and "\
+               "attempts to stop the task" do
+                expect_execution { task.state_reader.disconnect }
+                    .to do
+                        quarantine(task)
+                        emit task.stop_event
+                    end
+            end
+
+            it "does nothing more if the remote getter is lost as well" do
+                mock_disconnected_remote_state_getter
+                # Inhibit the stop call ... or we have a race
+                flexmock(task).should_receive(:queue_last_chance_to_stop)
+                expect_execution { task.state_reader.disconnect }
+                    .to { quarantine task }
+
+                deployment_kill
+            end
+        end
+
+        describe "when losing the state reader while stopping" do
+            before do
+                @task.properties.hook = "stop"
+                syskit_configure_and_start(@task)
+                synchronize_on_sleep(task, execute: -> { task.stop! })
+            end
+
+            it "goes into quarantine and falls back to the remote state getter" do
+                expect_execution { task.state_reader.disconnect }
+                    .to do
+                        quarantine(task)
+                        emit task.stop_event
+                    end
+            end
+
+            it "does nothing more if the remote getter is lost as well" do
+                mock_disconnected_remote_state_getter
+                expect_execution { task.state_reader.disconnect }
+                    .to { quarantine task }
+
+                deployment_kill
+            end
+        end
+
+        describe "when losing the state reader while processing an exception" do
+            before do
+                @task.properties.hook = "exception"
+                syskit_configure(@task)
+                synchronize_on_sleep(task, execute: -> { task.start! })
+            end
+
+            it "goes into quarantine and falls back to the remote state getter" do
+                expect_execution { task.state_reader.disconnect }
+                    .to do
+                        quarantine(task)
+                        emit task.exception_event
+                    end
+            end
+
+            it "does nothing more if the remote getter is lost as well" do
+                mock_disconnected_remote_state_getter
+                expect_execution { task.state_reader.disconnect }
+                    .to { quarantine task }
+
+                deployment_kill
+            end
+        end
+
+        describe "when only losing the remote state reader "\
+                 "while processing an exception" do
+            before do
+                @task.properties.hook = "exception"
+                syskit_configure(@task)
+                synchronize_on_sleep(task, execute: -> { task.start! })
+            end
+
+            it "goes into quarantine" do
+                mock_disconnected_remote_state_getter
+                expect_execution.to { quarantine(task) }
+                deployment_kill
+            end
+        end
+
+        def mock_disconnected_remote_state_getter
+            task_info = task.execution_agent.remote_task_handles[task.orocos_name]
+            flexmock(task_info.state_getter)
+                .should_receive(:connected?).and_return(false)
+        end
+
+        def synchronize_on_sleep(task, execute: ->(_) {}, predicates: ->(_) {})
+            expect_execution(&execute).join_all_waiting_work(false).to do
+                have_one_new_sample task.sleep_start_port
+                instance_eval(&predicates)
+            end
+        end
+
+        def find_logger
+            logger_m = Syskit::TaskContext.find_model_from_orogen_name("logger::Logger")
+            plan.find_tasks(logger_m).first
+        end
+
+        def remove_logger
+            execute do
+                logger = find_logger
+                plan.unmark_permanent_task(logger)
+                plan.remove_task(logger)
+            end
+        end
+
+        def deployment_kill # rubocop:disable Metrics/AbcSize
+            expect_execution { task.execution_agent.stop! }
+                .to do
+                    emit task.execution_agent.stop_event
+                    emit task.aborted_event if task.running?
+                    ignore_errors_from quarantine(task)
+                end
+        end
+    end
+end

--- a/test/models/test_task_context.rb
+++ b/test/models/test_task_context.rb
@@ -26,6 +26,10 @@ describe Syskit::Models::TaskContext do
         it "resolves toplevel events" do
             assert_equal :exception, Syskit::TaskContext.find_state_event(:EXCEPTION)
         end
+
+        it "does not define an event for PRE_OPERATIONAL" do
+            assert_nil Syskit::TaskContext.find_state_event(:PRE_OPERATIONAL)
+        end
     end
 
     describe "specialized models" do

--- a/test/runtime/test_connection_management.rb
+++ b/test/runtime/test_connection_management.rb
@@ -1091,13 +1091,12 @@ module Syskit
             def stop_and_collect_execution_agents(*tasks)
                 expect_execution do
                     tasks.each { |t| t.execution_agent.stop! }
-                end.to do
+                end.garbage_collect(true).to do
                     tasks.each do |t|
-                        emit t.execution_agent.stop_event
+                        emit t.execution_agent.kill_event
                         emit t.aborted_event
                     end
                 end
-                expect_execution.garbage_collect(true).to_run
             end
         end
     end

--- a/test/runtime/test_connection_management.rb
+++ b/test/runtime/test_connection_management.rb
@@ -761,16 +761,20 @@ module Syskit
 
                 it "removes connections when the source deployment is stopped" do
                     stop_and_collect_execution_agents(source)
-                    flexmock(ConnectionManagement).new_instances.should_receive(:warn)
-                                                  .with(/error while disconnecting|I am assuming that the disconnection is actually effective/)
+                    flexmock(ConnectionManagement)
+                        .new_instances.should_receive(:warn)
+                        .with(Regexp.new("error while disconnecting|I am assuming that "\
+                                         "the disconnection is actually effective"))
                     ConnectionManagement.update(plan)
                     assert_is_disconnected(source_alive: false)
                 end
 
                 it "removes connections when the sink deployment is stopped" do
                     stop_and_collect_execution_agents(sink)
-                    flexmock(ConnectionManagement).new_instances.should_receive(:warn)
-                                                  .with(/error while disconnecting|I am assuming that the disconnection is actually effective/)
+                    flexmock(ConnectionManagement)
+                        .new_instances.should_receive(:warn)
+                        .with(Regexp.new("error while disconnecting|I am assuming that "\
+                                         "the disconnection is actually effective"))
                     ConnectionManagement.update(plan)
                     assert_is_disconnected(sink_alive: false)
                 end

--- a/test/runtime/test_update_task_states.rb
+++ b/test/runtime/test_update_task_states.rb
@@ -41,44 +41,6 @@ module Syskit
                 flexmock(task).should_receive(:setup).never
                 Syskit::Runtime.update_task_states(plan)
             end
-
-            it "does not call #will_never_setup? if the task has a configuration precedence" do
-                component_m = Syskit::TaskContext.new_submodel
-                task0 = syskit_stub_and_deploy(component_m)
-                task1 = syskit_stub_and_deploy(component_m)
-                task0.should_configure_after task1.start_event
-                syskit_start_execution_agents(task0)
-                syskit_start_execution_agents(task1)
-
-                flexmock(task0).should_receive(:will_never_setup?).never
-                Runtime.update_task_states(task0.plan)
-            end
-
-            describe "when the task will never setup" do
-                attr_reader :task
-                before do
-                    component_m = Syskit::TaskContext.new_submodel
-                    task = syskit_stub_and_deploy(component_m)
-                    syskit_start_execution_agents(task)
-
-                    plan.unmark_mission_task(task)
-                    flexmock(task).should_receive(:will_never_setup?).once.and_return(true)
-                    @task = task
-                end
-
-                it "attempts to kill it and does nothing further if that succeeds" do
-                    task.should_receive(:kill_execution_agent_if_alone).pass_thru
-                    expect_execution.scheduler(true).to { achieve { task.execution_agent.finishing? } }
-                end
-                it "marks the task as failed-to-start if the execution agent cannot be killed" do
-                    task.should_receive(:kill_execution_agent_if_alone).and_return(false)
-                    failure_reason = expect_execution { Runtime.update_task_states(plan) }
-                                     .scheduler(true)
-                                     .to { fail_to_start task }
-                    assert_equal "#{task} reports that it cannot be configured (FATAL_ERROR ?)",
-                                 failure_reason.original_exception.message
-                end
-            end
         end
     end
 end

--- a/test/test_component.rb
+++ b/test/test_component.rb
@@ -456,12 +456,6 @@ describe Syskit::Component do
         end
     end
 
-    describe "#will_never_setup?" do
-        it "returns false" do
-            refute Syskit::Component.new.will_never_setup?
-        end
-    end
-
     describe "#ready_for_setup?" do
         it "returns true on a blank task" do
             assert Syskit::Component.new.ready_for_setup?

--- a/test/test_deployment.rb
+++ b/test/test_deployment.rb
@@ -514,6 +514,16 @@ module Syskit
                     expect_execution { deployment_task.stop! }
                         .to { emit deployment_task.stop_event }
                 end
+                it "does attempt to gracefully shutdown the deployment "\
+                   "if present tasks are finished" do
+                    task = deployment_task.task("mapped_task_name")
+                    syskit_configure_and_start(task)
+                    expect_execution { task.stop! }.to { emit task.stop_event }
+                    process.should_receive(:kill).once
+                           .with(false, cleanup: false, hard: false).pass_thru
+                    expect_execution { deployment_task.stop! }
+                        .to { emit deployment_task.stop_event }
+                end
                 it "does not cleanup and hard-kills the process if "\
                    "the kill event is called" do
                     orocos_task.should_receive(:rtt_state).never

--- a/test/test_deployment.rb
+++ b/test/test_deployment.rb
@@ -502,7 +502,10 @@ module Syskit
                     process.should_receive(:kill).once
                            .with(false, cleanup: false, hard: false).pass_thru
                     expect_execution { deployment_task.stop! }
-                        .to { emit deployment_task.stop_event }
+                        .to do
+                            emit deployment_task.stop_event
+                            not_emit deployment_task.kill_event
+                        end
                 end
                 it "does not attempt to cleanup if some tasks have a representation in "\
                    "the plan" do
@@ -512,7 +515,10 @@ module Syskit
                     process.should_receive(:kill).once
                            .with(false, cleanup: false, hard: true).pass_thru
                     expect_execution { deployment_task.stop! }
-                        .to { emit deployment_task.stop_event }
+                        .to do
+                            emit deployment_task.stop_event
+                            emit deployment_task.kill_event
+                        end
                 end
                 it "does attempt to gracefully shutdown the deployment "\
                    "if present tasks are finished" do
@@ -522,7 +528,10 @@ module Syskit
                     process.should_receive(:kill).once
                            .with(false, cleanup: false, hard: false).pass_thru
                     expect_execution { deployment_task.stop! }
-                        .to { emit deployment_task.stop_event }
+                        .to do
+                            emit deployment_task.stop_event
+                            not_emit deployment_task.kill_event
+                        end
                 end
                 it "does not cleanup and hard-kills the process if "\
                    "the kill event is called" do
@@ -531,7 +540,10 @@ module Syskit
                     process.should_receive(:kill).once
                            .with(false, cleanup: false, hard: true).pass_thru
                     expect_execution { deployment_task.kill! }
-                        .to { emit deployment_task.stop_event }
+                        .to do
+                            emit deployment_task.stop_event
+                            emit deployment_task.kill_event
+                        end
                 end
                 it "ignores com errors with the tasks" do
                     orocos_task.should_receive(:cleanup).and_raise(Orocos::ComError)

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -429,11 +429,13 @@ module Syskit
                     .timeout(0).to { not_emit task.stop_event }
                 assert task.finishing?
             end
-            it "emits interrupt and aborted if orocos_task#stop raises ComError" do
+            it "is quarantined if orocos_task#stop raises ComError" do
                 orocos_task.should_receive(:stop).and_raise(Orocos::ComError)
                 expect_execution { task.stop! }
                     .to do
-                        emit task.aborted_event, task.interrupt_event
+                        quarantine task
+                        ignore_errors_from(have_error_matching(Roby::EmissionFailed))
+                        emit task.aborted_event
                     end
             end
             it "emits interrupt if orocos_task#stop raises StateTransitionFailed "\

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -595,29 +595,11 @@ module Syskit
                     .and_return([Orocos::OLD_DATA, state = Object.new])
                 assert_equal state, task.update_orogen_state
             end
-        end
-
-        describe "#will_never_setup?" do
-            before do
-                plan.add(@task = TaskContext.new)
-            end
-            it "returns false if the provided state is not FATAL_ERROR" do
-                refute @task.will_never_setup?(:BLA)
-            end
-            it "returns true if the provided state is FATAL_ERROR" do
-                assert @task.will_never_setup?(:FATAL_ERROR)
-            end
-            it "returns false if no state is given and read_current_state "\
-                "returns something else than FATAL_ERROR" do
-                flexmock(@task).should_receive(:read_current_state)
-                               .and_return(:BLA)
-                refute @task.will_never_setup?
-            end
-            it "returns true if no state is given and read_current_state "\
-                "returns FATAL_ERROR" do
-                flexmock(@task).should_receive(:read_current_state)
-                               .and_return(:FATAL_ERROR)
-                assert @task.will_never_setup?
+            it "emits the exception event when transitioned to exception" do
+                task = syskit_stub_deploy_configure_and_start(@task_m, remote_task: false)
+                puts task.orocos_task.class
+                expect_execution { task.orocos_task.exception }
+                    .to { emit task.exception_event }
             end
         end
 

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -2067,14 +2067,15 @@ module Syskit
                         task.properties.test = 21
                         wait_until_promise_stops_on_barrier
                         barrier.wait
-                        execute_one_cycle
+                        expect_execution.to_run
+                        assert_equal 21, task.test_property.remote_value
 
                         flexmock(task).should_receive(:commit_properties).once.pass_thru
                         task.properties.test = 42
 
                         flexmock(task).should_receive(:would_use_property_update?)
                                       .and_return(false)
-                        execute_one_cycle
+                        expect_execution.to_run
                         assert_equal 21, task.test_property.remote_value
                         actual_property_value =
                             Orocos.allow_blocking_calls { task.orocos_task.test }

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -2211,5 +2211,48 @@ module Syskit
                 end
             end
         end
+
+        describe "deployment shortcuts" do
+            before do
+                Syskit.conf.register_process_server(
+                    "unmanaged_tasks", RobyApp::UnmanagedTasksManager.new
+                )
+
+                Roby.app.using_task_library "orogen_syskit_tests"
+                @task_m = TaskContext.find_model_from_orogen_name(
+                    "orogen_syskit_tests::Empty"
+                )
+            end
+            after do
+                Syskit.conf.remove_process_server("unmanaged_tasks")
+            end
+
+            it "allows to declare a 'default' deployment" do
+                name = "#{Process.pid}#{name}"
+                task = syskit_deploy(@task_m.deployed_as(name))
+                assert_equal name, task.orocos_name
+            end
+
+            it "allows to declare an unmanaged deployment" do
+                name = "#{Process.pid}#{name}"
+                task = syskit_deploy(@task_m.deployed_as_unmanaged(name))
+                assert_equal "unmanaged_tasks", task.execution_agent.arguments[:on]
+                assert_equal name, task.orocos_name
+            end
+
+            it "allows to use a specific deployment without prefix" do
+                task = syskit_deploy(
+                    @task_m.deploy_with("syskit_fatal_error_recovery_test")
+                )
+                assert_equal "b", task.orocos_name
+            end
+
+            it "allows to use a specific deployment with prefix" do
+                task = syskit_deploy(
+                    @task_m.deploy_with("syskit_fatal_error_recovery_test" => Process.pid)
+                )
+                assert_equal "#{Process.pid}b", task.orocos_name
+            end
+        end
     end
 end


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-orogen_syskit_tests/pull/1
- [x] https://github.com/rock-core/tools-roby/pull/200
- [x] https://github.com/rock-core/rtt/pull/4

This is built on top of #293 

This pull request is an attempt to (finally) deal with some rather dark corners of component execution. The issue at hand is how to handle components that do not exactly follow the implicit contract of "please do not block" and "report your state". Up until now, they would not really be dealt with, and the system could simply start to do Bad Things.

This type of failure in pre-start states (which are not visible to Syskit) are handled through a new internal flag in Deployment that marks the component as "in fatal". After being started, they are put in quarantine, the support of which has been reworked in https://github.com/rock-core/tools-roby/pull/198 for this purpose.

In both cases, the system will not allow any usage of these components in the network. Syskit just does not know enough to handle them. To recover from this, the pull request implements two things:
- if the component is the only one running in its deployment ("utility tasks" excepted, that is ignoring the logger), the deployment is killed right away.
- if the component is not alone, an optional mechanism (which is disabled by default for backward compatibility reasons) allows to automatically restart it on the next network that needs one of the components that is in fatal. That is (1) it will leave the deployment alone if the "in fatal" components are not used - hoping that the "opportunistic" mechanism will trigger before we need to do the drastic thing - but (2) it will restart the deployment, and obviously the tasks that are executed by it, when required.

Add `Syskit.conf.auto_restart_deployments_with_quarantines = true` to your system configuration (e.g. config/init.rb) to enable the new behavior.