### PR TITLE
fix(orogen-test): unset ROBY_BASE_LOG_DIR before calling orogen-test

### DIFF
--- a/cmake/Syskit.cmake
+++ b/cmake/Syskit.cmake
@@ -56,4 +56,7 @@ function(syskit_orogen_tests NAME)
         COMMAND syskit orogen-test ${testfiles} --workdir ${workdir}/bundle
                        -- ${__minitest_args}
     )
+    set_tests_properties(${NAME} PROPERTIES
+        ENVIRONMENT ROBY_BASE_LOG_DIR
+    )
 endfunction()


### PR DESCRIPTION
Currently, if ROBY_BASE_LOG_DIR is set, the logs of *every* orogen
package whose tests have been executed end up in
$ROBY_BASE_LOG_DIR/bundle, which really makes no sense.

We could create to still store the logs under $ROBY_BASE_LOG_DIR,
but I personally feel that these logs should not be in the global
base log dir. I'm personally always looking for them in the bundle/
folder.