### PR TITLE
feat(orogen-test): set ROBY_BASE_LOG_DIR to ROCK_TEST_LOG_DIR

### DIFF
--- a/cmake/Syskit.cmake
+++ b/cmake/Syskit.cmake
@@ -68,6 +68,6 @@ function(syskit_orogen_tests NAME)
                        -- ${__minitest_args}
     )
     set_tests_properties(${NAME} PROPERTIES
-        ENVIRONMENT ROBY_BASE_LOG_DIR
+        ENVIRONMENT ROBY_BASE_LOG_DIR=${ROCK_TEST_LOG_DIR}
     )
 endfunction()


### PR DESCRIPTION
Instead of clearing it to make sure logs end up in bundle/, set
it to ROCK_TEST_LOG_DIR so that they are part of the test result
logs, which are saved by Autoproj

This allows to inspect networks and component test logs after a failure,
which is quite obviously useful