### PR TITLE
fix: live tests

### DIFF
--- a/test/live/run
+++ b/test/live/run
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/sh -e
 
 dir=$(mktemp -d)
 syskit gen app "$dir/app"

--- a/test/live/run
+++ b/test/live/run
@@ -2,5 +2,5 @@
 
 dir=$(mktemp -d)
 syskit gen app "$dir/app"
-syskit orogen-test --workdir "$dir/app" --logs="$dir/app/logs" "$@"
+syskit orogen-test --workdir "$dir/app" "$@"
 rm -rf $dir

--- a/test/live/test_blocking_hooks.rb
+++ b/test/live/test_blocking_hooks.rb
@@ -82,7 +82,7 @@ module Syskit
                             end
                         end
                         fail_to_start task
-                        emit deployment.stop_event
+                        emit deployment.kill_event
                     end
                 end
             end
@@ -122,7 +122,7 @@ module Syskit
                             end
                         end
                         fail_to_start task
-                        emit deployment.stop_event
+                        emit deployment.kill_event
                     end
                 end
             end
@@ -191,7 +191,7 @@ module Syskit
                             .match.with_origin(task.interrupt_event)
                         )
                         emit task.aborted_event
-                        emit deployment.stop_event
+                        emit deployment.kill_event
                     end
                 end
             end
@@ -254,7 +254,7 @@ module Syskit
                             .match.with_origin(task.interrupt_event)
                         )
                         emit task.aborted_event
-                        emit deployment.stop_event
+                        emit deployment.kill_event
                     end
                 end
             end
@@ -311,7 +311,7 @@ module Syskit
                         end
                         ignore_errors_from quarantine(task)
                         emit task.aborted_event
-                        emit deployment.stop_event
+                        emit deployment.kill_event
                     end
                 end
             end
@@ -397,7 +397,7 @@ module Syskit
                             end
                         end
                         fail_to_start task
-                        emit deployment.stop_event
+                        emit deployment.kill_event
                     end
                 end
 
@@ -444,9 +444,9 @@ module Syskit
 
             executed_tasks =
                 deployment.each_executed_task.find_all(&:running?)
-            expect_execution { deployment.stop! }
+            expect_execution { deployment.kill! }
                 .to do
-                    emit deployment.stop_event
+                    emit deployment.kill_event
                     executed_tasks.each { |t| emit t.aborted_event }
                 end
         end

--- a/test/live/test_fatal_error.rb
+++ b/test/live/test_fatal_error.rb
@@ -73,7 +73,7 @@ module Syskit
             end
 
             it "does not auto-restart the deployment if the tasks "\
-            "in FATAL_ERROR are not involved in the new network" do
+               "in FATAL_ERROR are not involved in the new network" do
                 Syskit.conf.auto_restart_deployments_with_quarantines = true
 
                 trigger_fatal_error(@task)
@@ -83,10 +83,11 @@ module Syskit
             end
 
             it "auto-restarts deployments with a quarantined task "\
-            "if configured to do so" do
+               "if configured to do so" do
                 Syskit.conf.auto_restart_deployments_with_quarantines = true
 
                 @task.quarantined!
+                plan.unmark_mission_task(@task) # avoids QuarantinedTaskError
 
                 # DO NOT use syskit_configure_and_start, it forcefully starts
                 # the execution agent, which does not work here.
@@ -108,10 +109,11 @@ module Syskit
             end
 
             it "does not auto-restart the deployment if quarantined "\
-            "tasks are not involved in the new network" do
+               "tasks are not involved in the new network" do
                 Syskit.conf.auto_restart_deployments_with_quarantines = true
 
                 @task.quarantined!
+                plan.unmark_mission_task(@task) # avoid QuarantinedTaskError
 
                 new_task = syskit_deploy(@task2_m)
                 assert_same @task2, new_task
@@ -128,6 +130,8 @@ module Syskit
                     task.quarantined!
                     task2.quarantined!
                 end.to do
+                    quarantine task
+                    quarantine task2
                     emit task.aborted_event
                     emit task2.aborted_event
                     emit deployment.kill_event


### PR DESCRIPTION
Depends on:
- [x] https://github.com/rock-core/tools-roby/pull/206
- [x] https://github.com/orocos-toolchain/orogen/pull/146
- [x] https://github.com/rock-core/rtt/pull/5
- [x] https://github.com/rock-gazebo/simulation-rock_gazebo/pull/40

These `live` tests have been introduced recently to allow running a full Syskit event loop during the tests, by executing
the files one by one under `syskit orogen-test`

Turns out that the `run` script did not call sh with -e, and that - therefore - any error was ignored. To add insult to injury,
the script itself had a bug (orogen-test has no --logs argument) and the tests were not passing.

Oh well.

Anyways, fix the run script and fix the test. Luckily, I did not manage to find bugs in the code-under-test (but did
find one in Roby's test harness)