### PR TITLE
fix(test): spurious test failure in live test

### DIFF
--- a/lib/syskit/runtime/update_task_states.rb
+++ b/lib/syskit/runtime/update_task_states.rb
@@ -21,7 +21,7 @@ module Syskit
         #
         # Handle state changes for a single task
         def self.handle_single_task_state_update(scheduler, task)
-            task.validate_state_reader_connected
+            return unless task.validate_state_reader_connected
 
             handle_task_configuration(scheduler, task) unless task.setup?
             return if !task.running? && !task.starting?

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -546,7 +546,7 @@ module Syskit
         #
         # Handle having our state reader be disconnected
         def validate_state_reader_connected
-            return if state_reader.connected?
+            return true if state_reader.connected?
 
             queue_last_chance_to_stop if running? && !stop_event.pending?
             quarantined!
@@ -567,6 +567,8 @@ module Syskit
                 elsif stop_event.pending?
                     stop_event.emit_failed(Roby::EmissionFailed.new(error, stop_event))
                 end
+
+                false
             else
                 # Switch to the remote state getter to at least figure out
                 # in which toplevel state we are. The component is unusable
@@ -577,6 +579,8 @@ module Syskit
 
                 @state_reader = @remote_state_getter
                 @remote_state_getter.resume_or_start
+
+                true
             end
         end
 


### PR DESCRIPTION
The bug was a conjunction of three things:
- The tests related to losing both the state reader and the state getter
  would have `join_all_waiting_work(true)`. This caused the tests
  to wait for the blocked method (usually stop) to return.
- update_task_states would call TaskContext#validate_state_reader_connected,
  but still read new states.
- The tests would only mock the remote state getter connected? method,
  which caused update_task_states

So, essentially, we had a race condition between the expect_execution
leaving (that is, the blocking method returning) and the deployment_kill
call. In essence, the tests were not testing what we wanted, that is that
the runtime code would stop reading and reacting to state.

The test got changed to join_all_waiting_work(false) until quarantine,
then sleep to let the blocking call return and then check that the
relevant event was not emitted. These tests failed under the current
implementation.

To fix the tests, I changed update_task_states to not process tasks
whose state reading is completely lost. Note that it had (probably)
no impact on live systems, as a disconnected remote state getter
returns no new states.