### PR TITLE
fix(runtime): ignore finished children in Composition#executable?

### DIFF
--- a/lib/syskit/composition.rb
+++ b/lib/syskit/composition.rb
@@ -197,7 +197,7 @@ module Syskit
                 if child_task.kind_of?(TaskContext)
                     return false unless child_task.orocos_task
                 elsif child_task.kind_of?(Component) && child_task.start_event.root?
-                    return false unless child_task.executable?
+                    return false if child_task.pending? && !child_task.executable?
                 end
             end
             true

--- a/test/test_composition.rb
+++ b/test/test_composition.rb
@@ -340,6 +340,22 @@ describe Syskit::Composition do
             assert cmp.setup?
         end
 
+        it "is compatible with using another composition to achieve start" do
+            starter_cmp_m = Syskit::Composition.new_submodel
+            cmp_m = Syskit::Composition.new_submodel do
+                add starter_cmp_m, as: "starter", success: [:success]
+                event :start do |_context|
+                    start_event.achieve_with starter_child.success_event
+                end
+            end
+
+            cmp = syskit_stub_deploy_and_configure(cmp_m)
+            execute { cmp.start! }
+            syskit_start(cmp.starter_child)
+            expect_execution { cmp.starter_child.success_event.emit }
+                .to { emit cmp.start_event }
+        end
+
         # Test for a regression where the #all_inputs_connected? test that is
         # specific to TaskContext was also applied to compositions
         it "can go through it even if it has input ports" do


### PR DESCRIPTION
Composition#executable? is implemented so that compositions are started
only when all their children are started.

However, if we want to use a child to actually implement an asynchronous
start, this fails: the child emits success, becomes non-executable which
blocks the emission of start.

Modify Composition#executable? to ignore non-pending children, which
are either executable (if running) or will never be (if finished)