### PR TITLE
fix(droby): isolate loaded droby models

### DIFF
--- a/lib/syskit/droby/enable.rb
+++ b/lib/syskit/droby/enable.rb
@@ -9,7 +9,7 @@ Typelib::Type.include Syskit::DRoby::V5::TypelibTypeDumper
 Typelib::Type.extend Syskit::DRoby::V5::TypelibTypeModelDumper
 
 Roby::DRoby::ObjectManager.include Syskit::DRoby::V5::ObjectManagerExtension
-Roby::DRoby::Marshal.include Syskit::DRoby::V5::MarshalExtension
+Roby::DRoby::Marshal.prepend Syskit::DRoby::V5::MarshalExtension
 
 Syskit::InstanceRequirements.include Syskit::DRoby::V5::InstanceRequirementsDumper
 Syskit::Models::ComBusModel.include Syskit::DRoby::V5::ComBusDumper

--- a/lib/syskit/droby/v5/droby_dump.rb
+++ b/lib/syskit/droby/v5/droby_dump.rb
@@ -20,6 +20,12 @@ module Syskit
             end
 
             module MarshalExtension
+                def initialize(*, **)
+                    super
+
+                    @registered_projects = []
+                end
+
                 def has_orogen_project?(project_name)
                     object_manager.has_orogen_project?(project_name)
                 end
@@ -44,6 +50,14 @@ module Syskit
 
                 def find_local_orogen_model(droby)
                     find_local_model(droby, name: "orogen::" + droby.orogen_name)
+                end
+
+                def registered_orogen_project?(project)
+                    @registered_projects.include?(project)
+                end
+
+                def register_orogen_project(project)
+                    @registered_projects << project
                 end
             end
 
@@ -370,7 +384,9 @@ module Syskit
                     # This is the information that is needed to un-marshal it. It
                     # It returns nil if there is no usable information about this project
                     def droby_dump_project(peer, project)
-                        if project.name
+                        if peer.registered_orogen_project?(project)
+                            return Project.new(nil, nil, [])
+                        elsif project.name
                             begin
                                 text, = project
                                         .loader.project_model_text_from_name(project.name)

--- a/lib/syskit/droby/v5/droby_dump.rb
+++ b/lib/syskit/droby/v5/droby_dump.rb
@@ -329,9 +329,22 @@ module Syskit
                         end
                     end
 
+                    def self.related_types_for(type)
+                        return [] unless type.contains_opaques?
+
+                        [Roby.app.default_loader.intermediate_type_for(type)]
+                    end
+
+
                     def droby_dump(peer)
-                        types = orogen_model.each_interface_type
-                                            .map { |t| peer.dump(t) }
+                        types =
+                            orogen_model
+                            .project.self_tasks.each_value
+                            .map { |t| t.each_interface_type.to_a }
+                            .flatten.uniq
+                            .flat_map { |t| [t] + TaskContextDumper.related_types_for(t) }
+
+                        types = types.map { |t| peer.dump(t) }
 
                         supermodel = Roby::DRoby::V5::DRobyModel
                                      .dump_supermodel(peer, self)

--- a/lib/syskit/droby/v5/droby_dump.rb
+++ b/lib/syskit/droby/v5/droby_dump.rb
@@ -208,6 +208,7 @@ module Syskit
 
                 def droby_dump(peer)
                     peer_registry = peer.object_manager.typelib_registry
+
                     unless peer_registry.include?(name)
                         reg = registry.minimal(name)
                         xml = reg.to_xml
@@ -297,10 +298,6 @@ module Syskit
                         end
 
                         def create_new_proxy_model(peer)
-                            peer.object_manager.use_global_loader = @version.nil?
-
-                            register_types(peer)
-
                             unless (local_model = resolve_exact_orogen_model(peer))
                                 syskit_supermodel = peer.local_model(supermodel)
                                 local_model = syskit_supermodel
@@ -354,7 +351,7 @@ module Syskit
                         end
 
                         def update(peer, local_object, fresh_proxy: false)
-                            register_types(peer)
+                            register_types(peer) unless fresh_proxy
 
                             super
                         end

--- a/lib/syskit/droby/v5/droby_dump.rb
+++ b/lib/syskit/droby/v5/droby_dump.rb
@@ -382,8 +382,8 @@ module Syskit
                         end
 
                         types =
-                            project
-                            .self_tasks.each_value.map { |t| t.each_interface_type.to_a }
+                            (project.self_tasks.values + [orogen_model])
+                            .map { |t| t.each_interface_type.to_a }
                             .flatten.uniq
                             .flat_map { |t| [t] + TaskContextDumper.related_types_for(t) }
                         types = types.map { |t| peer.dump(t) }

--- a/lib/syskit/models/base.rb
+++ b/lib/syskit/models/base.rb
@@ -151,12 +151,20 @@ module Syskit
             m.kind_of?(Syskit::Models::Base)
         end
 
-        def self.create_orogen_task_context_model(*args)
-            OroGen::Spec::TaskContext.new(Roby.app.default_orogen_project, *args)
+        def self.create_orogen_project(loader: Roby.app.default_loader)
+            OroGen::Spec::Project.new(loader)
         end
 
-        def self.create_orogen_deployment_model(*args)
-            OroGen::Spec::Deployment.new(Roby.app.default_orogen_project, *args)
+        def self.create_orogen_typekit_model(*args, project: create_orogen_project)
+            OroGen::Spec::Typekit.new(project, *args)
+        end
+
+        def self.create_orogen_task_context_model(*args, project: create_orogen_project, **kw)
+            OroGen::Spec::TaskContext.new(project, *args, **kw)
+        end
+
+        def self.create_orogen_deployment_model(name = nil, project: create_orogen_project)
+            OroGen::Spec::Deployment.new(project, name)
         end
     end
 end

--- a/lib/syskit/models/data_service.rb
+++ b/lib/syskit/models/data_service.rb
@@ -24,8 +24,8 @@ module Syskit
                 model
             end
 
-            def initialize(project: Roby.app.default_orogen_project)
-                @orogen_model = OroGen::Spec::TaskContext.new(project)
+            def initialize(project: Models.create_orogen_project)
+                @orogen_model = Models.create_orogen_task_context_model(project: project)
                 super()
             end
 
@@ -492,7 +492,7 @@ module Syskit
 
         # Metamodel for all communication busses
         class ComBusModel < DeviceModel
-            def initialize(project: Roby.app.default_orogen_project, &block)
+            def initialize(project: Models.create_orogen_project, &block)
                 super
                 @override_policy = true
             end

--- a/lib/syskit/models/task_context.rb
+++ b/lib/syskit/models/task_context.rb
@@ -195,11 +195,13 @@ module Syskit
             def setup_submodel(submodel,
                 orogen_model: nil,
                 orogen_model_name: submodel.name,
+                loader: Roby.app.default_loader,
                 **options)
 
                 unless orogen_model
+                    project = OroGen::Spec::Project.new(loader)
                     orogen_model = self.orogen_model.class.new(
-                        Roby.app.default_orogen_project, orogen_model_name,
+                        project, orogen_model_name,
                         subclasses: self.orogen_model
                     )
                     orogen_model.extended_state_support

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -917,7 +917,7 @@ module Syskit
                                       dot_index, mode)
 
                     path = File.join(dir, basename)
-                    File.open(dataflow_path, "w") do |io|
+                    File.open(path, "w") do |io|
                         io.write Graphviz.new(plan).send(mode, dot_options)
                     end
                     path

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -290,10 +290,6 @@ module Syskit
                 @ros_loader ||= OroGen::ROS::Loader.new(default_loader)
             end
 
-            def default_orogen_project
-                @default_orogen_project ||= OroGen::Spec::Project.new(default_loader)
-            end
-
             # A set of task libraries that should be imported when the application
             # gets reloaded
             #

--- a/lib/syskit/scripts/ide.rb
+++ b/lib/syskit/scripts/ide.rb
@@ -5,8 +5,6 @@ require "syskit/gui/ide"
 require "syskit/scripts/common"
 require "vizkit"
 
-Roby.app.require_app_dir
-
 load_all = false
 runtime_mode = nil
 runtime_only = false
@@ -40,9 +38,9 @@ parser = OptionParser.new do |opt|
 end
 options = {}
 Roby::Application.host_options(parser, options)
-Roby.app.guess_app_dir unless runtime_only
 Syskit::Scripts.common_options(parser, true)
 remaining = parser.parse(ARGV)
+Roby.app.require_app_dir unless runtime_only
 
 # We don't need the process server, win some startup time
 Roby.app.using "syskit"

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -102,17 +102,18 @@ module Syskit
             orogen_model.worstcase_trigger_latency = latency
         end
 
+        # @param [OroGen::Spec::TaskDeployment] orogen_model runtime model for this task
         def initialize(orogen_model: nil, **arguments)
             super(**arguments)
 
             @orogen_model =
                 orogen_model ||
-                Orocos::Spec::TaskDeployment.new(nil, model.orogen_model)
+                OroGen::Spec::TaskDeployment.new(nil, model.orogen_model)
 
             properties = {}
             property_overrides = {}
             model.orogen_model.each_property do |p|
-                type = Roby.app.default_loader.intermediate_type_for(p.type)
+                type = self.class.orogen_model.loader.intermediate_type_for(p.type)
                 properties[p.name] = LiveProperty.new(self, p.name, type)
                 property_overrides[p.name] = Property.new(p.name, type)
             end

--- a/test/droby/test_droby_dump.rb
+++ b/test/droby/test_droby_dump.rb
@@ -183,12 +183,14 @@ module Syskit
             end
 
             it "return an already received oroGen model" do
+                task_m = TaskContext.new_submodel
                 assert_same droby_transfer(task_m).orogen_model,
                             droby_transfer(task_m).orogen_model
             end
 
             it "return an already existing oroGen/Syskit model pair" do
-                assert_same droby_transfer(task_m)
+                task_m = TaskContext.new_submodel
+                assert_same droby_transfer(task_m),
                             droby_transfer(task_m)
             end
 

--- a/test/droby/test_droby_dump.rb
+++ b/test/droby/test_droby_dump.rb
@@ -177,7 +177,7 @@ module Syskit
                                 .with("test").and_return(project_text)
 
                 orogen_model = loader.task_model_from_name("test::Task")
-                task_m = Syskit::TaskContext.define_from_orogen(orogen_model, register: false)
+                task_m = TaskContext.define_from_orogen(orogen_model, register: false)
                 unmarshalled = droby_transfer task_m
                 assert_equal "/Test", unmarshalled.out_port.type.name
             end
@@ -202,28 +202,28 @@ module Syskit
                 loader.project_model_from_text(project_text)
 
                 orogen_model = loader.task_model_from_name("test::Task")
-                task_m = Syskit::TaskContext.define_from_orogen(orogen_model, register: false)
+                task_m = TaskContext.define_from_orogen(orogen_model, register: false)
                 unmarshalled = droby_transfer task_m
                 assert_equal "test::Task", unmarshalled.orogen_model.name
             end
 
             it "gracefully handles models that do not have a real backing project" do
                 orogen_model = Models.create_orogen_task_context_model("test::Task")
-                task_m = Syskit::TaskContext.new_submodel(orogen_model: orogen_model)
+                task_m = TaskContext.new_submodel(orogen_model: orogen_model)
                 unmarshalled = droby_transfer task_m
                 assert_equal "test::Task", unmarshalled.orogen_model.name
             end
 
             it "gracefully handles anonymous models" do
                 orogen_model = Models.create_orogen_task_context_model
-                task_m = Syskit::TaskContext.new_submodel(orogen_model: orogen_model)
+                task_m = TaskContext.new_submodel(orogen_model: orogen_model)
                 unmarshalled = droby_transfer task_m
                 assert_same unmarshalled, droby_transfer(task_m)
             end
 
             it "gracefully handles submodels of anonymous models" do
                 orogen_model = Models.create_orogen_task_context_model
-                task_m = Syskit::TaskContext.new_submodel(orogen_model: orogen_model)
+                task_m = TaskContext.new_submodel(orogen_model: orogen_model)
                 subtask_m = task_m.new_submodel
                 unmarshalled = droby_transfer subtask_m
                 assert_same droby_transfer(task_m), unmarshalled.superclass
@@ -240,7 +240,7 @@ module Syskit
 
             it "marshals and unmarshals the superclasses" do
                 parent_model = Models.create_orogen_task_context_model("parent::Task")
-                parent_m = Syskit::TaskContext.new_submodel(orogen_model: parent_model)
+                parent_m = TaskContext.new_submodel(orogen_model: parent_model)
 
                 child_model = Models.create_orogen_task_context_model(
                     "child::Task", subclasses: parent_model
@@ -257,7 +257,7 @@ module Syskit
             it "deals with types shared between the superclass and the subclass" do
                 parent_model = Models.create_orogen_task_context_model("parent::Task")
                 parent_model.output_port "out", stub_type("/test")
-                parent_m = Syskit::TaskContext.new_submodel(orogen_model: parent_model)
+                parent_m = TaskContext.new_submodel(orogen_model: parent_model)
 
                 child_model = Models.create_orogen_task_context_model(
                     "child::Task", subclasses: parent_model

--- a/test/models/test_deployment.rb
+++ b/test/models/test_deployment.rb
@@ -30,24 +30,24 @@ module Syskit
         end
 
         def test_define_from_orogen
-            orogen_deployment = Orocos::Spec::Deployment.new
-            orogen_task = OroGen::Spec::TaskContext.new(app.default_orogen_project)
+            orogen_deployment = Models.create_orogen_deployment_model
+            orogen_task = Models.create_orogen_task_context_model
             orogen_deployment.task "task", orogen_task
             model = Syskit::Deployment.define_from_orogen orogen_deployment, register: false
             assert_same model.orogen_model, orogen_deployment
         end
 
         def test_define_from_orogen_does_not_register_anonymous_deployment
-            orogen_deployment = Orocos::Spec::Deployment.new
-            orogen_task = OroGen::Spec::TaskContext.new(app.default_orogen_project)
+            orogen_deployment = Models.create_orogen_deployment_model
+            orogen_task = Models.create_orogen_task_context_model
             orogen_deployment.task "task", orogen_task
             flexmock(::Deployments).should_receive(:const_set).never
             Syskit::Deployment.define_from_orogen orogen_deployment, register: true
         end
 
         def test_define_from_orogen_can_register_named_deployments
-            orogen_deployment = Orocos::Spec::Deployment.new(nil, "motor_controller")
-            orogen_task = OroGen::Spec::TaskContext.new(app.default_orogen_project)
+            orogen_deployment = Models.create_orogen_deployment_model("motor_controller")
+            orogen_task = Models.create_orogen_task_context_model
             orogen_deployment.task "task", orogen_task
             model = Syskit::Deployment.define_from_orogen orogen_deployment, register: true
             assert_same model, Deployments::MotorController

--- a/test/models/test_task_context.rb
+++ b/test/models/test_task_context.rb
@@ -156,19 +156,19 @@ module Syskit # :nodoc:
 
         describe "#has_model_for?" do
             it "returns true if the given oroGen model has a corresponding syskit model" do
-                orogen_model = OroGen::Spec::TaskContext.new(app.default_orogen_project, "my_project::Task")
+                orogen_model = Models.create_orogen_task_context_model("my_project::Task")
                 syskit_model = TaskContext.define_from_orogen(orogen_model)
                 assert TaskContext.has_model_for?(orogen_model)
             end
             it "returns false if the given oroGen model does not have a corresponding syskit model" do
-                orogen_model = OroGen::Spec::TaskContext.new(app.default_orogen_project, "my_project::Task")
+                orogen_model = Models.create_orogen_task_context_model("my_project::Task")
                 assert !TaskContext.has_model_for?(orogen_model)
             end
         end
 
         describe "#find_model_from_orogen_name" do
             it "returns the syskit model if there is one for an oroGen model with the given name" do
-                orogen_model = OroGen::Spec::TaskContext.new(app.default_orogen_project, "my_project::Task")
+                orogen_model = Models.create_orogen_task_context_model("my_project::Task")
                 syskit_model = TaskContext.define_from_orogen(orogen_model)
                 assert_same syskit_model, TaskContext.find_model_from_orogen_name("my_project::Task")
             end
@@ -179,21 +179,21 @@ module Syskit # :nodoc:
 
         describe "#has_submodel?" do
             it "returns false on unknown orogen models" do
-                model = OroGen::Spec::TaskContext.new(app.default_orogen_project)
+                model = Models.create_orogen_task_context_model
                 assert !TaskContext.has_model_for?(model)
             end
         end
 
         describe "#find_model_by_orogen" do
             it "returns nil on unknown orogen models" do
-                model = OroGen::Spec::TaskContext.new(app.default_orogen_project)
+                model = Models.create_orogen_task_context_model
                 assert !TaskContext.find_model_by_orogen(model)
             end
         end
 
         describe "#model_for" do
             it "raises ArgumentError on unknown orogen models" do
-                model = OroGen::Spec::TaskContext.new(app.default_orogen_project)
+                model = Models.create_orogen_task_context_model
                 assert_raises(ArgumentError) { TaskContext.model_for(model) }
             end
         end
@@ -204,7 +204,7 @@ module Syskit # :nodoc:
             end
 
             it "registers the model as a constant whose name is based on the oroGen model name, under OroGen" do
-                orogen_model = OroGen::Spec::TaskContext.new(app.default_orogen_project, "my_project::Task")
+                orogen_model = Models.create_orogen_task_context_model("my_project::Task")
                 syskit_model = TaskContext.define_from_orogen(orogen_model, register: true)
                 assert_same syskit_model, OroGen::MyProject::Task
             end
@@ -215,7 +215,7 @@ module Syskit # :nodoc:
                 end
 
                 it "registers the model as a global constant whose name is based on the oroGen model name" do
-                    orogen_model = OroGen::Spec::TaskContext.new(app.default_orogen_project, "my_project::Task")
+                    orogen_model = Models.create_orogen_task_context_model("my_project::Task")
                     syskit_model =
                         TaskContext.define_from_orogen(orogen_model, register: true)
 
@@ -234,14 +234,14 @@ module Syskit # :nodoc:
                 end
 
                 it "issues a warning if requested to register a model as a constant that already exists" do
-                    orogen_model = OroGen::Spec::TaskContext.new(app.default_orogen_project, "definition_module::Task")
+                    orogen_model = Models.create_orogen_task_context_model("definition_module::Task")
                     OroGen::DefinitionModule.const_set(:Task, (obj = Object.new))
                     flexmock(TaskContext).should_receive(:warn).once
                     TaskContext.define_from_orogen(orogen_model, register: true)
                 end
                 it "refuses to register the model as a constant if the constant already exists" do
                     Syskit.logger.level = Logger::FATAL
-                    orogen_model = OroGen::Spec::TaskContext.new(app.default_orogen_project, "definition_module::Task")
+                    orogen_model = Models.create_orogen_task_context_model("definition_module::Task")
                     OroGen::DefinitionModule.const_set(:Task, (obj = Object.new))
                     flexmock(TaskContext).should_receive(:warn).once
                     syskit_model = TaskContext.define_from_orogen(orogen_model, register: true)
@@ -260,7 +260,7 @@ module Syskit # :nodoc:
         describe "#define_from_orogen" do
             it "calls new_submodel to create the new model" do
                 model = TaskContext.new_submodel
-                orogen = OroGen::Spec::TaskContext.new(app.default_orogen_project)
+                orogen = Models.create_orogen_task_context_model
                 flexmock(OroGen::RTT::TaskContext)
                     .should_receive(:new_submodel)
                     .with(orogen_model: orogen).once.and_return(model)
@@ -268,7 +268,7 @@ module Syskit # :nodoc:
             end
 
             it "sets the model name to the OroGen call chain" do
-                project = OroGen::Spec::Project.new(app.default_orogen_project.loader)
+                project = OroGen::Spec::Project.new(app.default_loader)
                 project.name "test"
                 orogen = OroGen::Spec::TaskContext.new(project, "test::Task")
                 TaskContext.define_from_orogen(orogen, register: true)
@@ -276,7 +276,7 @@ module Syskit # :nodoc:
             end
 
             it "registers the model on the OroGen namespace" do
-                project = OroGen::Spec::Project.new(app.default_orogen_project.loader)
+                project = OroGen::Spec::Project.new(app.default_loader)
                 project.name "test"
                 orogen = OroGen::Spec::TaskContext.new(project, "test::Task")
                 TaskContext.define_from_orogen(orogen, register: true)
@@ -295,7 +295,7 @@ module Syskit # :nodoc:
                     end
                 end
 
-                project = OroGen::Spec::Project.new(app.default_orogen_project.loader)
+                project = OroGen::Spec::Project.new(app.default_loader)
                 project.name "test"
                 orogen = OroGen::Spec::TaskContext.new(project, "test::Task")
                 klass.define_from_orogen(orogen, register: true)
@@ -304,10 +304,8 @@ module Syskit # :nodoc:
             end
 
             it "creates the model from the superclass if it does not exist" do
-                orogen_parent = OroGen::Spec::TaskContext.new(app.default_orogen_project)
-                orogen = OroGen::Spec::TaskContext.new(
-                    app.default_orogen_project, subclasses: orogen_parent
-                )
+                orogen_parent = Models.create_orogen_task_context_model
+                orogen = Models.create_orogen_task_context_model(subclasses: orogen_parent)
                 parent_model = TaskContext.new_submodel
                 flexmock(TaskContext)
                     .should_receive(:define_from_orogen).with(orogen, register: false)
@@ -320,12 +318,10 @@ module Syskit # :nodoc:
             end
 
             it "reuses the model of the superclass if it has already been created" do
-                orogen_parent = OroGen::Spec::TaskContext.new(app.default_orogen_project)
+                orogen_parent = Models.create_orogen_task_context_model
                 parent_model = TaskContext.define_from_orogen(orogen_parent)
 
-                orogen = OroGen::Spec::TaskContext.new(
-                    app.default_orogen_project, subclasses: orogen_parent
-                )
+                orogen = Models.create_orogen_task_context_model(subclasses: orogen_parent)
                 flexmock(TaskContext)
                     .should_receive(:define_from_orogen).with(orogen)
                     .pass_thru
@@ -337,12 +333,12 @@ module Syskit # :nodoc:
             end
 
             it "properly defines state events" do
-                orogen = OroGen::Spec::TaskContext.new(app.default_orogen_project) do
-                    error_states :CUSTOM_ERROR
-                    exception_states :CUSTOM_EXCEPTION
-                    fatal_states :CUSTOM_FATAL
-                    runtime_states :CUSTOM_RUNTIME
-                end
+                orogen = Models.create_orogen_task_context_model
+                orogen.error_states :CUSTOM_ERROR
+                orogen.exception_states :CUSTOM_EXCEPTION
+                orogen.fatal_states :CUSTOM_FATAL
+                orogen.runtime_states :CUSTOM_RUNTIME
+
                 model = TaskContext.define_from_orogen orogen
                 assert !model.custom_error_event.terminal?
                 assert model.custom_exception_event.terminal?
@@ -378,7 +374,7 @@ module Syskit # :nodoc:
         describe "#has_dynamic_input_port?" do
             attr_reader :task_m, :opaque_t, :intermediate_t
             before do
-                typekit = OroGen::Spec::Typekit.new(app.default_orogen_project, "test")
+                typekit = Models.create_orogen_typekit_model("test")
                 opaque_t = typekit.create_interface_opaque "/opaque", 0
                 intermediate_t = typekit.create_null "/intermediate"
                 typekit.opaques << OroGen::Spec::OpaqueDefinition.new(opaque_t, intermediate_t.name, {}, nil)
@@ -400,7 +396,7 @@ module Syskit # :nodoc:
         describe "#has_dynamic_output_port?" do
             attr_reader :task_m, :opaque_t, :intermediate_t
             before do
-                typekit = OroGen::Spec::Typekit.new(app.default_orogen_project, "test")
+                typekit = Models.create_orogen_typekit_model("test")
                 opaque_t = typekit.create_interface_opaque "/opaque", 0
                 intermediate_t = typekit.create_null "/intermediate"
                 typekit.opaques << OroGen::Spec::OpaqueDefinition.new(opaque_t, intermediate_t.name, {}, nil)

--- a/test/roby_app/test_rest_api.rb
+++ b/test/roby_app/test_rest_api.rb
@@ -113,15 +113,12 @@ module Syskit
                         Syskit.conf.register_process_server("something_else",
                                                             flexmock)
 
-                        orogen_task_m = OroGen::Spec::TaskContext.new(
-                            Roby.app.default_orogen_project, "test::Task"
-                        )
+                        orogen_task_m =
+                            Models.create_orogen_task_context_model("test::Task")
                         @syskit_task_m = Syskit::TaskContext.define_from_orogen(
                             orogen_task_m
                         )
-                        orogen_deployment_m = OroGen::Spec::Deployment.new(
-                            nil, "test_deployment"
-                        )
+                        orogen_deployment_m = Models.create_orogen_deployment_model("test_deployment")
                         orogen_deployment_m.task "test_task", orogen_task_m
                         @deployment_m = Syskit::Deployment.define_from_orogen(orogen_deployment_m)
                     end

--- a/test/roby_app/test_rest_deployment_manager.rb
+++ b/test/roby_app/test_rest_deployment_manager.rb
@@ -13,13 +13,10 @@ module Syskit
                 @unmanaged_tasks = flexmock
                 @conf.register_process_server("unmanaged_tasks", @unmanaged_tasks)
 
-                @orogen_task_m = OroGen::Spec::TaskContext.new(
-                    @roby_app.default_orogen_project, "test::Task"
-                )
+                @orogen_task_m = Models.create_orogen_task_context_model("test::Task")
                 @task_m = Syskit::TaskContext.new_submodel(orogen_model: @orogen_task_m)
-                @orogen_deployment_m = OroGen::Spec::Deployment.new(
-                    @roby_app.default_orogen_project, "test_deployment"
-                )
+                @orogen_deployment_m =
+                    Models.create_orogen_deployment_model("test_deployment")
                 @orogen_deployment_m.task "test_task", @orogen_task_m
                 @deployment_m = Syskit::Deployment.define_from_orogen(@orogen_deployment_m)
 

--- a/test/test_deployment.rb
+++ b/test/test_deployment.rb
@@ -50,7 +50,7 @@ module Syskit
 
         before do
             @task_m = TaskContext.new_submodel
-            orogen_model = Orocos::Spec::Deployment.new(Orocos.default_loader, "deployment")
+            orogen_model = Models.create_orogen_deployment_model("deployment")
             @orogen_deployed_task = orogen_model.task "task", task_m.orogen_model
             @deployment_m = Deployment.new_submodel(orogen_model: orogen_model)
 
@@ -95,7 +95,7 @@ module Syskit
 
         describe "#initialize" do
             it "uses the model name as default deployment name" do
-                model = Orocos::Spec::Deployment.new(nil, "test")
+                model = Models.create_orogen_deployment_model("test")
                 deployment_m = Deployment.new_submodel(orogen_model: model)
                 deployment = deployment_m.new
                 deployment.freeze_delayed_arguments
@@ -203,7 +203,7 @@ module Syskit
                         event :ready
                     end
 
-                    orogen_model = Orocos::Spec::Deployment.new(Orocos.default_loader, "deployment")
+                    orogen_model = Models.create_orogen_deployment_model("deployment")
                     orogen_master = orogen_model.task "master", task_m.orogen_model
                     orogen_slave = orogen_model.task "slave", task_m.orogen_model
                     orogen_slave.slave_of(orogen_master)


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-orocosrb/pull/147

On top of https://github.com/rock-core/tools-syskit/pull/307 (style fixes)

The current droby loading implementation was always trying to merge remote models with local ones (in Roby.app). This was coming from the (long lost) legacy of distributed roby, where local and remote systems wanted to make sure they were agreeing on the models that they were manipulating.

However, in the only existing use case of the droby implementation - logs - this is very harmful.

- it fails if local models differ from remote ones (i.e. if a local orogen project got changed since a log file was generated)
- it triggers load-time hooks that make us load orogen extension files, which is actually rather slow

This pull request reimplements that part of the loading logic to isolate the loaded models from the global ones. Since it requires changes on the dumped data, it versions it and falls back to the current implementation (global models) for older log files.