### PR TITLE
fix: successfully load log files created before 20ce287 that have incompatible types

### DIFF
--- a/lib/syskit/droby/enable.rb
+++ b/lib/syskit/droby/enable.rb
@@ -8,7 +8,7 @@ Orocos::TaskContext.extend Roby::DRoby::V5::DRobyConstant::Dump
 Typelib::Type.include Syskit::DRoby::V5::TypelibTypeDumper
 Typelib::Type.extend Syskit::DRoby::V5::TypelibTypeModelDumper
 
-Roby::DRoby::ObjectManager.include Syskit::DRoby::V5::ObjectManagerExtension
+Roby::DRoby::ObjectManager.prepend Syskit::DRoby::V5::ObjectManagerExtension
 Roby::DRoby::Marshal.prepend Syskit::DRoby::V5::MarshalExtension
 
 Syskit::InstanceRequirements.include Syskit::DRoby::V5::InstanceRequirementsDumper

--- a/lib/syskit/droby/v5/droby_dump.rb
+++ b/lib/syskit/droby/v5/droby_dump.rb
@@ -314,8 +314,10 @@ module Syskit
                         def create_new_proxy_model(peer)
                             unless (local_model = resolve_exact_orogen_model(peer))
                                 syskit_supermodel = peer.local_model(supermodel)
-                                local_model = syskit_supermodel
-                                              .new_submodel(name: @orogen_name)
+                                local_model =
+                                    syskit_supermodel
+                                    .new_submodel(name: @orogen_name,
+                                                  extended_state_support: false)
                                 if name
                                     local_model.name = name
                                 end

--- a/lib/syskit/models/task_context.rb
+++ b/lib/syskit/models/task_context.rb
@@ -192,9 +192,11 @@ module Syskit
             #
             # @param [String] name an optional name for this submodel
             # @return [void]
-            def setup_submodel(submodel,
+            def setup_submodel(
+                submodel,
                 orogen_model: nil,
                 orogen_model_name: submodel.name,
+                extended_state_support: true,
                 loader: Roby.app.default_loader,
                 **options)
 
@@ -204,7 +206,7 @@ module Syskit
                         project, orogen_model_name,
                         subclasses: self.orogen_model
                     )
-                    orogen_model.extended_state_support
+                    orogen_model.extended_state_support if extended_state_support
                 end
                 submodel.orogen_model = orogen_model
                 super


### PR DESCRIPTION
[20ce287](https://github.com/rock-core/tools-syskit/commit/20ce287864098a0c6390fb54a934b7d98aa8f476) changed the log file format, while keeping backward compatibility on the reading side.

Unfortunately, that means that older log files could still not be loaded if they had incompatible types. This commit adds a way to disable loading orogen models completely, which provides the same functionality, albeit losing some information on the way.