### PR TITLE
fix: Enforce 'ruby_tasks autogeneration inside the './tasks' folder

### DIFF
--- a/lib/syskit/cli/gen_main.rb
+++ b/lib/syskit/cli/gen_main.rb
@@ -127,7 +127,7 @@ module Syskit
             option :robot, aliases: "r", type: :string, default: nil,
                            desc: "the robot name for robot-specific scaffolding"
             def ruby_task(name)
-                gen_common("ruby_task", name, "compositions", "Compositions")
+                gen_common("ruby_task", name, "tasks", "Tasks")
             end
 
             desc "srv NAME", "generate a new data service"


### PR DESCRIPTION
Currently, `syskit gen ruby_task <task>`, generates the new task inside the `./models/compositions` and `./test/compositions` directory. 

With this change, the auto generated files will be in the `tasks` basename.