### PR TITLE
fix(gui): display triggers and logging policies in the IDE

### DIFF
--- a/lib/syskit/gui/component_network_base_view.rb
+++ b/lib/syskit/gui/component_network_base_view.rb
@@ -172,6 +172,8 @@ module Syskit
                 base_task = original_task.as_service
                 engine = Syskit::NetworkGeneration::Engine.new(main_plan)
                 engine.resolve_system_network([base_task.task.planning_task])
+                NetworkGeneration::LoggerConfigurationSupport
+                    .add_logging_to_network(engine, engine.work_plan)
                 base_task.task
             ensure
                 if engine && engine.work_plan.respond_to?(:commit_transaction)

--- a/lib/syskit/gui/component_network_base_view.rb
+++ b/lib/syskit/gui/component_network_base_view.rb
@@ -170,8 +170,19 @@ module Syskit
                 main_plan ||= Roby::Plan.new
                 main_plan.add(original_task = model.as_plan)
                 base_task = original_task.as_service
-                engine = Syskit::NetworkGeneration::Engine.new(main_plan)
-                engine.resolve_system_network([base_task.task.planning_task])
+                begin
+                    engine = Syskit::NetworkGeneration::Engine.new(main_plan)
+                    engine.resolve_system_network([base_task.task.planning_task])
+                rescue RuntimeError
+                    engine = Syskit::NetworkGeneration::Engine.new(main_plan)
+                    engine.resolve_system_network(
+                        [base_task.task.planning_task],
+                        validate_abstract_network: false,
+                        validate_generated_network: false,
+                        validate_deployed_network: false
+                    )
+                end
+
                 NetworkGeneration::LoggerConfigurationSupport
                     .add_logging_to_network(engine, engine.work_plan)
                 base_task.task

--- a/lib/syskit/network_generation/dataflow_dynamics.rb
+++ b/lib/syskit/network_generation/dataflow_dynamics.rb
@@ -141,6 +141,7 @@ module Syskit
             end
 
             def pretty_print(pp)
+                pp.text "sample_size: #{sample_size}"
                 pp.seplist(triggers) do |tr|
                     pp.text "(#{tr.name}): #{tr.period} #{tr.sample_count}"
                 end

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -113,6 +113,9 @@ module Syskit
                 if compute_policies
                     @dataflow_dynamics = DataFlowDynamics.new(work_plan)
                     @port_dynamics = dataflow_dynamics.compute_connection_policies
+                    @dataflow_dynamics.result.each do |task, dynamics|
+                        task.trigger_information = dynamics
+                    end
                     log_timepoint "compute_connection_policies"
                 end
 

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -119,6 +119,9 @@ module Syskit
                     log_timepoint "compute_connection_policies"
                 end
 
+                @deployment_tasks = work_plan.find_local_tasks(Deployment).to_set
+                @deployed_tasks = work_plan.find_local_tasks(Component).to_set
+
                 nil
             end
 

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -69,6 +69,8 @@ module Syskit
             @remote_state_getter = remote_handles.state_getter
             @pending_exception_states = []
 
+            @calculated_dynamics = {}
+
             remote_handles.default_properties.each do |p, p_value|
                 syskit_p = property(p.name)
                 syskit_p.remote_property = p
@@ -102,6 +104,21 @@ module Syskit
             orogen_model.worstcase_trigger_latency = latency
         end
 
+        # @api private
+        #
+        # Set the dynamics calculated during the deployment
+        attr_writer :trigger_information
+
+        # Trigger calculations performed during deployment
+        def task_trigger_information
+            @trigger_information[nil]
+        end
+
+        # Trigger calculations for a single port
+        def find_port_trigger_information(name)
+            @trigger_information[name.to_str]
+        end
+
         # @param [OroGen::Spec::TaskDeployment] orogen_model runtime model for this task
         def initialize(orogen_model: nil, **arguments)
             super(**arguments)
@@ -109,6 +126,7 @@ module Syskit
             @orogen_model =
                 orogen_model ||
                 OroGen::Spec::TaskDeployment.new(nil, model.orogen_model)
+            @trigger_information = {}
 
             properties = {}
             property_overrides = {}


### PR DESCRIPTION
A not-so-well-known feature of Syskit is the ability to calculate and propagate a port's expected dynamics (period and bursts), and use this to calculate connection policies - especially buffer sizes.

The functionality is still working, but displaying the result was broken - probably for a very long time. This pull request restores the display, while at the same time storing the trigger information on the task themselves for easier access / analysis.

The last commit disables validations if a deployed network has errors. This is necessary for e.g. our system which resolves some of the services at runtime.