### PR TITLE
fix: use the localhost process server in --single mode

### DIFF
--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -510,9 +510,7 @@ module Syskit
                     )
                     return client
                 elsif app.single?
-                    client = Syskit::RobyApp::RemoteProcesses::Client.new(
-                        "localhost", port, root_loader: app.default_loader
-                    )
+                    client = process_server_for("localhost")
                     register_process_server(
                         name, client, app.log_dir, host_id: host_id || "localhost"
                     )


### PR DESCRIPTION
The current code was trying to connect to a process server
on localhost, but at the process server's configured port. This
really made no sense.

--single is meant to provide us with a way to run a distributed
system on a single machine. What makes the most sense w.r.t.
process servers is to simply use the local one in this case.