### PR TITLE
fix: register ruby tasks deployments on `Deployments`

### DIFF
--- a/lib/syskit/models/ruby_task_context.rb
+++ b/lib/syskit/models/ruby_task_context.rb
@@ -28,7 +28,7 @@ module Syskit
             # The deployment is created with a single task named 'task'
             def deployment_model
                 orogen_model = self.orogen_model
-                deployment_name = "Deployment::RubyTasks::#{name}"
+                deployment_name = "Deployments::RubyTasks::#{name}"
                 @deployment_model ||=
                     Syskit::Deployment.new_submodel(name: deployment_name) do
                         task "task", orogen_model


### PR DESCRIPTION
All the other deployments are there. `Deployment` was clearly a typo