### PR TITLE
fix(droby): disable rebuilding orogen models for now

### DIFF
--- a/lib/syskit/droby/v5/droby_dump.rb
+++ b/lib/syskit/droby/v5/droby_dump.rb
@@ -5,7 +5,7 @@ module Syskit
         module V5
             VERSION = 1
 
-            @rebuild_orogen_models = true
+            @rebuild_orogen_models = false
 
             # Global control for {ObjectManager#rebuild_orogen_models?}
             #

--- a/test/droby/test_droby_dump.rb
+++ b/test/droby/test_droby_dump.rb
@@ -160,6 +160,12 @@ module Syskit
 
         describe V5::Models::TaskContextDumper do
             before do
+                @__rebuild_orogen_models = Syskit::DRoby::V5.rebuild_orogen_models?
+                Syskit::DRoby::V5.rebuild_orogen_models = true
+            end
+
+            after do
+                Syskit::DRoby::V5.rebuild_orogen_models = @__rebuild_orogen_models
             end
 
             it "dumps the orogen model and rebuilds the model on the other side" do


### PR DESCRIPTION
There are still too many bugs lingering there, and we do little
use of this feature. Disable it by default until it is ready.