### PR TITLE
feat: add 'read_only' attribute for TaskContext

### DIFF
--- a/lib/syskit/exceptions.rb
+++ b/lib/syskit/exceptions.rb
@@ -4,6 +4,7 @@ module Syskit
     class InternalError < RuntimeError; end
     class ConfigError < RuntimeError; end
     class SpecError < RuntimeError; end
+    class InvalidReadOnlyOperation < RuntimeError; end
 
     class Ambiguous < SpecError; end
 

--- a/test/models/test_task_context.rb
+++ b/test/models/test_task_context.rb
@@ -362,7 +362,7 @@ module Syskit # :nodoc:
 
             it "passes the :task_arguments option as arguments to the newly created task" do
                 task = task_model.instanciate(plan, DependencyInjectionContext.new, task_arguments: { conf: ["default"] })
-                assert_equal Hash[conf: ["default"]], task.arguments
+                assert_equal Hash[conf: ["default"], read_only: Roby::DefaultArgument.new(false)], task.arguments
             end
             it "sets the fullfilled model properly" do
                 arguments = Hash[conf: ["default"]]

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -2240,5 +2240,88 @@ module Syskit
                 assert_equal "#{Process.pid}b", task.orocos_name
             end
         end
+
+        describe "read_only" do
+            before do
+                task_m = TaskContext.new_submodel do
+                    property "p", "/double"
+                end
+
+                @task =
+                    syskit_stub_deploy_and_configure(task_m.with_arguments(read_only: true))
+
+                Orocos.allow_blocking_calls { @task.orocos_task.configure(false) }
+            end
+
+            it "raises when attempting to change a property" do
+                task = @task
+
+                assert_raises(InvalidReadOnlyOperation) do
+                    task.properties.p = 2.0
+                end
+            end
+
+            it "emits start when the task is started while the component is running" do
+                task = @task
+                Orocos.allow_blocking_calls { task.orocos_task.start(false) }
+
+                assert state(task.orocos_task) == :RUNNING
+
+                expect_execution { task.start! }
+                    .to { emit task.start_event }
+            end
+
+            it "does not emit start" \
+            "if the task is started while the component is not running" do
+                task = @task
+
+                assert state(task.orocos_task) != :RUNNING
+
+                expect_execution { task.start! }
+                    .to { not_emit task.start_event }
+
+                # just to avoid: "TeardownFailedError: failed to tear down plan"
+                execute { task.stop! }
+            end
+
+            it "emits start when the component is started while the task is starting" do
+                task = @task
+                execute { task.start! }
+
+                assert task.starting?
+
+                expect_execution do
+                    Orocos.allow_blocking_calls { task.orocos_task.start(false) }
+                end.to { emit task.start_event }
+            end
+
+            it "does not emit interrupted" \
+            "if the task is stopped while the component is running" do
+                task = @task
+                Orocos.allow_blocking_calls { task.orocos_task.start(false) }
+                execute { task.start! }
+
+                assert task.running? && state(task.orocos_task) == :RUNNING
+
+                expect_execution { task.stop! }
+                    .to { not_emit task.interrupt_event }
+            end
+
+            it "emits stop when the component is stopped while the task is running" do
+                task = @task
+                Orocos.allow_blocking_calls { task.orocos_task.start(false) }
+                execute { task.start! }
+
+                assert task.running?
+
+                expect_execution do
+                    Orocos.allow_blocking_calls { task.orocos_task.stop(false) }
+                end.to { emit task.stop_event }
+            end
+
+            def state(component)
+                Orocos.allow_blocking_calls { component.rtt_state }
+            end
+        end
     end
 end


### PR DESCRIPTION
read-only tasks are tasks that share a resource (i.e "#orocos_task") with another task running on a different Syskit instance.
In that way, it does not interfere with the resource, as it will only perform read operations, skip setup, and also not stop when interrupted (so child tasks are not garbage collected).