### PR TITLE
feat: allow passing a service expressed as an InstanceRequirements in IR#select_service

### DIFF
--- a/lib/syskit/instance_requirements.rb
+++ b/lib/syskit/instance_requirements.rb
@@ -282,7 +282,9 @@ module Syskit
                 raise ArgumentError, "#{service} is not a service of #{self}"
             end
 
-            if service.component_model.placeholder?
+            if service.kind_of?(InstanceRequirements)
+                merge(service)
+            elsif service.component_model.placeholder?
                 if srv = base_model.find_data_service_from_type(service.model)
                     @base_model = srv
                     @model = srv.attach(model)

--- a/lib/syskit/test/profile_assertions.rb
+++ b/lib/syskit/test/profile_assertions.rb
@@ -266,7 +266,7 @@ module Syskit
                               compute_policies: false,
                               compute_deployments: false)
             rescue Minitest::Assertion, StandardError => e
-                raise ProfileAssertionFailed.new(actions, e), e.message
+                raise ProfileAssertionFailed.new(actions, e), e.message, e.backtrace
             end
 
             # Spec-style call for {#assert_can_instanciate_together}
@@ -361,7 +361,7 @@ module Syskit
                               compute_policies: true,
                               compute_deployments: true)
             rescue Minitest::Assertion, StandardError => e
-                raise ProfileAssertionFailed.new(actions, e), e.message
+                raise ProfileAssertionFailed.new(actions, e), e.message, e.backtrace
             end
 
             # Spec-style call for {#assert_can_deploy_together}
@@ -406,7 +406,7 @@ module Syskit
                 syskit_configure(task_contexts)
                 roots
             rescue Minitest::Assertion, StandardError => e
-                raise ProfileAssertionFailed.new(actions, e), e.message
+                raise ProfileAssertionFailed.new(actions, e), e.message, e.backtrace
             end
 
             # Spec-style call for {#assert_can_configure_together}

--- a/test/test_instance_requirements.rb
+++ b/test/test_instance_requirements.rb
@@ -363,7 +363,10 @@ describe Syskit::InstanceRequirements do
             task_m = Syskit::TaskContext.new_submodel { provides Syskit::DataService.new_submodel, as: "srv" }
             assert_raises(ArgumentError) { req.select_service(task_m.srv_srv) }
         end
-        it "accepts selecting services from placeholder tasks if the set of models in the task matches the set of models in the instance requirements" do
+
+        it "accepts selecting services from placeholder tasks "\
+           "if the set of models in the task matches the set of models "\
+           "in the instance requirements" do
             srv_m  = Syskit::DataService.new_submodel
             task_m = srv_m.placeholder_model
 
@@ -373,6 +376,22 @@ describe Syskit::InstanceRequirements do
             assert_equal srv, req.service
             instanciated = req.instanciate(plan)
             assert_equal srv, instanciated.model
+        end
+
+        it "accepts a service selection expressed as an InstanceRequirements" do
+            srv_m  = Syskit::DataService.new_submodel
+            task_m = Syskit::TaskContext.new_submodel do
+                argument :key
+                provides srv_m, as: "test"
+            end
+
+            req = Syskit::InstanceRequirements.new([task_m])
+            srv = task_m.with_arguments(key: 10).test_srv
+            srv.name = "name" # closer to the original bug, which was a Definition
+            req_srv = req.select_service(srv)
+
+            assert_equal task_m.test_srv, req_srv.model
+            assert_equal({ key: 10 }, req_srv.arguments)
         end
     end
 


### PR DESCRIPTION
InstanceRequirements is the go-to object to represent ready-to-instanciate models (with e.g. arguments). This fixes a use-case, where one would need to inject a specific bound service, while also setting arguments. 