### PR TITLE
fix(net_gen): do not start a logger we do not use

### DIFF
--- a/lib/syskit/network_generation/logger.rb
+++ b/lib/syskit/network_generation/logger.rb
@@ -130,7 +130,6 @@ module Syskit
                     size: Syskit.conf.logs.default_logging_buffer_size
                 ]
 
-                seen_loggers = Set.new
                 engine.deployment_tasks.each do |deployment|
                     next unless deployment.plan
 
@@ -165,12 +164,10 @@ module Syskit
                     # Disconnect current log connections, we're going to
                     # reestablish the ones we want later on. We leave other
                     # connections as-is
-                    unless seen_loggers.include?(logger_task)
-                        dataflow = work_plan.task_relation_graph_for(Flows::DataFlow)
-                        deployment.each_executed_task do |t|
-                            if engine.deployed_tasks.include?(t)
-                                dataflow.remove_relation(t, logger_task)
-                            end
+                    dataflow = work_plan.task_relation_graph_for(Flows::DataFlow)
+                    deployment.each_executed_task do |t|
+                        if engine.deployed_tasks.include?(t)
+                            dataflow.remove_relation(t, logger_task)
                         end
                     end
 

--- a/test/network_generation/test_logger.rb
+++ b/test/network_generation/test_logger.rb
@@ -60,6 +60,23 @@ describe Syskit::NetworkGeneration::LoggerConfigurationSupport do
                               ["out2", "task.out2"] => {}], @dataflow_graph.edge_info(task, logger)
         end
 
+        it "marks the loggers as permanent" do
+            logger = @deployment.task("deployment_Logger")
+            Syskit::NetworkGeneration::LoggerConfigurationSupport
+                .add_logging_to_network(syskit_engine, plan)
+
+            assert plan.permanent_task?(logger)
+        end
+
+        it "does not mark a logger as permanent if it is unused" do
+            logger = @deployment.task("deployment_Logger")
+            flexmock(deployment).should_receive(log_port?: false)
+            Syskit::NetworkGeneration::LoggerConfigurationSupport
+                .add_logging_to_network(syskit_engine, plan)
+
+            refute plan.permanent_task?(logger)
+        end
+
         it "sets default_logger?" do
             logger = deployment.task "deployment_Logger"
             Syskit::NetworkGeneration::LoggerConfigurationSupport


### PR DESCRIPTION
This allows a (fragile but working) sharing of deployments across
Syskit instance, by disabling logging in one of the two instances.