### PR TITLE
fix(cli): disable development mode in `syskit ide`

### DIFF
--- a/lib/syskit/scripts/ide.rb
+++ b/lib/syskit/scripts/ide.rb
@@ -47,6 +47,7 @@ Roby.app.using "syskit"
 Syskit.conf.only_load_models = true
 Syskit.conf.disables_local_process_server = true
 Roby.app.ignore_all_load_errors = true
+Roby.app.development_mode = false
 
 direct_files, model_names = remaining.partition do |arg|
     File.file?(arg)


### PR DESCRIPTION
The development mode turns on features that are specific to a running
Syskit instance, and are useless (and even could be harmful) in the IDE.

I discovered this because after I disabled the rebuilding of orogen
models, the IDE started reporting exceptions related to configuration
loading. At runtime, it was discovering configuration changes and tried
to reload the models using the (now empty) rebuilt models from remote.
Which obviously fails because they had no properties.