### PR TITLE
fix: do not set job_id on the plan patterns' placeholder tasks

### DIFF
--- a/lib/syskit/actions/action_model.rb
+++ b/lib/syskit/actions/action_model.rb
@@ -68,12 +68,11 @@ module Syskit
                 end
 
                 def plan_pattern(**arguments)
-                    job_id = {}
-                    if arguments.key?(:job_id)
-                        job_id[:job_id] = arguments.delete(:job_id)
-                    end
+                    as_plan_args = arguments.slice(:job_id)
+                    arguments.delete(:job_id)
+
                     req = to_instance_requirements(**arguments)
-                    placeholder = req.as_plan(**job_id)
+                    placeholder = req.as_plan(**as_plan_args)
                     placeholder.planning_task.action_model = self
                     placeholder.planning_task.action_arguments = req.arguments
                     placeholder

--- a/lib/syskit/instance_requirements.rb
+++ b/lib/syskit/instance_requirements.rb
@@ -1006,13 +1006,16 @@ module Syskit
         #
         # @return [Syskit::Component]
         def as_plan(**arguments)
+            subplan_args = arguments.slice(:job_id)
+            arguments.delete(:job_id)
+
             if arguments.empty?
                 req = self
             else
                 req = dup
                 req.with_arguments(**arguments)
             end
-            Syskit::InstanceRequirementsTask.subplan(req, **arguments)
+            Syskit::InstanceRequirementsTask.subplan(req, **subplan_args)
         end
 
         def to_s

--- a/test/actions/test_action_model.rb
+++ b/test/actions/test_action_model.rb
@@ -86,14 +86,17 @@ describe Syskit::Actions::Models::Action do
             task = action_m.plan_pattern(job_id: 20, test: 10)
             assert_equal 20, task.planning_task.job_id
         end
+        it "does not pass the job ID argument to the placeholder task" do
+            task = action_m.plan_pattern(job_id: 20, test: 10)
+            refute task.arguments.set?(:job_id)
+        end
         it "does not pass the job ID argument to the action" do
             task = action_m.plan_pattern(job_id: 20, test: 10)
             assert_equal Hash[test: 10], task.planning_task.action_arguments
         end
         it "does not set the job ID at all if not given" do
             task = action_m.plan_pattern
-            # Will raise if already set, even if set to nil
-            task.planning_task.job_id = 10
+            refute task.planning_task.arguments.set?(:job_id)
         end
     end
 

--- a/test/test_instance_requirements.rb
+++ b/test/test_instance_requirements.rb
@@ -616,6 +616,23 @@ describe Syskit::InstanceRequirements do
             ir.as_plan(foo: 10)
             assert_nil ir.arguments[:foo]
         end
+
+        it "does not set job_id if it is not given" do
+            @task_m.argument :foo
+            ir = Syskit::InstanceRequirements.new([@task_m])
+            task = ir.as_plan(foo: 10)
+            refute task.arguments.set?(:job_id)
+            refute task.planning_task.arguments.set?(:job_id)
+        end
+
+        it "keeps job_id to itself, not passing it to the underlying task" do
+            @task_m.argument :foo
+            ir = Syskit::InstanceRequirements.new([@task_m])
+            task = ir.as_plan(job_id: 20, foo: 10)
+            refute task.arguments.set?(:job_id)
+            assert_equal 10, task.arguments[:foo]
+            assert_equal 20, task.planning_task.job_id
+        end
     end
 
     describe "#as" do


### PR DESCRIPTION
This is generally harmless ... unless two actions end up being
handled by the same task.

The regression here for me was the impossibility to spawn two gazebo
links from the same ModelTask. Network generation would create the
same task, but with different job IDs, which then cannot be merged.