### PR TITLE
fix: do not allow read-only if 'Roby.app.single'

### DIFF
--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -171,7 +171,7 @@ module Syskit
         #
         # By default, its false
         def read_only?
-            read_only
+            read_only && !Roby.app.single?
         end
 
         # Whether the task should be kept in plan


### PR DESCRIPTION
During tests, read-only tasks would fail to initialize, leading to strange errors during test case's Teardown