### PR TITLE
feat: optionally kill all running deployments of a process server on connection

### DIFF
--- a/lib/syskit/roby_app/remote_processes.rb
+++ b/lib/syskit/roby_app/remote_processes.rb
@@ -6,3 +6,13 @@ require "syskit/roby_app/remote_processes/loader"
 require "syskit/roby_app/remote_processes/log_upload_state"
 require "syskit/roby_app/remote_processes/process"
 require "syskit/roby_app/remote_processes/protocol"
+
+module Syskit
+    module RobyApp
+        # Implementation of Syskit's remote process server and client
+        module RemoteProcesses
+            extend Logger::Hierarchy
+            extend Logger::Forward
+        end
+    end
+end

--- a/lib/syskit/roby_app/remote_processes/client.rb
+++ b/lib/syskit/roby_app/remote_processes/client.rb
@@ -306,6 +306,14 @@ module Syskit
                     join(deployment_name) if wait
                 end
 
+                def kill_all(cleanup: false, hard: true)
+                    socket.write(COMMAND_KILL_ALL)
+                    Marshal.dump([cleanup, hard], socket)
+                    raise Failed, "failed kill_all" unless wait_for_ack
+
+                    Marshal.load(socket)
+                end
+
                 def join(deployment_name)
                     process = processes[deployment_name]
                     return unless process

--- a/lib/syskit/roby_app/remote_processes/client.rb
+++ b/lib/syskit/roby_app/remote_processes/client.rb
@@ -279,14 +279,14 @@ module Syskit
 
                     result = {}
                     @death_queue.each do |name, status|
-                        Orocos.debug "#{name} died"
+                        RemoteProcesses.debug "#{name} died"
                         if (p = processes.delete(name))
                             p.dead!
                             result[p] = status
                         else
-                            Orocos.warn "process server reported the exit "\
-                                        "of '#{name}', but no process with "\
-                                        "that name is registered"
+                            RemoteProcesses.warn "process server reported the exit "\
+                                                 "of '#{name}', but no process with "\
+                                                 "that name is registered"
                         end
                     end
                     @death_queue.clear

--- a/lib/syskit/roby_app/remote_processes/protocol.rb
+++ b/lib/syskit/roby_app/remote_processes/protocol.rb
@@ -11,7 +11,8 @@ module Syskit
             COMMAND_START      = "S"
             COMMAND_END        = "E"
             COMMAND_QUIT       = "Q"
-            COMMAND_LOG_UPLOAD_FILE = "U"
+            COMMAND_KILL_ALL   = "K"
+            COMMAND_LOG_UPLOAD_FILE  = "U"
             COMMAND_LOG_UPLOAD_STATE = "X"
 
             EVENT_DEAD_PROCESS = "D"

--- a/lib/syskit/roby_app/remote_processes/server.rb
+++ b/lib/syskit/roby_app/remote_processes/server.rb
@@ -199,7 +199,8 @@ module Syskit
                             readable_sockets.delete(com_r)
                             cmd = com_r.read(1)
                             if cmd == INTERNAL_SIGCHLD_TRIGGERED
-                                process_dead_processes
+                                dead_processes = reap_dead_subprocesses
+                                announce_dead_processes(dead_processes)
                             elsif cmd == INTERNAL_QUIT
                                 next
                             elsif cmd
@@ -230,24 +231,74 @@ module Syskit
                     quit_and_join
                 end
 
-                def process_dead_processes
-                    while (exited = ::Process.wait2(-1, ::Process::WNOHANG))
-                        pid, exit_status = *exited
-                        process_name, process = processes.find { |_, p| p.pid == pid }
-                        next unless process_name
+                # Check if a specific subprocess terminated and deregister it
+                #
+                # @param [Integer] pid the subprocess pid
+                # @return [(Orocos::Process,Process::Status),nil] the terminated process
+                #   and its exit status if it terminated, nil otherwise
+                # @raise Errno::ECHILD if there is no such child with this PID
+                def try_wait_for_subprocess_exit(pid)
+                    return unless (exited = try_wait_pid(pid))
 
-                        process.dead!(exit_status)
-                        processes.delete(process_name)
-                        Server.debug "announcing death: #{process_name}"
+                    handle_dead_subprocess(*exited)
+                end
+
+                # Detect all subprocesses of this server that have died and
+                # de-register them
+                #
+                # @return [Array<(Orocos::Process,Process:Status)>] the list of terminated
+                #   subprocesses and their exit status
+                def reap_dead_subprocesses
+                    dead_processes = []
+                    while (exited = try_wait_pid(-1))
+                        dead_processes << handle_dead_subprocess(*exited)
+                    end
+                    dead_processes
+                rescue Errno::ECHILD
+                    dead_processes
+                end
+
+                # Reap a single terminated subprocess if there is one
+                #
+                # @param [Integer] pid PID of a specific subprocess of interest.
+                #   Set to -1 for all subprocesss
+                # @return [Proces::Status,nil] the exit status or nil if no
+                #   subprocess matching `pid` has finished
+                def try_wait_pid(pid)
+                    ::Process.wait2(pid, ::Process::WNOHANG)
+                end
+
+                # Deregister a dead subprocess from the server
+                #
+                # @param [Integer] exit_pid the process PID
+                # @param [Process::Status] exit_status the process exit status
+                # @return [(Orocos::Process,Process::Status)]
+                def handle_dead_subprocess(exit_pid, exit_status)
+                    process_name, process =
+                        processes.find { |_, p| p.pid == exit_pid }
+                    return unless process_name
+
+                    process.dead!(exit_status)
+                    processes.delete(process_name)
+
+                    [process, exit_status]
+                end
+
+                # Announce the end of finished sub-processes to our clients
+                #
+                # @param [Array<(Orocos::Process,Process::Status)>] the list of
+                #   terminated processes
+                def announce_dead_processes(dead_processes)
+                    dead_processes.each do |process, exit_status|
+                        Server.debug "announcing death of #{process.name}"
                         each_client do |socket|
                             Server.debug "  announcing to #{socket}"
                             socket.write(EVENT_DEAD_PROCESS)
-                            Marshal.dump([process_name, exit_status], socket)
+                            Marshal.dump([process.name, exit_status], socket)
                         rescue SystemCallError, IOError => e
                             Server.debug "  #{socket}: #{e}"
                         end
                     end
-                rescue Errno::ECHILD # rubocop:disable Lint/SuppressedException
                 end
 
                 # Helper method that stops all running processes
@@ -343,6 +394,14 @@ module Syskit
                             Server.warn "no process named #{name} to end"
                             socket.write(RET_NO)
                         end
+                    elsif cmd_code == COMMAND_KILL_ALL
+                        cleanup, hard = Marshal.load(socket)
+                        Server.debug "#{socket} requested the end of all processes"
+                        processes = kill_all(cleanup: cleanup, hard: hard)
+                        dead = join_all(processes)
+                        socket.write(RET_YES)
+                        ret = dead.map { |dead_p, dead_s| [dead_p.name, dead_s] }
+                        socket.write Marshal.dump(ret)
                     elsif cmd_code == COMMAND_QUIT
                         quit
                     elsif cmd_code == COMMAND_LOG_UPLOAD_FILE
@@ -433,6 +492,50 @@ module Syskit
 
                 def end_process(process, cleanup: true, hard: false)
                     process.kill(false, cleanup: cleanup, hard: hard)
+                end
+
+                # Kill all running subprocesses
+                #
+                # This method does not wait for their end, nor does it de-register
+                # them.
+                #
+                # @see join_all announce_dead_processes
+                def kill_all(cleanup: false, hard: true)
+                    processes.each_value do |p|
+                        p.kill(false, cleanup: cleanup, hard: hard)
+                    end
+                    processes.values
+                end
+
+                # Exception raised by {#join_all} when its timeout is reached
+                class JoinAllTimeout < RuntimeError; end
+
+                # Wait for the given processes to end
+                #
+                # @param [Array<Orocos::Process>] processes the subprocess objects
+                # @param [Float] poll polling period in seconds
+                # @param [Float] timeout timeout after which the method will raise
+                #   if there are some of the listed subprocesses still running
+                # @return [Array<(Orocos::Process,Process::Status)>]
+                def join_all(processes, poll: 0.1, timeout: 10)
+                    deadline = Time.now + timeout
+                    dead_processes = []
+                    until processes.empty?
+                        processes.delete_if do |p|
+                            if (status = try_wait_for_subprocess_exit(p.pid))
+                                dead_processes << status
+                                true
+                            end
+                        end
+
+                        if Time.now > deadline
+                            raise JoinAllTimeout,
+                                  "timed out while waiting for #{processes.size} "\
+                                  "processes to terminate"
+                        end
+                        sleep poll
+                    end
+                    dead_processes
                 end
 
                 def quit

--- a/lib/syskit/roby_app/remote_processes/server.rb
+++ b/lib/syskit/roby_app/remote_processes/server.rb
@@ -217,9 +217,9 @@ module Syskit
                         end
                     end
 
-                    Server.fatal "process server exited normally"
+                    Server.info "process server exited normally"
                 rescue Interrupt
-                    Server.fatal "process server exited after SIGINT"
+                    Server.warn "process server exited after SIGINT"
                 rescue Exception => e
                     Server.fatal "process server exited because of unhandled exception"
                     Server.fatal "#{e.message} #{e.class}"
@@ -252,9 +252,9 @@ module Syskit
 
                 # Helper method that stops all running processes
                 def quit_and_join # :nodoc:
-                    Server.warn "stopping process server"
+                    Server.info "stopping process server"
                     processes.each_value do |p|
-                        Server.warn "killing #{p.name}"
+                        Server.info "killing #{p.name}"
                         # Kill the process hard. If there are still processes,
                         # it means that the normal cleanup procedure did not
                         # work.  Not the time to call stop or whatnot

--- a/lib/syskit/roby_app/remote_processes/server.rb
+++ b/lib/syskit/roby_app/remote_processes/server.rb
@@ -143,6 +143,7 @@ module Syskit
                     end
                 end
 
+                INTERNAL_QUIT = "Q"
                 INTERNAL_SIGCHLD_TRIGGERED = "S"
 
                 def open(fd: nil)
@@ -199,6 +200,8 @@ module Syskit
                             cmd = com_r.read(1)
                             if cmd == INTERNAL_SIGCHLD_TRIGGERED
                                 process_dead_processes
+                            elsif cmd == INTERNAL_QUIT
+                                next
                             elsif cmd
                                 Server.warn "unknown internal communication code "\
                                             "#{cmd.inspect}"
@@ -434,6 +437,7 @@ module Syskit
 
                 def quit
                     @quit = true
+                    @com_w&.write INTERNAL_QUIT
                 end
 
                 Upload = Struct.new(

--- a/test/roby_app/remote_processes/test_remote_processes.rb
+++ b/test/roby_app/remote_processes/test_remote_processes.rb
@@ -11,39 +11,6 @@ describe Syskit::RobyApp::RemoteProcesses do
     attr_reader :client
     attr_reader :root_loader
 
-    class TestLogTransferServer < Syskit::RobyApp::LogTransferServer::SpawnServer
-        attr_reader :certfile_path
-
-        def initialize(target_dir, user, password)
-            @certfile_path = File.join(__dir__, "cert.crt")
-            private_cert = File.join(__dir__, "cert-private.crt")
-            super(target_dir, user, password, private_cert)
-        end
-    end
-
-    def start_server
-        raise "server already started" if @server
-
-        @server = Syskit::RobyApp::RemoteProcesses::Server.new(@app, port: 0)
-        server.open
-        @server_thread = Thread.new { server.listen }
-    end
-
-    def connect_to_server
-        @root_loader = OroGen::Loaders::Aggregate.new
-        OroGen::Loaders::RTT.setup_loader(root_loader)
-        @client = Syskit::RobyApp::RemoteProcesses::Client.new(
-            "localhost",
-            server.port,
-            root_loader: root_loader
-        )
-    end
-
-    def start_and_connect_to_server
-        start_server
-        connect_to_server
-    end
-
     before do
         @app = Roby::Application.new
         @app.log_dir = make_tmpdir
@@ -304,5 +271,38 @@ describe Syskit::RobyApp::RemoteProcesses do
                 flunk("upload failed: #{r.message}") unless r.success?
             end
         end
+    end
+
+    class TestLogTransferServer < Syskit::RobyApp::LogTransferServer::SpawnServer
+        attr_reader :certfile_path
+
+        def initialize(target_dir, user, password)
+            @certfile_path = File.join(__dir__, "cert.crt")
+            private_cert = File.join(__dir__, "cert-private.crt")
+            super(target_dir, user, password, private_cert)
+        end
+    end
+
+    def start_server
+        raise "server already started" if @server
+
+        @server = Syskit::RobyApp::RemoteProcesses::Server.new(@app, port: 0)
+        server.open
+        @server_thread = Thread.new { server.listen }
+    end
+
+    def connect_to_server
+        @root_loader = OroGen::Loaders::Aggregate.new
+        OroGen::Loaders::RTT.setup_loader(root_loader)
+        @client = Syskit::RobyApp::RemoteProcesses::Client.new(
+            "localhost",
+            server.port,
+            root_loader: root_loader
+        )
+    end
+
+    def start_and_connect_to_server
+        start_server
+        connect_to_server
     end
 end

--- a/test/roby_app/remote_processes/test_remote_processes.rb
+++ b/test/roby_app/remote_processes/test_remote_processes.rb
@@ -47,8 +47,11 @@ describe Syskit::RobyApp::RemoteProcesses do
     before do
         @app = Roby::Application.new
         @app.log_dir = make_tmpdir
-        @current_log_level = Syskit::RobyApp::RemoteProcesses::Server.logger.level
-        Syskit::RobyApp::RemoteProcesses::Server.logger.level = Logger::FATAL + 1
+        @__server_current_log_level =
+            Syskit::RobyApp::RemoteProcesses::Server.logger.level
+        Syskit::RobyApp::RemoteProcesses::Server.logger.level = Logger::WARN
+        @__orocos_current_log_level = Orocos.logger.level
+        Orocos.logger.level = Logger::FATAL
     end
 
     after do
@@ -58,9 +61,12 @@ describe Syskit::RobyApp::RemoteProcesses do
         end
         @server&.close
 
-        if @current_log_level
-            Syskit::RobyApp::RemoteProcesses::Server.logger.level = @current_log_level
+        if @__server_current_log_level
+            Syskit::RobyApp::RemoteProcesses::Server.logger.level =
+                @__server_current_log_level
         end
+
+        Orocos.logger.level = @__orocos_current_log_level if @__orocos_current_log_level
     end
 
     describe "#initialize" do

--- a/test/roby_app/remote_processes/test_remote_processes.rb
+++ b/test/roby_app/remote_processes/test_remote_processes.rb
@@ -163,7 +163,6 @@ describe Syskit::RobyApp::RemoteProcesses do
     end
 
     describe "stopping all remote processes" do
-        attr_reader :process
         before do
             start_and_connect_to_server
             @processes = 10.times.map do |i|
@@ -190,10 +189,9 @@ describe Syskit::RobyApp::RemoteProcesses do
         end
 
         it "does not send for a notification that the process died" do
-            Process.kill "KILL", process.pid
-            dead_processes = client.wait_termination
-            assert dead_processes[process]
-            assert !process.alive?
+            client.kill_all
+            sleep 2
+            assert client.wait_termination(0).empty?
         end
     end
 

--- a/test/roby_app/remote_processes/test_remote_processes.rb
+++ b/test/roby_app/remote_processes/test_remote_processes.rb
@@ -53,7 +53,7 @@ describe Syskit::RobyApp::RemoteProcesses do
 
     after do
         if @server_thread&.alive?
-            @server_thread.raise Interrupt
+            @server.quit
             @server_thread.join
         end
         @server&.close


### PR DESCRIPTION
This should allow to recover from Syskit crashes (provided that a
watchdog kills the Syskit process). It does not apply to local process
servers, as they are always started fresh. But local process servers
(and locally started components) can be terminated by e.g. systemd
along with syskit itself. This is meant to deal with the remote ones.