### PR TITLE
fix: update syskit start all deployments method 

### DIFF
--- a/lib/syskit/models/deployment_group.rb
+++ b/lib/syskit/models/deployment_group.rb
@@ -225,6 +225,9 @@ module Syskit
 
             # Enumerates all the deployments registered on self
             #
+            # @param [String] on the process server names to look for. If empty, all
+            #   process server names will be considered.
+            # @param [String] except_on the process server names to be ignored.
             # @yieldparam [ConfiguredDeployment]
             def each_configured_deployment(on: [], except_on: [])
                 return enum_for(__method__, on: on, except_on: except_on) unless block_given?

--- a/lib/syskit/models/deployment_group.rb
+++ b/lib/syskit/models/deployment_group.rb
@@ -226,15 +226,13 @@ module Syskit
             # Enumerates all the deployments registered on self
             #
             # @yieldparam [ConfiguredDeployment]
-            def each_configured_deployment(on: nil, except_on: "")
-                return enum_for(__method__) unless block_given?
+            def each_configured_deployment(on: [], except_on: [])
+                return enum_for(__method__, on: on, except_on: except_on) unless block_given?
 
                 deployments.each_value do |set|
                     set.each do |c|
-                        if !on.nil? && c.process_server_name == on || \
-                           on.nil? && c.process_server_name != except_on
-                            yield(c)
-                        end
+                        yield(c) if !on.empty? && on.include?(c.process_server_name)
+                        yield(c) if on.empty? && !except_on.include?(c.process_server_name)
                     end
                 end
             end

--- a/lib/syskit/models/deployment_group.rb
+++ b/lib/syskit/models/deployment_group.rb
@@ -225,18 +225,12 @@ module Syskit
 
             # Enumerates all the deployments registered on self
             #
-            # @param [String] on the process server names to look for. If empty, all
-            #   process server names will be considered.
-            # @param [String] except_on the process server names to be ignored.
             # @yieldparam [ConfiguredDeployment]
-            def each_configured_deployment(on: [], except_on: [])
-                return enum_for(__method__, on: on, except_on: except_on) unless block_given?
+            def each_configured_deployment
+                return enum_for(__method__) unless block_given?
 
                 deployments.each_value do |set|
-                    set.each do |c|
-                        yield(c) if !on.empty? && on.include?(c.process_server_name)
-                        yield(c) if on.empty? && !except_on.include?(c.process_server_name)
-                    end
+                    set.each { |c| yield(c) }
                 end
             end
 

--- a/lib/syskit/models/deployment_group.rb
+++ b/lib/syskit/models/deployment_group.rb
@@ -226,11 +226,16 @@ module Syskit
             # Enumerates all the deployments registered on self
             #
             # @yieldparam [ConfiguredDeployment]
-            def each_configured_deployment
+            def each_configured_deployment(on: nil, except_on: "")
                 return enum_for(__method__) unless block_given?
 
                 deployments.each_value do |set|
-                    set.each { |c| yield(c) }
+                    set.each do |c|
+                        if !on.nil? && c.process_server_name == on || \
+                           on.nil? && c.process_server_name != except_on
+                            yield(c)
+                        end
+                    end
                 end
             end
 

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -741,12 +741,19 @@ module Syskit
                                            .find_all(&:reusable?)
                                            .map(&:process_name).to_set
 
-                deployment_group.each_configured_deployment(
-                          on: on,
-                          except_on: except_on
-                ) do |configured_deployment|
-                    if existing_deployments.include?(configured_deployment.process_name)
-                        next
+                deployment_group.each_configured_deployment do |configured_deployment|
+                    next if existing_deployments.include?(
+                        configured_deployment.process_name
+                    )
+
+                    if on.empty?
+                        next if except_on.include?(
+                            configured_deployment.process_server_name
+                        )
+                    else
+                        next unless on.include?(
+                            configured_deployment.process_server_name
+                        )
                     end
 
                     plan.add_permanent_task(configured_deployment.new)

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -735,8 +735,15 @@ module Syskit
                                            .find_all(&:reusable?)
                                            .map(&:process_name).to_set
 
-                Syskit.conf.each_configured_deployment(on: on, except_on: except_on) do |configured_deployment|
-                    next if existing_deployments.include?(configured_deployment.process_name)
+                Syskit.conf
+                      .deployment_group
+                      .each_configured_deployment(
+                          on: on,
+                          except_on: except_on
+                      ) do |configured_deployment|
+                    if existing_deployments.include?(configured_deployment.process_name)
+                        next
+                    end
 
                     plan.add_permanent_task(configured_deployment.new)
                 end

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -727,10 +727,10 @@ module Syskit
 
             # Start all deployments
             #
-            # @param [String] on the name of the process servers on which
+            # @param [Array<String>] on the name of the process servers on which
             #   deployments should be started. If empty, all servers are considered
-            # @param [String] except_on the of the process servers on which deployments
-            #   should NOT be started.
+            # @param [Array<String>] except_on the of the process servers on which
+            #   deployments should NOT be started.
             def syskit_start_all_deployments(
                 deployment_group: Syskit.conf.deployment_group,
                 on: [],

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -727,8 +727,10 @@ module Syskit
 
             # Start all deployments
             #
-            # @param [String,nil] on the name of the process server on which
-            #   deployments should be started. If nil, all servers are considered
+            # @param [String] on the name of the process servers on which
+            #   deployments should be started. If empty, all servers are considered
+            # @param [String] except_on the of the process servers on which deployments
+            #   should NOT be started.
             def syskit_start_all_deployments(
                 deployment_group: Syskit.conf.deployment_group,
                 on: [],

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -729,18 +729,20 @@ module Syskit
             #
             # @param [String,nil] on the name of the process server on which
             #   deployments should be started. If nil, all servers are considered
-            def syskit_start_all_deployments(on: nil, except_on: "unmanaged_tasks")
+            def syskit_start_all_deployments(
+                deployment_group: Syskit.conf.deployment_group,
+                on: [],
+                except_on: ["unmanaged_tasks"]
+            )
                 existing_deployments = plan.find_tasks(Syskit::Deployment)
                                            .not_finished
                                            .find_all(&:reusable?)
                                            .map(&:process_name).to_set
 
-                Syskit.conf
-                      .deployment_group
-                      .each_configured_deployment(
+                deployment_group.each_configured_deployment(
                           on: on,
                           except_on: except_on
-                      ) do |configured_deployment|
+                ) do |configured_deployment|
                     if existing_deployments.include?(configured_deployment.process_name)
                         next
                     end

--- a/test/roby_app/test_plugin.rb
+++ b/test/roby_app/test_plugin.rb
@@ -338,6 +338,17 @@ module Syskit
 
             describe "Syskit start all deployments" do
                 attr_reader :group
+
+                def use_model_on_group(model, name, server)
+                    deployment_m = syskit_stub_deployment_model(model)
+                    @group.use_deployment(
+                        Hash[deployment_m => name],
+                        on: server,
+                        process_managers: @conf,
+                        loader: @loader
+                    )
+                end
+
                 before do
                     @app = Roby::Application.new
                     @conf = RobyApp::Configuration.new(@app)
@@ -349,27 +360,14 @@ module Syskit
                         "test-mng", Orocos::RubyTasks::ProcessManager.new(@loader), ""
                     )
                     @group = Syskit::Models::DeploymentGroup.new
-
                     model_m = Syskit::TaskContext.new_submodel(
                         orogen_model_name: "test::Task"
-                    )
-                    deployment_m = syskit_stub_deployment_model(model_m)
-                    @group.use_deployment(
-                        Hash[deployment_m => "task"],
-                        on: "localhost",
-                        process_managers: @conf,
-                        loader: @loader
                     )
                     second_model_m = Syskit::TaskContext.new_submodel(
                         name: "empty", orogen_model_name: "orogen_syskit_tests::Empty"
                     )
-                    second_deployment_m = syskit_stub_deployment_model(second_model_m)
-                    @group.use_deployment(
-                        Hash[second_deployment_m => "empty"],
-                        on: "test-mng",
-                        process_managers: @conf,
-                        loader: @loader
-                    )
+                    use_model_on_group(model_m, "task", "localhost")
+                    use_model_on_group(second_model_m, "empty", "test-mng")
                 end
 
                 it "starts all deployments" do


### PR DESCRIPTION
It needed a `each_configured_deployment` method from `Syskit.conf` which doesnt exist anymore.