### PR TITLE
feat(app): optionally call kill_all on newly connected process servers

### DIFF
--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -84,6 +84,16 @@ module Syskit
             #   disabled altogether
             attr_accessor :log_rotation_period
 
+            # Whether Syskit should instruct a process server to kill all its
+            # processes on connection
+            #
+            # This is a recovery mechanism on Syskit crash. Cleaning up the
+            # process server allows to reuse it and recover quickly.
+            #
+            # It is false by default for backward compatibility, but you most
+            # likely want this
+            attr_predicate :kill_all_on_process_server_connection?, true
+
             # Whether the rotated logs should be uploaded to Syskit's local log dir
             #
             # This is considered experimental, and is disabled by default
@@ -122,6 +132,7 @@ module Syskit
                 @opportunistic_recovery_from_quarantine = true
                 @auto_restart_deployments_with_quarantines = false
                 @exception_transition_timeout = 20.0
+                @kill_all_on_process_server_connection = false
 
                 @log_rotation_period = nil
                 @log_upload = false
@@ -565,6 +576,7 @@ module Syskit
                     log_dir, Roby.app.time_tag,
                     { "parent" => Roby.app.app_metadata }
                 )
+                client.kill_all if kill_all_on_process_server_connection?
                 register_process_server(name, client, log_dir, host_id: host_id || name)
                 client
             end


### PR DESCRIPTION
This should allow to recover from Syskit crashes (provided that a watchdog kills the Syskit process). It does not apply to local process servers, as they are always started fresh. But local process servers (and locally started components) can be terminated by e.g. systemd along with syskit itself. This is meant to deal with the remote ones.