### PR TITLE
feat: use the IORs as published by the orogen deployments to resolve task contexts

### DIFF
--- a/lib/syskit/roby_app/remote_processes/client.rb
+++ b/lib/syskit/roby_app/remote_processes/client.rb
@@ -314,6 +314,14 @@ module Syskit
                     Marshal.load(socket)
                 end
 
+                def wait_running(*process_names)
+                    socket.write(COMMAND_WAIT_RUNNING)
+                    Marshal.dump(process_names, socket)
+                    wait_for_answer do
+                        return Marshal.load(socket)
+                    end
+                end
+
                 def join(deployment_name)
                     process = processes[deployment_name]
                     return unless process

--- a/lib/syskit/roby_app/remote_processes/process.rb
+++ b/lib/syskit/roby_app/remote_processes/process.rb
@@ -42,12 +42,6 @@ module Syskit
                     @alive = false
                 end
 
-                # Returns the task context object for the process' task that has this
-                # name
-                def task(task_name)
-                    process_client.name_service.get(task_name, process: self)
-                end
-
                 # Cleanly stop the process
                 #
                 # @see kill!

--- a/lib/syskit/roby_app/remote_processes/process.rb
+++ b/lib/syskit/roby_app/remote_processes/process.rb
@@ -29,6 +29,7 @@ module Syskit
                     @process_client = process_client
                     @pid = pid
                     @alive = true
+                    @ior_mappings = {}
                     super(name, deployment_model)
                 end
 
@@ -64,20 +65,12 @@ module Syskit
                     @alive
                 end
 
-                # Resolve all tasks within the deployment
-                #
-                # A deployment is usually considered ready when all its tasks can be
-                # resolved successfully
-                def resolve_all_tasks(cache = {})
-                    Orocos::Process.resolve_all_tasks(self, cache) do |task_name|
-                        task(task_name)
-                    end
+                def resolve_all_tasks
+                    Orocos::Process.resolve_all_tasks(self)
                 end
 
-                # Waits for the deployment to be ready. +timeout+ is the number of
-                # milliseconds we should wait. If it is nil, will wait indefinitely
-                def wait_running(timeout = nil)
-                    Orocos::Process.wait_running(self, timeout)
+                def define_ior_mappings(mappings)
+                    @ior_mappings = mappings
                 end
             end
         end

--- a/lib/syskit/roby_app/remote_processes/protocol.rb
+++ b/lib/syskit/roby_app/remote_processes/protocol.rb
@@ -12,6 +12,7 @@ module Syskit
             COMMAND_END        = "E"
             COMMAND_QUIT       = "Q"
             COMMAND_KILL_ALL   = "K"
+            COMMAND_WAIT_RUNNING = "W"
             COMMAND_LOG_UPLOAD_FILE  = "U"
             COMMAND_LOG_UPLOAD_STATE = "X"
 

--- a/lib/syskit/roby_app/unmanaged_tasks_manager.rb
+++ b/lib/syskit/roby_app/unmanaged_tasks_manager.rb
@@ -152,6 +152,24 @@ module Syskit
                 dead_processes
             end
 
+            def wait_running(*process_names)
+                result = {}
+                process_names.each do |name|
+                    if (p = processes[name])
+                        begin
+                            ior_resolution = p.wait_running(0)
+                            result[name] = { iors: ior_resolution }
+                        rescue Orocos::NotFound, Orocos::CORBA::ComError => e
+                            result[name] = { error: e.message }
+                        end
+                    else
+                        result[name] =
+                            { error: "#{name} was not found of the processes list" }
+                    end
+                end
+                result
+            end
+
             # Requests to stop the given deployment
             #
             # The call does not block until the process has quit. You will have to

--- a/test/roby_app/test_configuration.rb
+++ b/test/roby_app/test_configuration.rb
@@ -117,25 +117,6 @@ describe Syskit::RobyApp::Configuration do
                 process = client.start "deployment", deployment_m.orogen_model
                 assert_equal 20, process.pid
             end
-
-            it "allows to specify the name service used to resolve the process' task" do
-                process_server_start
-
-                name_service = Orocos::Local::NameService.new
-                name_service.register ruby_task, "resolved-remote-name"
-                client = @conf.connect_to_orocos_process_server(
-                    "test-remote", "localhost",
-                    port: process_server_port,
-                    name_service: name_service
-                )
-
-                process = client.start(
-                    "deployment", deployment_m.orogen_model,
-                    { "name" => "resolved-remote-name" }
-                )
-                tasks = process.resolve_all_tasks
-                assert_equal({ "resolved-remote-name" => ruby_task }, tasks)
-            end
         end
 
         def process_server_create

--- a/test/roby_app/test_unmanaged_tasks.rb
+++ b/test/roby_app/test_unmanaged_tasks.rb
@@ -7,27 +7,176 @@ module Syskit
         describe UnmanagedTasksManager do
             attr_reader :process_manager, :task_model, :unmanaged_task, :deployment_task
 
-            before do
-                @task_model = Syskit::TaskContext.new_submodel
-                Syskit.conf.register_process_server(
-                    "unmanaged_tasks", UnmanagedTasksManager.new
-                )
-                @process_manager = Syskit.conf.process_server_for("unmanaged_tasks")
-                use_unmanaged_task task_model => "unmanaged_deployment_test"
-                @task = syskit_deploy(task_model)
-                @deployment_task = @task.execution_agent
-                plan.unmark_mission_task(@task)
-            end
+            describe "using the default name service" do
+                before do
+                    @task_model = Syskit::TaskContext.new_submodel
+                    Syskit.conf.register_process_server(
+                        "unmanaged_tasks", UnmanagedTasksManager.new
+                    )
+                    @process_manager = Syskit.conf.process_server_for("unmanaged_tasks")
+                    use_unmanaged_task task_model => "unmanaged_deployment_test"
+                    @task = syskit_deploy(task_model)
+                    @deployment_task = @task.execution_agent
+                    plan.unmark_mission_task(@task)
+                end
 
-            after do
-                if deployment_task.running?
+                after do
+                    if deployment_task.running?
+                        expect_execution { deployment_task.stop! }
+                            .to { emit deployment_task.stop_event }
+                    end
+
+                    unmanaged_task&.dispose
+
+                    Syskit.conf.remove_process_server("unmanaged_tasks")
+                end
+
+                it "sets the deployment's process name's to the specified name" do
+                    assert_equal "unmanaged_deployment_test", deployment_task.process_name
+                end
+
+                it "readies the execution agent when the task becomes available" do
+                    expect_execution { deployment_task.start! }
+                        .join_all_waiting_work(false)
+                        .to do
+                            emit deployment_task.start_event
+                            not_emit deployment_task.ready_event
+                        end
+
+                    create_unmanaged_task
+                    expect_execution.to { emit deployment_task.ready_event }
+                    task = deployment_task.task("unmanaged_deployment_test")
+                    assert_equal unmanaged_task, task.orocos_task
+                end
+
+                it "stopping the process causes the monitor thread to quit" do
+                    make_deployment_ready
+                    monitor_thread = deployment_task.orocos_process.monitor_thread
+                    expect_execution { deployment_task.stop! }
+                        .to { emit deployment_task.stop_event }
+                    refute deployment_task.orocos_process.monitor_thread.alive?
+                    assert deployment_task.orocos_process.dead?
+                    refute monitor_thread.alive?
+                end
+
+                it "allows to kill a started deployment that was not ready" do
+                    expect_execution { deployment_task.start! }
+                        .join_all_waiting_work(false)
+                        .to { emit deployment_task.start_event }
+                    expect_execution { deployment_task.stop! }
+                        .join_all_waiting_work(false)
+                        .to { emit deployment_task.stop_event }
+                end
+
+                it "allows to kill a deployment that is ready" do
+                    make_deployment_ready
                     expect_execution { deployment_task.stop! }
                         .to { emit deployment_task.stop_event }
                 end
 
-                unmanaged_task&.dispose
+                it "aborts the execution agent if the monitor thread fails "\
+                "in unexpected ways" do
+                    make_deployment_ready
 
-                Syskit.conf.remove_process_server("unmanaged_tasks")
+                    process_died = capture_log(deployment_task, :warn) do
+                        background_thread_died =
+                            capture_log(deployment_task.orocos_process, :fatal) do
+                                expect_execution do
+                                    deployment_task
+                                        .orocos_process.monitor_thread
+                                        .raise RuntimeError
+                                end.to { emit deployment_task.failed_event }
+                            end
+                        assert_equal ["assuming #{deployment_task.orocos_process} died "\
+                                      "because the background thread died with",
+                                      "RuntimeError (RuntimeError)"],
+                                     background_thread_died
+                    end
+                    assert_equal ["unmanaged_deployment_test unexpectedly died "\
+                                  "on process server unmanaged_tasks"],
+                                 process_died
+                end
+
+                it "deregisters the process object of the process whose thread failed" do
+                    make_deployment_ready
+                    process = deployment_task.orocos_process
+                    process_manager = process.process_manager
+                    begin
+                        flexmock(process).should_receive(dead?: true)
+                        flexmock(process)
+                            .should_receive(:verify_threads_state)
+                            .and_raise(RuntimeError)
+                        capture_log(process, :fatal) do
+                            assert_equal [process],
+                                         process_manager.wait_termination(0).to_a
+                            assert_equal Set[], process_manager.wait_termination(0)
+                        end
+                    ensure (
+                        process_manager.processes["unmanaged_deployment_test"] = process
+                    )
+                    end
+                end
+
+                it "stops the deployment if the remote task becomes unavailable" do
+                    make_deployment_ready
+                    messages = capture_log(deployment_task, :warn) do
+                        expect_execution do
+                            delete_unmanaged_task
+                            # Synchronize on the monitor thread explicitely, otherwise
+                            # the RTT state read might kick in first and bypass the
+                            # whole purpose of the test
+                            deployment_task.orocos_process.monitor_thread.join
+                            assert deployment_task.orocos_process.dead?
+                        end.to { emit deployment_task.failed_event }
+                    end
+                    assert_equal ["unmanaged_deployment_test unexpectedly died on "\
+                                  "process server unmanaged_tasks"],
+                                 messages
+                end
+
+                # This is really a heisentest .... previous versions of
+                # UnmanagedProcess would fail when this happened but the current
+                # implementation should be completely imprevious
+                it "handles concurrently having the monitor fail and #kill being called" \
+                do
+                    make_deployment_ready
+                    expect_execution do
+                        delete_unmanaged_task
+                        deployment_task.orocos_process.kill
+                    end.to { emit deployment_task.stop_event }
+                end
+            end
+
+            describe "specifying the name service" do
+                attr_reader :name_service
+                before do
+                    @task_model = Syskit::TaskContext.new_submodel
+                    @name_service = Orocos::Local::NameService.new
+                    Syskit.conf.register_process_server(
+                        "new_unmanaged_tasks",
+                        UnmanagedTasksManager.new(name_service: name_service)
+                    )
+                    @process_manager =
+                        Syskit.conf.process_server_for("new_unmanaged_tasks")
+                    use_unmanaged_task(task_model => "unmanaged_deployment_test",
+                                       on: "new_unmanaged_tasks")
+                    @task = syskit_deploy(task_model)
+                    @deployment_task = @task.execution_agent
+                    plan.unmark_mission_task(@task)
+                end
+
+                it "allows to specify the name service used to resolve tasks" do
+                    create_unmanaged_task
+                    name_service.register @unmanaged_task
+
+                    process = process_manager.start(
+                        "unmanaged_deployment_test", deployment_task.model.orogen_model
+                    )
+                    result = process.wait_running
+                    assert_includes(result, "unmanaged_deployment_test")
+                    assert_kind_of(String, result["unmanaged_deployment_test"])
+                    assert_match(/^IOR:/, result["unmanaged_deployment_test"])
+                end
             end
 
             def create_unmanaged_task
@@ -50,116 +199,6 @@ module Syskit
             def delete_unmanaged_task
                 unmanaged_task.dispose
                 @unmanaged_task = nil
-            end
-
-            it "sets the deployment's process name's to the specified name" do
-                assert_equal "unmanaged_deployment_test", deployment_task.process_name
-            end
-
-            it "readies the execution agent when the task becomes available" do
-                expect_execution { deployment_task.start! }
-                    .join_all_waiting_work(false)
-                    .to do
-                        emit deployment_task.start_event
-                        not_emit deployment_task.ready_event
-                    end
-
-                create_unmanaged_task
-                expect_execution.to { emit deployment_task.ready_event }
-                task = deployment_task.task("unmanaged_deployment_test")
-                assert_equal unmanaged_task, task.orocos_task
-            end
-
-            it "stopping the process causes the monitor thread to quit" do
-                make_deployment_ready
-                monitor_thread = deployment_task.orocos_process.monitor_thread
-                expect_execution { deployment_task.stop! }
-                    .to { emit deployment_task.stop_event }
-                refute deployment_task.orocos_process.monitor_thread.alive?
-                assert deployment_task.orocos_process.dead?
-                refute monitor_thread.alive?
-            end
-
-            it "allows to kill a started deployment that was not ready" do
-                expect_execution { deployment_task.start! }
-                    .join_all_waiting_work(false)
-                    .to { emit deployment_task.start_event }
-                expect_execution { deployment_task.stop! }
-                    .join_all_waiting_work(false)
-                    .to { emit deployment_task.stop_event }
-            end
-
-            it "allows to kill a deployment that is ready" do
-                make_deployment_ready
-                expect_execution { deployment_task.stop! }
-                    .to { emit deployment_task.stop_event }
-            end
-
-            it "aborts the execution agent if the monitor thread fails "\
-               "in unexpected ways" do
-                make_deployment_ready
-
-                process_died = capture_log(deployment_task, :warn) do
-                    background_thread_died =
-                        capture_log(deployment_task.orocos_process, :fatal) do
-                            expect_execution do
-                                deployment_task
-                                    .orocos_process.monitor_thread
-                                    .raise RuntimeError
-                            end.to { emit deployment_task.failed_event }
-                        end
-                    assert_equal ["assuming #{deployment_task.orocos_process} died "\
-                                  "because the background thread died with",
-                                  "RuntimeError (RuntimeError)"], background_thread_died
-                end
-                assert_equal ["unmanaged_deployment_test unexpectedly died "\
-                              "on process server unmanaged_tasks"],
-                             process_died
-            end
-
-            it "deregisters the process object of the process whose thread failed" do
-                make_deployment_ready
-                process = deployment_task.orocos_process
-                process_manager = process.process_manager
-                begin
-                    flexmock(process).should_receive(dead?: true)
-                    flexmock(process)
-                        .should_receive(:verify_threads_state)
-                        .and_raise(RuntimeError)
-                    capture_log(process, :fatal) do
-                        assert_equal [process], process_manager.wait_termination(0).to_a
-                        assert_equal Set[], process_manager.wait_termination(0)
-                    end
-                ensure process_manager.processes["unmanaged_deployment_test"] = process
-                end
-            end
-
-            it "stops the deployment if the remote task becomes unavailable" do
-                make_deployment_ready
-                messages = capture_log(deployment_task, :warn) do
-                    expect_execution do
-                        delete_unmanaged_task
-                        # Synchronize on the monitor thread explicitely, otherwise
-                        # the RTT state read might kick in first and bypass the
-                        # whole purpose of the test
-                        deployment_task.orocos_process.monitor_thread.join
-                        assert deployment_task.orocos_process.dead?
-                    end.to { emit deployment_task.failed_event }
-                end
-                assert_equal ["unmanaged_deployment_test unexpectedly died on "\
-                              "process server unmanaged_tasks"],
-                             messages
-            end
-
-            # This is really a heisentest .... previous versions of
-            # UnmanagedProcess would fail when this happened but the current
-            # implementation should be completely imprevious
-            it "handles concurrently having the monitor fail and #kill being called" do
-                make_deployment_ready
-                expect_execution do
-                    delete_unmanaged_task
-                    deployment_task.orocos_process.kill
-                end.to { emit deployment_task.stop_event }
             end
         end
     end

--- a/test/runtime/test_update_deployment_state.rb
+++ b/test/runtime/test_update_deployment_state.rb
@@ -4,16 +4,187 @@ require "syskit/test/self"
 
 module Syskit
     module Runtime
+        class ProcessServerFixture
+            attr_reader :loader
+            attr_reader :processes
+            attr_reader :killed_processes
+            def initialize
+                @killed_processes = []
+                @processes = {}
+                @loader = FlexMock.undefined
+            end
+
+            def wait_termination(*)
+                dead_processes = @killed_processes
+                @killed_processes = []
+                dead_processes
+            end
+
+            def start(name, *)
+                processes.fetch(name)
+            end
+
+            def wait_running(*process_names)
+                resolved = {}
+                process_names.each do |p_name|
+                    resolved[p_name] = {}
+                    @processes.each_value do |p|
+                        resolved[p_name] = p.ior_mappings
+                    end
+                end
+                resolved
+            end
+
+            def disconnect; end
+        end
+
         describe ".update_deployment_states" do
-            it "calls #dead! on the dead deployments" do
-                client = flexmock
-                flexmock(Syskit.conf).should_receive(:each_process_server_config)
-                                     .and_return([flexmock(client: client)])
-                client.should_receive(:wait_termination).and_return([[p = flexmock, s = flexmock]])
-                flexmock(Deployment).should_receive(:deployment_by_process).with(p)
-                                    .and_return(d = flexmock(finishing?: true))
-                d.should_receive(:dead!).with(s).once
-                Runtime.update_deployment_states(plan)
+            describe "#handle_dead_deployments" do
+                it "calls #dead! on the dead deployments" do
+                    client = flexmock
+                    flexmock(Syskit.conf).should_receive(:each_process_server_config)
+                                         .and_return([flexmock(client: client)])
+                    client.should_receive(:wait_termination)
+                          .and_return([[p = flexmock, s = flexmock]])
+                    flexmock(Deployment).should_receive(:deployment_by_process).with(p)
+                                        .and_return(d = flexmock(finishing?: true))
+                    d.should_receive(:dead!).with(s).once
+                    Runtime.update_deployment_states(plan)
+                end
+            end
+
+            describe "#trigger_ready_deployments" do
+                attr_reader :mocked_remote_tasks
+                attr_reader :process_server_config
+
+                before do
+                    @mocked_remote_tasks = {
+                        "first_process" => {
+                            iors: {
+                                "task_name" => "IOR",
+                                "task2" => "IOR2"
+                            }
+                        },
+                        "other_process" => {
+                            iors: {
+                                "third_task" => "IOR3",
+                                "fourth_task" => "IOR4"
+                            }
+                        }
+                    }
+                    process_server = ProcessServerFixture.new
+                    @process_server_config = Syskit.conf.register_process_server(
+                        "fixture", process_server, flexmock("log_dir")
+                    )
+                end
+
+                it "updates the deployments remote tasks when they are ready" do
+                    client_mock = flexmock(process_server_config.client)
+                    d1 = mocked_deployment(
+                        "first_process", "fixture", mocked_remote_tasks["first_process"]
+                    )
+                    d2 = mocked_deployment(
+                        "other_process", "fixture", mocked_remote_tasks["other_process"]
+                    )
+
+                    flexmock(Runtime)
+                        .should_receive(:find_all_not_ready_deployments)
+                        .and_return({ "fixture": [d1, d2] })
+                    flexmock(Syskit.conf)
+                        .should_receive(:process_server_config_for)
+                        .and_return(process_server_config)
+                    client_mock.should_receive(:wait_running)
+                               .and_return(mocked_remote_tasks)
+                    Runtime.update_deployment_states(plan)
+                end
+
+                it "emits that the ready event failed and an error was received" do
+                    mocked_remote_tasks["other_process"] = { error: "some error" }
+                    client_mock = flexmock(process_server_config.client)
+                    d1 = mocked_deployment(
+                        "first_process", "fixture", mocked_remote_tasks["first_process"]
+                    )
+                    d2 = mocked_deployment(
+                        "other_process", "fixture", mocked_remote_tasks["other_process"]
+                    )
+
+                    flexmock(Runtime)
+                        .should_receive(:find_all_not_ready_deployments)
+                        .and_return({ "fixture": [d1, d2] })
+                    flexmock(Syskit.conf)
+                        .should_receive(:process_server_config_for)
+                        .and_return(process_server_config)
+                    client_mock.should_receive(:wait_running)
+                               .and_return(mocked_remote_tasks)
+                    Runtime.update_deployment_states(plan)
+                end
+
+                it "ignores the deployment when it hasnt received a result from "\
+                   "wait running" do
+                    client_mock = flexmock(process_server_config.client)
+                    d1 = mocked_deployment(
+                        "first_process", "fixture", mocked_remote_tasks["first_process"]
+                    )
+
+                    flexmock(Runtime)
+                        .should_receive(:find_all_not_ready_deployments)
+                        .and_return({ "fixture": [d1] })
+                    flexmock(Syskit.conf)
+                        .should_receive(:process_server_config_for)
+                        .and_return(process_server_config)
+                    client_mock.should_receive(:wait_running)
+                               .and_return({ "first_process": nil })
+                    flexmock(d1.ready_event).should_receive(:emit_failed).never
+                    flexmock(d1).should_receive(:update_remote_tasks).never
+                    Runtime.update_deployment_states(plan)
+                end
+
+                it "ignores the deployment when its ready event is pending" do
+                    client_mock = flexmock(process_server_config.client)
+                    d1 = mocked_deployment(
+                        "first_process", "fixture", mocked_remote_tasks["first_process"],
+                        pending: true
+                    )
+
+                    flexmock(Runtime)
+                        .should_receive(:find_all_not_ready_deployments)
+                        .and_return({ "fixture": [d1] })
+                    flexmock(Syskit.conf)
+                        .should_receive(:process_server_config_for)
+                        .and_return(process_server_config)
+                    client_mock.should_receive(:wait_running)
+                               .and_return({
+                                               "first_process" => {
+                                                   iors: {
+                                                       "task_name" => "IOR",
+                                                       "task2" => "IOR2"
+                                                   }
+                                               }
+                                           })
+                    flexmock(d1.ready_event).should_receive(:emit_failed).never
+                    flexmock(d1).should_receive(:update_remote_tasks).never
+                    Runtime.update_deployment_states(plan)
+                end
+
+                def mocked_deployment(
+                    process_name, process_server_name, remote_tasks, pending: false
+                )
+                    ready_event = flexmock({ pending?: pending })
+                    mock = flexmock({ process_name: process_name,
+                                      arguments: { on: process_server_name },
+                                      ready_event: ready_event })
+
+                    error = remote_tasks[:error]
+                    if error
+                        mock.ready_event.should_receive(:emit_failed).with(error)
+                        mock.should_receive(:update_remote_tasks).never
+                    else
+                        mock.should_receive(:ready_event).never
+                        mock.should_receive(:update_remote_tasks)
+                            .with(remote_tasks[:iors])
+                    end
+                    mock
+                end
             end
         end
     end

--- a/test/test_deployment.rb
+++ b/test/test_deployment.rb
@@ -5,11 +5,11 @@ require "syskit/test/self"
 module Syskit
     class ProcessServerFixture
         attr_reader :loader
-        attr_reader :tasks
+        attr_reader :processes
         attr_reader :killed_processes
         def initialize
             @killed_processes = []
-            @tasks = {}
+            @processes = {}
             @loader = FlexMock.undefined
         end
 
@@ -20,7 +20,7 @@ module Syskit
         end
 
         def start(name, *)
-            tasks.fetch(name)
+            processes.fetch(name)
         end
 
         def wait_running(*process_names)
@@ -37,23 +37,18 @@ module Syskit
         def disconnect; end
     end
     class ProcessFixture
-
-        class ModelFixture
-            def extended_state_support?
-                false
-            end
-        end
-
         attr_reader :process_server
         attr_reader :name_mappings
         attr_reader :ior_mappings
-        attr_reader :model
         attr_reader :property_names
+        attr_accessor :tasks
+
         def initialize(process_server)
             @process_server = process_server
             @name_mappings = Hash["task" => "mapped_task_name"]
             @ior_mappings = { "mapped_task_name" => "IOR" }
             @property_names = []
+            @tasks = {}
         end
 
         def get_mapped_name(name)
@@ -69,9 +64,8 @@ module Syskit
         end
 
         def resolve_all_tasks
-            process_server.tasks
+            tasks
         end
-
     end
 
     describe Deployment do
@@ -86,13 +80,13 @@ module Syskit
 
             @process_server = ProcessServerFixture.new
             @process = ProcessFixture.new(process_server)
-            process_server.tasks["mapped_task_name"] = process
             @log_dir = flexmock("log_dir")
             @process_server_config =
                 Syskit.conf.register_process_server("fixture", process_server, log_dir)
             @deployment_task = deployment_m
                                .new(process_name: "mapped_task_name", on: "fixture",
                                     name_mappings: { "task" => "mapped_task_name" })
+            process_server.processes["mapped_task_name"] = process
             plan.add_permanent_task(@deployment_task)
 
             flexmock(process_server)
@@ -353,11 +347,11 @@ module Syskit
             describe "monitoring for ready" do
                 attr_reader :orocos_task
                 before do
-                    process_server.should_receive(:start).and_return(process)
                     @orocos_task = Orocos.allow_blocking_calls do
                         Orocos::RubyTasks::TaskContext.new "test"
                     end
-                    process.define_ior_mappings({"mapped_task_name" => "IOR"})
+                    process.tasks["test"] = @orocos_task
+                    process_server.should_receive(:start).and_return(process)
                 end
                 after do
                     orocos_task.dispose
@@ -366,26 +360,58 @@ module Syskit
                 it "does not emit ready if the process is not ready yet" do
                     expect_execution { deployment_task.start! }
                         .join_all_waiting_work(false).to_run
-                    sync = Concurrent::Event.new
-                    process.should_receive(:resolve_all_tasks)
-                           .and_return do
-                               sync.set
-                               nil
-                           end
-                    sync.wait
-                    expect_execution { sync.wait }
+                    client_mock = flexmock(process_server_config.client)
+                    client_mock
+                        .should_receive(:wait_running)
+                        .and_return({})
+                    expect_execution
                         .join_all_waiting_work(false)
                         .to { not_emit deployment_task.ready_event }
                 end
 
-                it "is interrupted by the stop command" do
+                it "does not try resolving the task handles when resolve all" \
+                   "tasks raises an exception" do
+                    flexmock(process)
+                        .should_receive(:resolve_all_tasks)
+                        .and_raise(Orocos::IORNotRegisteredError, "some error")
                     expect_execution do
                         deployment_task.start!
-                        deployment_task.stop!
                     end.to do
-                        not_emit deployment_task.ready_event
-                        emit deployment_task.stop_event
+                        flexmock(execution_engine).should_receive(:promise).never
                     end
+                end
+
+                it "does not emit_failed the ready event when the asynchronous part of "\
+                   "the ready codepath is interrupted by the stop command" do
+                    expect_execution { deployment_task.start! }
+                        .join_all_waiting_work(false)
+                        .to { emit deployment_task.start_event }
+
+                    # Use a barrier to make sure we do the ready event
+                    # processing after we actually stopped the deployment
+                    barrier = Concurrent::CyclicBarrier.new(2)
+                    flexmock(deployment_task)
+                        .should_receive(:resolve_remote_task_handles)
+                        .and_return do
+                            barrier.wait
+                            raise "fail the remote calls"
+                        end
+
+                    # Wait for the deployment ready codepath to reach the barrier
+                    expect_execution.join_all_waiting_work(false).to do
+                        achieve { barrier.number_waiting == 1 }
+                    end
+
+                    plan.unmark_permanent_task(deployment_task)
+                    expect_execution { deployment_task.stop! }
+                        .join_all_waiting_work(false)
+                        .to do
+                            not_emit deployment_task.ready_event
+                            emit deployment_task.stop_event
+                        end
+
+                    barrier.wait
+                    expect_execution.to_run
                 end
 
                 def make_deployment_ready
@@ -412,34 +438,13 @@ module Syskit
                 end
 
                 it "polls for process readiness" do
-                    sync = Concurrent::Event.new
-                    process.should_receive(:resolve_all_tasks)
-                           .and_return do
-                        if !sync.set?
-                            sync.set
-                            nil
-                        else Hash["mapped_task_name" => orocos_task]
-                        end
-                    end
-
                     expect_execution { deployment_task.start! }
                         .join_all_waiting_work(false).to_run
-                    sync.wait
-                    expect_execution { sync.wait }
+                    expect_execution
+                        .poll { Syskit::Runtime.update_deployment_states(plan) }
                         .to { emit deployment_task.ready_event }
                 end
-                it "fails the ready event if the ready event monitor raises" do
-                    expect_execution do
-                        process.should_receive(:resolve_all_tasks)
-                               .and_raise(RuntimeError.new("some message"))
-                        deployment_task.start!
-                    end.to do
-                        have_error_matching(
-                            Roby::EmissionFailed
-                            .match.with_origin(deployment_task.ready_event)
-                        )
-                    end
-                end
+
                 it "emits ready when the process is ready" do
                     make_deployment_ready
                     assert deployment_task.ready?
@@ -724,7 +729,7 @@ module Syskit
             def create_deployment(host_id, name: flexmock)
                 process_server = ProcessServerFixture.new
                 process = ProcessFixture.new(process_server)
-                process_server.tasks["mapped_task_name"] = process
+                process_server.processes["mapped_task_name"] = process
                 log_dir = flexmock("log_dir")
                 process_server_config =
                     Syskit.conf.register_process_server(name, process_server, log_dir, host_id: host_id)

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -1750,6 +1750,7 @@ module Syskit
                             @remote_test_property = task.orocos_task.raw_property("test")
                             @remote_test_property.write(0.2)
                         end
+                        @property.update_remote_value(0.2)
                     end
                     def mock_remote_property
                         property.remote_property = @remote_test_property
@@ -1830,10 +1831,10 @@ module Syskit
                         @property = task.test_property
                         Orocos.allow_blocking_calls do
                             @remote_test_property = task.orocos_task.raw_property("test")
-                            @test_property_initial_value = @remote_test_property.read
                             @remote_test_property.write(0.2)
                         end
                     end
+
                     def mock_remote_property
                         property.remote_property = @remote_test_property
                         flexmock(@remote_test_property)
@@ -1922,6 +1923,7 @@ module Syskit
                         @remote_test_property = task.orocos_task.raw_property("test")
                         remote_test_property.write(0.2)
                     end
+                    @stub_property.update_remote_value(0.2)
                     @guard = syskit_guard_against_start_and_configure
                 end
                 def mock_remote_property
@@ -1988,7 +1990,7 @@ module Syskit
                     end
                     promises.each(&:execute)
                     execution_engine.join_all_waiting_work
-                    assert_equal (0...100).to_a, finished
+                    assert_equal (0...100).to_a, finished.sort
                 end
 
                 it "is serialized with the initial commit in task setup" do


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-orocosrb/pull/149

We are changing orocos to get the task's IOR through a pipe with orogen instead of the name service to discover the task.