### PR TITLE
fix: remove unnecessary base_setup/base_cleanup

### DIFF
--- a/lib/syskit/cli/gen_main.rb
+++ b/lib/syskit/cli/gen_main.rb
@@ -188,7 +188,6 @@ module Syskit
             def orogen(project_name)
                 Roby.app.require_app_dir(needs_current: true)
                 Roby.app.single = true
-                Roby.app.base_setup
                 Syskit.conf.only_load_models = true
                 Roby.app.setup
 
@@ -210,7 +209,6 @@ module Syskit
                          )
             ensure
                 Roby.app.cleanup
-                Roby.app.base_cleanup
             end
 
             no_commands do


### PR DESCRIPTION
Roby.app.setup already calls base_setup/base_cleanup. Doing `base_setup` more than once might result in an error.