### PR TITLE
fix(cli): change `doc gen --set` to behave like in `run`

### DIFF
--- a/lib/syskit/cli/doc_main.rb
+++ b/lib/syskit/cli/doc_main.rb
@@ -20,7 +20,7 @@ module Syskit
                    type: :array, default: [],
                    desc: "list of path patterns to exclude from documentation"
             option :set,
-                   type: :array, default: [],
+                   type: :string, repeatable: true,
                    desc: "set some configuration parameters"
             def gen(target_path)
                 MetaRuby.keep_definition_location = true

--- a/test/cli/test_doc_main.rb
+++ b/test/cli/test_doc_main.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "syskit/test/self"
+require "roby/test/aruba_minitest"
+
+module Syskit
+    module CLI
+        describe "syskit gen" do
+            include Roby::Test::ArubaMinitest
+
+            before do
+                run_command_and_stop "syskit gen app"
+
+                @target_path = make_tmppath
+            end
+
+            it "fails if the config does not load" do
+                robot_config requires: <<~RUBY
+                    raise
+                RUBY
+
+                cmd = doc_gen fail_on_error: false
+                refute_equal 0, cmd.exit_status
+            end
+
+            it "allows multiple --set arguments" do
+                robot_config requires: <<~RUBY
+                    raise if !Conf.set1? || !Conf.set2?
+                RUBY
+
+                doc_gen "--set", "set1=true", "--set", "set2=true"
+            end
+
+            def doc_gen(*args, fail_on_error: true)
+                run_command_and_stop "syskit doc gen #{@target_path} #{args.join(' ')}",
+                                     fail_on_error: fail_on_error
+            end
+
+            def robot_config(requires: "")
+                contents = <<~RUBY
+                    Robot.requires do
+                        #{requires}
+                    end
+                RUBY
+                write_file "config/robots/default.rb", contents
+            end
+        end
+    end
+end


### PR DESCRIPTION
Arrays in thor expected to be called like `--set=one two three`, while `run` expects to have multiple `--set` options. Luckily,
thor handles the second behavior with `repeatable: true`