### PR TITLE
fix: log upload in mixed ruby environment

### DIFF
--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -147,7 +147,7 @@ module Syskit
                 @log_rotation_period = nil
                 @log_transfer = LogTransferManager::Configuration.new(
                     user: "syskit",
-                    port: 22,
+                    port: 20_301,
                     password: SecureRandom.base64(32),
                     self_spawned: true,
                     certificate: nil, # Use random generated self-signed certificate

--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -153,7 +153,8 @@ module Syskit
                     certificate: nil, # Use random generated self-signed certificate
                     target_dir: nil, # Use the app's log dir
                     default_max_upload_rate: Float::INFINITY,
-                    max_upload_rates: {}
+                    max_upload_rates: {},
+                    implicit_ftps: LogTransferServer.use_implicit_ftps?
                 )
 
                 clear

--- a/lib/syskit/roby_app/log_transfer_manager.rb
+++ b/lib/syskit/roby_app/log_transfer_manager.rb
@@ -39,7 +39,8 @@ module Syskit
                 @server = LogTransferServer::SpawnServer.new(
                     @conf.target_dir, @conf.user, @conf.password,
                     @self_signed_ca.private_certificate_path,
-                    interface: @conf.ip
+                    interface: @conf.ip,
+                    implicit_ftps: @conf.implicit_ftps?
                 )
                 @conf.port = @server.port
             end
@@ -79,7 +80,8 @@ module Syskit
                     process_server.client.log_upload_file(
                         @conf.ip, @conf.port, @conf.certificate,
                         @conf.user, @conf.password, Pathname(path),
-                        max_upload_rate: upload_rate
+                        max_upload_rate: upload_rate,
+                        implicit_ftps: @conf.implicit_ftps?
                     )
                 end
             end
@@ -141,7 +143,7 @@ module Syskit
             Configuration = Struct.new(
                 :enabled, :ip, :port, :user, :password, :certificate,
                 :self_spawned, :target_dir, :default_max_upload_rate,
-                :max_upload_rates,
+                :max_upload_rates, :implicit_ftps,
                 keyword_init: true
             ) do
                 def enabled?
@@ -150,6 +152,10 @@ module Syskit
 
                 def self_spawned?
                     self_spawned
+                end
+
+                def implicit_ftps?
+                    implicit_ftps
                 end
 
                 # Return the upload rate limit for a given process server

--- a/lib/syskit/roby_app/log_transfer_server/spawn_server.rb
+++ b/lib/syskit/roby_app/log_transfer_server/spawn_server.rb
@@ -26,7 +26,7 @@ module Syskit
                     password,
                     certfile_path,
                     interface: "127.0.0.1",
-                    tls: LogTransferServer.use_implicit_ftps? ? :implicit : :explicit,
+                    implicit_ftps: LogTransferServer.use_implicit_ftps?,
                     port: 0,
                     session_timeout: default_session_timeout,
                     nat_ip: nil,
@@ -39,7 +39,7 @@ module Syskit
                     server = Ftpd::FtpServer.new(driver)
                     server.interface = interface
                     server.port = port
-                    server.tls = tls
+                    server.tls = implicit_ftps ? :implicit : :explicit
                     server.passive_ports = passive_ports
                     server.certfile_path = certfile_path
                     server.auth_level = Ftpd.const_get("AUTH_PASSWORD")

--- a/lib/syskit/roby_app/remote_processes/client.rb
+++ b/lib/syskit/roby_app/remote_processes/client.rb
@@ -229,12 +229,13 @@ module Syskit
                 # upload progress
                 def log_upload_file(
                     host, port, certificate, user, password, localfile,
-                    max_upload_rate: Float::INFINITY
+                    max_upload_rate: Float::INFINITY,
+                    implicit_ftps: LogTransferServer.use_implicit_ftps?
                 )
                     socket.write(COMMAND_LOG_UPLOAD_FILE)
                     Marshal.dump(
                         [host, port, certificate, user, password, localfile,
-                         max_upload_rate], socket
+                         max_upload_rate, implicit_ftps], socket
                     )
 
                     wait_for_ack

--- a/lib/syskit/roby_app/remote_processes/ftp_upload.rb
+++ b/lib/syskit/roby_app/remote_processes/ftp_upload.rb
@@ -7,7 +7,8 @@ module Syskit
             class FTPUpload
                 def initialize( # rubocop:disable Metrics/ParameterLists
                     host, port, certificate, user, password, file,
-                    max_upload_rate: Float::INFINITY
+                    max_upload_rate: Float::INFINITY,
+                    implicit_ftps: false
                 )
 
                     @host = host
@@ -18,6 +19,7 @@ module Syskit
                     @file = file
 
                     @max_upload_rate = Float(max_upload_rate)
+                    @implicit_ftps = implicit_ftps
                 end
 
                 # Create a temporary file with the FTP server's public key, to pass
@@ -40,7 +42,7 @@ module Syskit
                         Net::FTP.open(
                             @host,
                             private_data_connection: false, port: @port,
-                            implicit_ftps: LogTransferServer.use_implicit_ftps?,
+                            implicit_ftps: @implicit_ftps,
                             ssl: { verify_mode: OpenSSL::SSL::VERIFY_PEER,
                                    ca_file: cert_path }
                         ) do |ftp|

--- a/lib/syskit/roby_app/remote_processes/server.rb
+++ b/lib/syskit/roby_app/remote_processes/server.rb
@@ -569,8 +569,8 @@ module Syskit
                 end
 
                 def log_upload_file(socket, parameters)
-                    host, port, certificate, user, password, localfile, max_upload_rate =
-                        parameters
+                    host, port, certificate, user, password, localfile,
+                        max_upload_rate, implicit_ftps = parameters
 
                     debug "#{socket} requested uploading of #{localfile}"
 
@@ -587,7 +587,8 @@ module Syskit
                         FTPUpload.new(
                             host, port, certificate,
                             user, password, localfile,
-                            max_upload_rate: max_upload_rate || Float::INFINITY
+                            max_upload_rate: max_upload_rate || Float::INFINITY,
+                            implicit_ftps: implicit_ftps
                         )
                 end
 

--- a/test/roby_app/spawn_server/test_spawn_server.rb
+++ b/test/roby_app/spawn_server/test_spawn_server.rb
@@ -18,9 +18,12 @@ module Syskit
                     private_key_path = File.join(
                         __dir__, "..", "remote_processes", "cert-private.crt"
                     )
+
+                    @implicit_ftps = LogTransferServer.use_implicit_ftps?
                     @server = SpawnServer.new(
                         @temp_serverdir, @user, @password,
-                        private_key_path
+                        private_key_path,
+                        implicit_ftps: @implicit_ftps
                     )
                 end
 
@@ -28,7 +31,7 @@ module Syskit
                     Net::FTP.open(
                         "localhost",
                         port: @server.port,
-                        implicit_ftps: LogTransferServer.use_implicit_ftps?,
+                        implicit_ftps: @implicit_ftps,
                         ssl: { verify_mode: OpenSSL::SSL::VERIFY_PEER,
                                verify_hostname: false,
                                ca_file: certfile_path },

--- a/test/roby_app/test_log_transfer_manager.rb
+++ b/test/roby_app/test_log_transfer_manager.rb
@@ -15,7 +15,8 @@ module Syskit
                 @conf = LogTransferManager::Configuration.new(
                     ip: "127.0.0.1",
                     self_spawned: true,
-                    max_upload_rates: {}
+                    max_upload_rates: {},
+                    implicit_ftps: LogTransferServer.use_implicit_ftps?
                 )
                 @conf.target_dir = make_tmpdir
                 @manager = nil

--- a/test/roby_app/test_plugin.rb
+++ b/test/roby_app/test_plugin.rb
@@ -278,6 +278,7 @@ module Syskit
                     Syskit.conf.log_transfer.password = "pass"
                     Syskit.conf.log_transfer.certificate = "cert"
                     Syskit.conf.log_transfer.port = 42
+                    Syskit.conf.log_transfer.implicit_ftps = false
                     conf = Syskit.conf.process_server_config_for("localhost")
                     flexmock(conf).should_receive(supports_log_transfer?: true)
                     flexmock(app)
@@ -292,7 +293,8 @@ module Syskit
                         .should_receive(:log_upload_file).explicitly
                         .with("127.0.0.1", 42, "cert", "user", "pass",
                               Pathname("old_log_file.log"),
-                              max_upload_rate: Float::INFINITY)
+                              max_upload_rate: Float::INFINITY,
+                              implicit_ftps: false)
                         .once
                     app.syskit_log_perform_rotation_and_transfer
                 end


### PR DESCRIPTION
The implicit/explicit FTPS flag works like this:

- two ruby 2.7 must use implicit (explicit does not work)
- anything that has a ruby 2.5 client must use explicit (implicit does not work)

The current support was not configurable, using the ruby version as indication of what method to use.
This was therefore working with 2.5/2.5 or 2.7/2.7. This PR adds a way to explicitly set 'explicit' (pun not
intended) on a ruby 2.7 syskit instance that has 2.5 process servers.

A bit better, but still not great (won't work in a mixed 2.7/2.5 environment on the client side)