### PR TITLE
fix: actions method missing interface

### DIFF
--- a/lib/syskit/actions/interface_model_extension.rb
+++ b/lib/syskit/actions/interface_model_extension.rb
@@ -223,13 +223,13 @@ module Syskit
 
             def has_through_method_missing?(name)
                 MetaRuby::DSLs.has_through_method_missing?(
-                    profile, m, "_tag" => :has_tag?
+                    profile, name, "_tag" => :has_tag?
                 ) || super
             end
 
             def find_through_method_missing(name, args)
                 MetaRuby::DSLs.find_through_method_missing(
-                    profile, m, args, "_tag" => :find_tag
+                    profile, name, args, "_tag" => :find_tag
                 ) || super
             end
 

--- a/test/actions/test_interface_model_extension.rb
+++ b/test/actions/test_interface_model_extension.rb
@@ -308,6 +308,27 @@ describe Syskit::Actions::InterfaceModelExtension do
         end
     end
 
+    describe "method missing" do
+        before do
+            @action_m = Roby::Actions::Interface.new_submodel
+            @srv_m = Syskit::DataService.new_submodel
+            profile_m = Syskit::Actions::Profile.new
+            profile_m.tag "t", @srv_m
+
+            @action_m.use_profile profile_m
+        end
+
+        it "returns an used profile's tag model when accessed with _tag "\
+           "at the model level" do
+            assert @action_m.t_tag.fullfills?(@srv_m)
+        end
+
+        it "returns an used profile's tag model when accessed with _tag "\
+           "at the instance level" do
+            assert @action_m.new(plan).t_tag.fullfills?(@srv_m)
+        end
+    end
+
     describe "overloading of definitions by actions" do
         attr_reader :actions, :profile
         before do


### PR DESCRIPTION
This was probably missed during refactoring, `m` isnt declared anywhere. This would cause a stack too deep error.