### PR TITLE
fix: handle task.depends_on(composition) when scheduling reconfigurations

### DIFF
--- a/lib/syskit/network_generation/merge_solver.rb
+++ b/lib/syskit/network_generation/merge_solver.rb
@@ -572,6 +572,14 @@ module Syskit
                     break
                 end
             end
+
+            def each_merge_leaf
+                return enum_for(__method__) unless block_given?
+
+                task_replacement_graph.each_vertex do |v|
+                    yield(v) if task_replacement_graph.leaf?(v)
+                end
+            end
         end
     end
 end


### PR DESCRIPTION
While the normal data structure does not generate this type of patterns, they must be supported - it is generally speaking useful, and is already used by e.g. the transformer to represent dynamic transformation producers.

The pattern obviously already triggered a bug since there was a specific bug fix for a task context->task context dependency. The fix was however too limited as it would not handle task context->composition.

This change implements a pass after deployment where we would find the root components from the "old plan" that are not used in the "new plan", and cut the dependency relations between these two. This should really handle all cases.