### PR TITLE
fix: validate that the "old" part of a reconfigured pair will get garbage collected

### DIFF
--- a/lib/syskit/test/network_manipulation.rb
+++ b/lib/syskit/test/network_manipulation.rb
@@ -210,11 +210,13 @@ module Syskit
                 resolve_options = Hash[on_error: :commit].merge(resolve_options)
                 begin
                     syskit_engine_resolve_handle_plan_export do
-                        syskit_engine ||= Syskit::NetworkGeneration::Engine.new(plan)
-                        syskit_engine.resolve(
-                            default_deployment_group: default_deployment_group,
-                            **resolve_options
-                        )
+                        execute do
+                            syskit_engine ||= Syskit::NetworkGeneration::Engine.new(plan)
+                            syskit_engine.resolve(
+                                default_deployment_group: default_deployment_group,
+                                **resolve_options
+                            )
+                        end
                     end
                 rescue StandardError => e
                     expect_execution do


### PR DESCRIPTION
On top of #357 

This commit is to essentially avoid the silent failure. With this change, Syskit will kill the old task, with the likely
effect of actually killing the main action. But better than blindly waiting (maybe ?)

I put it onto a separate pull request to get a bit more time with it before we merge, making sure there are no
unintended consequences, while #357 is, I believe, safe.