### PR TITLE
fix: change setup for read only tasks

### DIFF
--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -713,7 +713,7 @@ module Syskit
         def normal_task_verify_configurable_state(state)
             configurable =
                 CONFIGURABLE_RTT_STATES.include?(state) ||
-                    orocos_task.exception_state?(state)
+                orocos_task.exception_state?(state)
 
             return true if configurable
 

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -672,8 +672,6 @@ module Syskit
         # Returns true if this component needs to be setup by calling the
         # #setup method, or if it can be used as-is
         def ready_for_setup?(state = nil)
-            return running? if read_only?
-
             if execution_agent.configuring?(orocos_name)
                 debug { "#{self} not ready for setup: already configuring" }
                 return false
@@ -695,6 +693,8 @@ module Syskit
                 end
                 return
             end
+
+            return orocos_task.runtime_state?(state) if read_only?
 
             configurable_state =
                 CONFIGURABLE_RTT_STATES.include?(state) ||

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -672,6 +672,8 @@ module Syskit
         # Returns true if this component needs to be setup by calling the
         # #setup method, or if it can be used as-is
         def ready_for_setup?(state = nil)
+            return running? if read_only?
+
             if execution_agent.configuring?(orocos_name)
                 debug { "#{self} not ready for setup: already configuring" }
                 return false
@@ -718,7 +720,7 @@ module Syskit
         #  end
         #
         def setup?
-            read_only? || @setup
+            @setup
         end
 
         def ready_to_start!
@@ -921,6 +923,8 @@ module Syskit
 
         # (see Component#perform_setup)
         def perform_setup(promise)
+            return if read_only?
+
             prepare_for_setup(promise)
 
             # This calls #configure

--- a/lib/syskit/test/network_manipulation.rb
+++ b/lib/syskit/test/network_manipulation.rb
@@ -545,8 +545,6 @@ module Syskit
                     current_pending = pending.size
                     has_missing_states = false
                     pending.delete_if do |t|
-                        next true if t.read_only?
-
                         t.freeze_delayed_arguments
                         should_setup = Orocos.allow_blocking_calls do
                             if !t.kind_of?(Syskit::TaskContext)

--- a/lib/syskit/test/network_manipulation.rb
+++ b/lib/syskit/test/network_manipulation.rb
@@ -545,6 +545,8 @@ module Syskit
                     current_pending = pending.size
                     has_missing_states = false
                     pending.delete_if do |t|
+                        next true if t.read_only?
+
                         t.freeze_delayed_arguments
                         should_setup = Orocos.allow_blocking_calls do
                             if !t.kind_of?(Syskit::TaskContext)

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -2322,36 +2322,20 @@ module Syskit
                "while the component is running" do
                 Orocos.allow_blocking_calls { handle.configure(false) }
                 Orocos.allow_blocking_calls { handle.start(false) }
-                assert state(handle) == :RUNNING
-
                 create_configure_and_start_task
             end
 
-            it "emits start when the task is created and started after the component "\
-               "configuration but before its start" do
+            it "does not let itself be configured if the component is not configured" do
+                assert_raises(Syskit::Test::NetworkManipulation::NoConfigureFixedPoint) do
+                    create_and_configure_task
+                end
+            end
+
+            it "does not let itself be configured if the component is not started" do
                 Orocos.allow_blocking_calls { handle.configure(false) }
-                task = create_and_configure_task
-                Orocos.allow_blocking_calls { handle.start(false) }
-                expect_execution { task.start! }.to { emit task.start_event }
-            end
-
-            it "does not emit start if the task is started "\
-               "while the component is not running" do
-                task = create_and_configure_task
-                expect_execution { task.start! }.to { not_emit task.start_event }
-                # just to avoid: "TeardownFailedError: failed to tear down plan"
-                execute { task.stop! }
-            end
-
-            it "emits start when the component is started while the task is starting" do
-                task = create_and_configure_task
-                execute { task.start! }
-                assert task.starting?
-
-                expect_execution do
-                    Orocos.allow_blocking_calls { handle.configure(false) }
-                    Orocos.allow_blocking_calls { handle.start(false) }
-                end.to { emit task.start_event }
+                assert_raises(Syskit::Test::NetworkManipulation::NoConfigureFixedPoint) do
+                    create_and_configure_task
+                end
             end
 
             it "raises when attempting to change a property" do

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -727,6 +727,9 @@ module Syskit
                 task.should_receive(:read_only?).and_return(true)
                 task.should_receive(:prepare_for_setup).never
                 flexmock(task.orocos_task).should_receive(:configure).never
+                expect_execution { task.start! }.to do
+                    not_emit task.start_event, within: 0.5
+                end
             end
         end
 

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -2335,7 +2335,7 @@ module Syskit
 
             it "does not perform setup on configuration" do
                 task = deployment.task("test")
-                flexmock(task).should_receive(:perform_setup).once
+                flexmock(task).should_receive(:perform_setup).once.pass_thru
                 flexmock(task).should_receive(:prepare_for_setup).never
 
                 Orocos.allow_blocking_calls { handle.configure(false) }

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -700,6 +700,34 @@ module Syskit
                 task.should_receive(:read_current_state).and_return(:STOPPED)
                 assert task.ready_for_setup?
             end
+
+            it "returns false if the task is read_only and the component is not running" do
+                task.should_receive(:read_only?).and_return(true)
+                refute task.ready_for_setup?
+            end
+
+            it "returns true if the task is read_only and the component is in a running "\
+               "state" do
+                task.should_receive(:read_only?).and_return(true)
+                orocos_task.should_receive(:runtime_state?)
+                                          .and_return(true)
+                assert task.ready_for_setup?
+            end
+        end
+
+        describe "#perform_setup" do
+            attr_reader :task
+            before do
+                task = syskit_stub_and_deploy("Task") {}
+                syskit_start_execution_agents(task)
+                @task = flexmock(task)
+            end
+
+            it "does nothing when the task is read_only" do
+                task.should_receive(:read_only?).and_return(true)
+                task.should_receive(:prepare_for_setup).never
+                flexmock(task.orocos_task).should_receive(:configure).never
+            end
         end
 
         describe "#read_current_state" do


### PR DESCRIPTION
Instead of always considering that a read_only task setup is done, we will consider that it is done whenever its not-read only counterpart is running. Also, read_only tasks do nothing on perform_setup.