### PR TITLE
fix: do not terminate early dataflow computations when a port is not updated

### DIFF
--- a/lib/syskit/network_generation/dataflow_computation.rb
+++ b/lib/syskit/network_generation/dataflow_computation.rb
@@ -154,6 +154,20 @@ module Syskit
                 end
             end
 
+            # @api private
+            #
+            # For testing purposes only
+            def changed?
+                @changed
+            end
+
+            # @api private
+            #
+            # For testing purposes only
+            def reset_changed
+                @changed = false
+            end
+
             def reset(tasks = [])
                 @result = Hash.new { |h, k| h[k] = {} }
                 # Internal variable that is used to detect whether an iteration
@@ -318,7 +332,7 @@ module Syskit
                     @result[task][port_name] = info
                 else
                     begin
-                        @changed = @result[task][port_name].merge(info)
+                        @changed |= @result[task][port_name].merge(info)
                     rescue Exception => e
                         raise e, "while adding information to port #{port_name} on #{task}, #{e.message}", e.backtrace
                     end

--- a/test/network_generation/test_dataflow_computation.rb
+++ b/test/network_generation/test_dataflow_computation.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "syskit/test/self"
+
+module Syskit
+    module NetworkGeneration
+        describe DataFlowComputation do
+            describe "#add_port_info" do
+                before do
+                    @computation = DataFlowComputation.new
+                end
+
+                it "sets the port info to the new information object if it did not have "\
+                   "any" do
+                    @computation.add_port_info(@task, "port", info = flexmock)
+                    assert_equal info, @computation.port_info(@task, "port")
+                end
+
+                it "calls #merge on the existing port info when it gets updated" do
+                    @computation.add_port_info(@task, "port", info = flexmock)
+                    info.should_receive(:merge).with(new_info = flexmock).once
+                    @computation.add_port_info(@task, "port", new_info)
+                end
+
+                it "sets changed? if a port that had no previous info gets some" do
+                    @computation.add_port_info(@task, "port", flexmock)
+                    assert @computation.changed?
+                end
+
+                it "sets changed? if a port with existing information is updated" do
+                    @computation.add_port_info(@task, "port", flexmock(merge: true))
+                    @computation.reset_changed
+                    refute @computation.changed?
+                    @computation.add_port_info(@task, "port", flexmock)
+                    assert @computation.changed?
+                end
+
+                it "keeps changed? set even if the port is not updated" do
+                    @computation.add_port_info(@task, "port", flexmock(merge: false))
+                    @computation.add_port_info(@task, "port", flexmock)
+                    assert @computation.changed?
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
The logic was broken in add_port_info, which would reset `@changed` to false if the particular port was not updated, leading to the propagation algorithm to think it found a fixed point.

In practice, this caused some complex transformer setup to fail to propagate frames.