### PR TITLE
fix: only consider concrete connections when setting up the logger

### DIFF
--- a/lib/syskit/network_generation/logger.rb
+++ b/lib/syskit/network_generation/logger.rb
@@ -65,7 +65,7 @@ module Syskit
             def configure
                 super
 
-                each_input_connection do |source_task, source_port_name, sink_port_name, policy|
+                each_concrete_input_connection do |source_task, source_port_name, sink_port_name, policy|
                     source_port = source_task.find_output_port(source_port_name)
                     create_logging_port(sink_port_name, source_task, source_port)
                 end


### PR DESCRIPTION
This code has essentially only ever been used to setup default loggers, which are always directly connected to the component they are logging.

However, when using the logger manually, we do want to be able to connect it through composition(s). Fix this use-case