### PR TITLE
feat: implement `syskit log_runtime_archive`

### DIFF
--- a/bin/syskit
+++ b/bin/syskit
@@ -52,7 +52,7 @@ end
 ORIGINAL_ARGV = ARGV.dup
 mode = ARGV.shift
 
-SYSKIT_MODES = %w[ide process_server].freeze
+SYSKIT_MODES = %w[ide process_server log_runtime_archive].freeze
 ROBY_MODES = %w[run shell test gen quit restart].freeze
 if [nil, "--help", "-h", "help"].include?(mode)
     thor_modes = Syskit::CLI::Main

--- a/lib/syskit/cli/log_runtime_archive.rb
+++ b/lib/syskit/cli/log_runtime_archive.rb
@@ -132,7 +132,9 @@ module Syskit
                 logger.info(
                     "Archiving dataset #{path} in #{full ? 'full' : 'partial'} mode"
                 )
-                candidates = path.enum_for(:each_entry).map { path / _1 }
+                candidates =
+                    path.enum_for(:each_entry).map { path / _1 }
+                        .find_all { _1.file? }
                 candidates = archive_partial_filter_candidates(candidates) unless full
 
                 candidates.each do |child_path|

--- a/lib/syskit/cli/log_runtime_archive.rb
+++ b/lib/syskit/cli/log_runtime_archive.rb
@@ -42,13 +42,15 @@ module Syskit
                         archive_io, child_path, start_pos, data_pos, stat
                     )
                     child_path.unlink
+                    true
                 else
                     add_to_archive_rollback(archive_io, start_pos)
+                    false
                 end
-
             rescue Exception => e # rubocop:disable Lint/RescueException
+                Roby.display_exception(STDOUT, e)
                 add_to_archive_rollback(archive_io, start_pos) if start_pos
-                raise
+                false
             end
 
             # Finalize appending a file in the archive

--- a/lib/syskit/cli/log_runtime_archive.rb
+++ b/lib/syskit/cli/log_runtime_archive.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require "archive/tar/minitar"
+
+module Syskit
+    module CLI
+        module LogRuntimeArchive
+            # Find all dataset-looking folders within a root log folder
+            def self.find_all_dataset_folders(root_dir)
+                candidates = root_dir.enum_for(:each_entry).map do |child|
+                    next unless /^\d{8}\-\d{4}(\.\d+)?$/.match?(child.basename.to_s)
+
+                    child = (root_dir / child)
+                    next unless child.directory?
+
+                    child if (child / "info.yml").file?
+                end
+
+                candidates.compact.sort_by { _1.basename.to_s }
+            end
+
+            # Safely add an entry into an archive, compressing it with zstd
+            def self.add_to_archive(archive_io, child_path)
+                puts "adding #{child_path}"
+                stat = child_path.stat
+
+                start_pos = archive_io.tell
+                write_initial_header(archive_io, child_path, stat)
+                data_pos = archive_io.tell
+                exit_status = write_compressed_data(child_path, archive_io)
+
+                if exit_status.success?
+                    add_to_archive_commit(archive_io, child_path, start_pos, data_pos, stat)
+                    child_path.unlink
+                else
+                    add_to_archive_rollback(archive_io, start_pos)
+                end
+
+            rescue Exception => e # rubocop:disable Lint/RescueException
+                add_to_archive_rollback(archive_io, start_pos) if start_pos
+                raise
+            end
+
+            # Finalize appending a file in the archive
+            def self.add_to_archive_commit(
+                archive_io, child_path, start_pos, data_pos, stat
+            )
+                data_size = archive_io.tell - data_pos
+                write_padding(data_size, archive_io)
+
+                # Update header
+                archive_io.seek(start_pos, IO::SEEK_SET)
+                write_final_header(archive_io, child_path, stat, data_size)
+                archive_io.seek(0, IO::SEEK_END)
+            end
+
+            # Revert the addition of a file in the archive, after an error
+            def self.add_to_archive_rollback(archive_io, start_pos)
+                archive_io.truncate(start_pos)
+                archive_io.seek(start_pos, IO::SEEK_SET)
+            end
+
+            # Write a tar block header without the data size
+            def self.write_initial_header(archive_io, child_path, stat)
+                write_header(
+                    archive_io,
+                    "#{child_path.basename}.zst",
+                    { mode: 0o644, uid: stat.uid, gid: stat.gid,
+                      mtime: stat.mtime, size: 0 }
+                )
+            end
+
+            # Write the final tar block header at the given position
+            def self.write_final_header(archive_io, child_path, stat, size)
+                write_header(
+                    archive_io,
+                    "#{child_path.basename}.zst",
+                    { mode: 0o644, uid: stat.uid, gid: stat.gid,
+                      mtime: stat.mtime, size: size }
+                )
+            end
+
+            # Compress data and append it to the archive
+            def self.write_compressed_data(child_path, archive_io)
+                _, exit_status = child_path.open("r") do |io|
+                    zstd_transfer_r, zstd_transfer_w = IO.pipe
+                    pid = Process.spawn("zstd", "--stdout", in: io, out: zstd_transfer_w)
+                    zstd_transfer_w.close
+                    IO.copy_stream(zstd_transfer_r, archive_io)
+                    Process.waitpid2(pid)
+                end
+                exit_status
+            end
+
+            # Write necessary padding (tar requires multiples of 512 bytes)
+            def self.write_padding(size, io)
+                # Move to end, compute actual size, pad to 512 bytes blocks
+                remainder = (size + 511) / 512 * 512 - size
+                io.write("\0" * remainder)
+            end
+
+            def self.archive_dataset(archive_io, path, full:)
+                puts "Archiving dataset #{path} in #{full ? "full" : "partial"} mode"
+                candidates = path.enum_for(:each_entry).map { path / _1 }
+                candidates = archive_partial_filter_candidates(candidates) unless full
+
+                candidates.each do |child_path|
+                    add_to_archive(archive_io, child_path)
+                end
+            end
+
+            def self.archive_partial_filter_candidates(candidates)
+                per_file_and_idx = candidates.each_with_object({}) do |path, h|
+                    name = path.basename.to_s
+                    if (m = /\.(\d+)\.log$/.match(name))
+                        per_file = (h[m.pre_match] ||= {})
+                        per_file[Integer(m[1])] = path
+                    end
+                end
+
+                per_file_and_idx.each_value.flat_map do |logs|
+                    logs.delete(logs.keys.max)
+                    logs.values
+                end
+            end
+
+            def self.process_root_folder(root_dir, target_dir)
+                candidates = find_all_dataset_folders(root_dir)
+                running = candidates.last
+                candidates.each do |child|
+                    archive_path = target_dir / "#{child.basename}.tar"
+                    mode =
+                        if archive_path.exist?
+                            "r+"
+                        else
+                            "w"
+                        end
+
+                    archive_path.open(mode) do |archive_io|
+                        archive_io.seek(0, IO::SEEK_END)
+                        archive_dataset(archive_io, child, full: child != running)
+                    end
+                end
+            end
+
+            extend Archive::Tar::Minitar::ByteSize
+
+            # Copy a tar header (copied from minitar)
+            def self.write_header(io, long_name, header)
+                short_name, prefix, needs_long_name = split_name(long_name)
+
+                if needs_long_name
+                    long_name_header = {
+                        prefix: "",
+                        name: Archive::Tar::Minitar::PosixHeader::GNU_EXT_LONG_LINK,
+                        typeflag: "L",
+                        size: long_name.length,
+                        mode: 0
+                    }
+                    io.write(Archive::Tar::Minitar::PosixHeader.new(long_name_header))
+                    io.write(long_name)
+                    io.write("\0" * (512 - (long_name.length % 512)))
+                end
+
+                new_header = header.merge({ name: short_name, prefix: prefix })
+                io.write(Archive::Tar::Minitar::PosixHeader.new(new_header))
+            end
+
+            # Process a file name to determine whether it should use the GNU
+            # long file extension. Copied from minitar
+            def self.split_name(name) # rubocop:disable Metrics/AbcSize
+                if bytesize(name) <= 100
+                    prefix = ""
+                else
+                    parts = name.split(%r{\/})
+                    newname = parts.pop
+
+                    nxt = ""
+
+                    loop do
+                        nxt = parts.pop || ""
+                        break if bytesize(newname) + 1 + bytesize(nxt) >= 100
+
+                        newname = "#{nxt}/#{newname}"
+                    end
+
+                    prefix = (parts + [nxt]).join('/')
+                    name = newname
+                end
+
+                [name, prefix, (bytesize(name) > 100 || bytesize(prefix) > 155)]
+            end
+        end
+    end
+end

--- a/lib/syskit/scripts/log_runtime_archive.rb
+++ b/lib/syskit/scripts/log_runtime_archive.rb
@@ -1,0 +1,30 @@
+#! /usr/bin/env ruby
+# frozen_string_literal: true
+
+require "pathname"
+require "syskit/cli/log_runtime_archive"
+
+unless ARGV.size == 2
+    STDERR.puts "usage: log_runtime_archive ROOT_DIR TARGET_DIR"
+    exit 1
+end
+
+root_dir = Pathname.new(ARGV[0])
+target_dir = Pathname.new(ARGV[1])
+
+if !root_dir.directory?
+    warn "#{root_dir} is not a directory"
+    exit 1
+elsif !target_dir.directory?
+    warn "#{target_dir} is not a directory"
+    exit 1
+end
+
+POLLING_PERIOD = 600
+
+loop do
+    Syskit::CLI::LogRuntimeArchive.process_root_folder(root_dir, target_dir)
+
+    puts "Archived pending logs, sleeping #{POLLING_PERIOD}s"
+    sleep POLLING_PERIOD
+end

--- a/lib/syskit/scripts/log_runtime_archive.rb
+++ b/lib/syskit/scripts/log_runtime_archive.rb
@@ -21,8 +21,13 @@ end
 
 POLLING_PERIOD = 600
 
+logger = Logger.new(STDOUT)
+logger.level = Logger::INFO
+
 loop do
-    Syskit::CLI::LogRuntimeArchive.process_root_folder(root_dir, target_dir)
+    Syskit::CLI::LogRuntimeArchive.process_root_folder(
+        root_dir, target_dir, logger: logger
+    )
 
     puts "Archived pending logs, sleeping #{POLLING_PERIOD}s"
     sleep POLLING_PERIOD

--- a/lib/syskit/scripts/log_runtime_archive.rb
+++ b/lib/syskit/scripts/log_runtime_archive.rb
@@ -1,4 +1,3 @@
-#! /usr/bin/env ruby
 # frozen_string_literal: true
 
 require "pathname"

--- a/manifest.xml
+++ b/manifest.xml
@@ -23,6 +23,10 @@
     <depend_optional package="ruby-listen" />
     <depend_optional package="gui/vizkit" />
 
+    <!-- Log management -->
+    <depend_optional package="zstd" />
+    <depend_optional package="minitar" />
+
     <test_depend package="minitest" />
     <test_depend package="aruba" />
     <test_depend package="flexmock" />

--- a/test/cli/test_log_runtime_archive.rb
+++ b/test/cli/test_log_runtime_archive.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "syskit/test/self"
+require "syskit/cli/log_runtime_archive"
+
+module Syskit
+    module CLI
+        describe LogRuntimeArchive do
+            describe ".find_all_dataset_folders" do
+                before do
+                    @root = make_tmppath
+                end
+
+                def make_valid_folder(name)
+                    path = (@root / name)
+                    path.mkpath
+                    FileUtils.touch(path / "info.yml")
+                    path
+                end
+
+                it "returns the directories that look like a dataset path" do
+                    path = make_valid_folder("20229523-1104.1")
+                    assert_equal(
+                        [path],
+                        LogRuntimeArchive.find_all_dataset_folders(@root)
+                    )
+                end
+
+                it "sorts the entries lexicographically" do
+                    path1 = make_valid_folder("20229523-1104.1")
+                    path2 = make_valid_folder("20229423-1104.1")
+                    assert_equal(
+                        [path2, path1],
+                        LogRuntimeArchive.find_all_dataset_folders(@root)
+                    )
+                end
+
+                it "does not return paths that match the pattern but "\
+                   "do not have a info.yml file inside" do
+                    path = (@root / "20229423-1104")
+                    path.mkpath
+                    assert_equal([], LogRuntimeArchive.find_all_dataset_folders(@root))
+                end
+
+                it "does not return paths that do not match the pattern" do
+                    path = (@root / "20240223-11043")
+                    path.mkpath
+                    FileUtils.touch(path / "info.yml")
+                    assert_equal([], LogRuntimeArchive.find_all_dataset_folders(@root))
+                end
+
+                it "ignores paths that match the pattern but are not folders" do
+                    path = (@root / "20240223-1104")
+                    FileUtils.touch(path.to_s)
+                    assert_equal([], LogRuntimeArchive.find_all_dataset_folders(@root))
+                end
+            end
+
+            describe ".add_to_archive" do
+                before do
+                    @root = make_tmppath
+                    @archive_path = (make_tmppath / "archive.tar")
+                    @in_files = []
+                end
+
+                def make_in_file(name, content)
+                    path = (@root / name)
+                    path.write(content)
+                    @in_files << path
+                    path
+                end
+
+                def read_archive
+                    tar = Archive::Tar::Minitar::Input.open(@archive_path.open("r"))
+                    tar.each_entry.map { |e| [e, e.read] }
+                end
+
+                def decompress_data(data)
+                    IO.popen(["zstd", "-d", "--stdout"], "r+") do |io|
+                        io.write data
+                        io.close_write
+                        io.read
+                    end
+                end
+
+                def assert_entry_matches(entry, data, name:, content:)
+                    assert entry.file?
+                    assert_equal name, entry.full_name
+                    assert_equal content, decompress_data(data)
+                end
+
+                it "adds a compressed version of the input I/O to the archive "\
+                   "and deletes the input file" do
+                    in_path = make_in_file "something.txt", "something"
+
+                    @archive_path.open("w") do |archive_io|
+                        @in_files.each do |in_path|
+                            LogRuntimeArchive.add_to_archive(archive_io, in_path)
+                        end
+                    end
+
+                    entries = read_archive
+                    assert_equal 1, entries.size
+                    assert_entry_matches(
+                        *entries.first, name: "something.txt.zst", content: "something"
+                    )
+                    refute in_path.exist?
+                end
+
+                it "creates a multi-file archive" do
+                    bla = make_in_file "bla.txt", "bla"
+                    blo = make_in_file "blo.txt", "blo"
+                    @archive_path.open("w") do |archive_io|
+                        @in_files.each do |in_path|
+                            LogRuntimeArchive.add_to_archive(archive_io, in_path)
+                        end
+                    end
+
+                    entries = read_archive
+                    assert_equal 2, entries.size
+                    assert_entry_matches(*entries[0], name: "bla.txt.zst", content: "bla")
+                    assert_entry_matches(*entries[1], name: "blo.txt.zst", content: "blo")
+                    refute bla.exist?
+                    refute blo.exist?
+                end
+
+                it "restores the file as it was and keeps the input file if zstd fails "\
+                   "but continues with other files" do
+                    bla = make_in_file "bla.txt", "bla"
+                    blo = make_in_file "blo.txt", "blo"
+                    bli = make_in_file "bli.txt", "bli"
+
+                    @archive_path.open("w") do |archive_io|
+                        LogRuntimeArchive.add_to_archive(archive_io, bla)
+                        FlexMock.use(Process) do |mock|
+                            mock.should_receive(:waitpid2).once
+                                .and_return([10, flexmock(success?: false)])
+                            LogRuntimeArchive.add_to_archive(archive_io, blo)
+                        end
+                        LogRuntimeArchive.add_to_archive(archive_io, bli)
+                    end
+
+                    entries = read_archive
+                    assert_equal 2, entries.size
+                    assert_entry_matches(*entries[0], name: "bla.txt.zst", content: "bla")
+                    assert_entry_matches(*entries[1], name: "bli.txt.zst", content: "bli")
+                    refute bla.exist?
+                    assert blo.exist?
+                    refute bli.exist?
+                end
+            end
+        end
+    end
+end

--- a/test/cli/test_log_runtime_archive.rb
+++ b/test/cli/test_log_runtime_archive.rb
@@ -91,7 +91,7 @@ module Syskit
 
                 it "adds a compressed version of the input I/O to the archive "\
                    "and deletes the input file" do
-                    in_path = make_in_file "something.txt", "something"
+                    something = make_in_file "something.txt", "something"
 
                     @archive_path.open("w") do |archive_io|
                         @in_files.each do |in_path|
@@ -104,7 +104,7 @@ module Syskit
                     assert_entry_matches(
                         *entries.first, name: "something.txt.zst", content: "something"
                     )
-                    refute in_path.exist?
+                    refute something.exist?
                 end
 
                 it "creates a multi-file archive" do


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/package_set/pull/223

The tool will archive log folders as they are being created, in a robust way, into a tarball where each file is compressed with zstd. The objective is to reduce the needs for hard drive space, and have an archive ready to transfer for processing at the end of the run.