### PR TITLE
feat: implement splitting the generated dataset archives

### DIFF
--- a/lib/syskit/cli/log_runtime_archive.rb
+++ b/lib/syskit/cli/log_runtime_archive.rb
@@ -10,7 +10,103 @@ module Syskit
         # compressing files using zstd
         #
         # It depends on the syskit instance using log rotation
-        module LogRuntimeArchive
+        class LogRuntimeArchive
+            DEFAULT_MAX_ARCHIVE_SIZE = 10_000_000_000 # 10G
+
+            def initialize(
+                root_dir, target_dir,
+                logger: LogRuntimeArchive.null_logger,
+                max_archive_size: DEFAULT_MAX_ARCHIVE_SIZE
+            )
+                @last_archive_index = {}
+                @logger = logger
+                @root_dir = root_dir
+                @target_dir = target_dir
+                @max_archive_size = max_archive_size
+            end
+
+            # Iterate over all datasets in a Roby log root folder and archive them
+            #
+            # The method assumes the last dataset is the current one (i.e. the running
+            # one), and will only archive already rotated files.
+            #
+            # @param [Pathname] root_dir the log root folder
+            # @param [Pathname] target_dir the folder in which to save the
+            #   archived datasets
+            def process_root_folder
+                candidates = self.class.find_all_dataset_folders(@root_dir)
+                running = candidates.last
+                candidates.each do |child|
+                    process_dataset(child, full: child != running)
+                end
+            end
+
+            def process_dataset(child, full:)
+                use_existing = true
+                loop do
+                    open_archive_for(
+                        child.basename.to_s, use_existing: use_existing
+                    ) do |io|
+                        if io.tell > @max_archive_size
+                            use_existing = false
+                            break
+                        end
+
+                        dataset_complete = self.class.archive_dataset(
+                            io, child,
+                            logger: @logger, full: full,
+                            max_size: @max_archive_size
+                        )
+                        return if dataset_complete
+                    end
+
+                    use_existing = false
+                end
+            end
+
+            # Create or open an archive
+            #
+            # The method will find an archive to open or create, do it and
+            # yield the corresponding IO. The archives are named #{basename}.${INDEX}.tar
+            #
+            # @param [Boolean] use_existing if false, always create a new
+            #   archive. If true, reuse the last archive that was created, if
+            #   present, or create ${basename}.0.tar otherwise.
+            def open_archive_for(basename, use_existing: true)
+                last_index = find_last_archive_index(basename)
+
+                index, mode =
+                    if !last_index
+                        [0, "w"]
+                    elsif use_existing
+                        [last_index, "r+"]
+                    else
+                        [last_index + 1, "w"]
+                    end
+
+                archive_path = @target_dir / "#{basename}.#{index}.tar"
+                archive_path.open(mode) do |io|
+                    io.seek(0, IO::SEEK_END)
+                    yield(io)
+                end
+            end
+
+            # Find the last archive index used for a given basename
+            #
+            # @param [String] basename the archive basename
+            def find_last_archive_index(basename)
+                i = @last_archive_index[basename] || 0
+                last_i = nil
+                loop do
+                    candidate = @target_dir / "#{basename}.#{i}.tar"
+                    return last_i unless candidate.exist?
+
+                    @last_archive_index[basename] = last_i
+                    last_i = i
+                    i += 1
+                end
+            end
+
             # Find all dataset-looking folders within a root log folder
             def self.find_all_dataset_folders(root_dir)
                 candidates = root_dir.enum_for(:each_entry).map do |child|
@@ -128,7 +224,13 @@ module Syskit
             # @param [Boolean] full whether we're arching the complete dataset (true),
             #   or only the files that we know are not being written to (for log
             #   directories of running Syskit instances)
-            def self.archive_dataset(archive_io, path, full:, logger: null_logger)
+            # @return [Boolean] true if we're done processing this dataset. False
+            #   if processing was interrupted by e.g. an archive that reached the
+            #   max_archive_size limit
+            def self.archive_dataset(
+                archive_io, path,
+                full:, logger: null_logger, max_size: DEFAULT_MAX_ARCHIVE_SIZE
+            )
                 logger.info(
                     "Archiving dataset #{path} in #{full ? 'full' : 'partial'} mode"
                 )
@@ -136,10 +238,13 @@ module Syskit
                     path.enum_for(:each_entry).map { path / _1 }
                         .find_all { _1.file? }
                 candidates = archive_partial_filter_candidates(candidates) unless full
-
-                candidates.each do |child_path|
+                candidates.each_with_index do |child_path, i|
                     add_to_archive(archive_io, child_path, logger: logger)
+
+                    return (i == candidates.size - 1) if archive_io.tell > max_size
                 end
+
+                true
             end
 
             # Filters all candidates for archiving to return the ones relevant for a
@@ -166,35 +271,6 @@ module Syskit
                     if (m = /\.(\d+)\.log$/.match(name))
                         per_file = (h[m.pre_match] ||= {})
                         per_file[Integer(m[1])] = path
-                    end
-                end
-            end
-
-            # Iterate over all datasets in a Roby log root folder and archive them
-            #
-            # The method assumes the last dataset is the current one (i.e. the running
-            # one), and will only archive already rotated files.
-            #
-            # @param [Pathname] root_dir the log root folder
-            # @param [Pathname] target_dir the folder in which to save the
-            #   archived datasets
-            def self.process_root_folder(root_dir, target_dir, logger: null_logger)
-                candidates = find_all_dataset_folders(root_dir)
-                running = candidates.last
-                candidates.each do |child|
-                    archive_path = target_dir / "#{child.basename}.tar"
-                    mode =
-                        if archive_path.exist?
-                            "r+"
-                        else
-                            "w"
-                        end
-
-                    archive_path.open(mode) do |archive_io|
-                        archive_io.seek(0, IO::SEEK_END)
-                        archive_dataset(
-                            archive_io, child, logger: logger, full: child != running
-                        )
                     end
                 end
             end

--- a/test/cli/test_log_runtime_archive.rb
+++ b/test/cli/test_log_runtime_archive.rb
@@ -192,39 +192,111 @@ module Syskit
             end
 
             describe ".process_root_folder" do
+                before do
+                    @archive_dir = make_tmppath
+                    @process = LogRuntimeArchive.new(@root, @archive_dir)
+                end
+
                 it "archives all folders, the last one only partially" do
                     dataset0 = make_valid_folder("20220434-2023")
                     dataset1 = make_valid_folder("20220434-2024")
                     dataset2 = make_valid_folder("20220434-2025")
 
-                    archive_dir = make_tmppath
-                    flexmock(LogRuntimeArchive)
-                        .should_receive(:archive_dataset)
-                        .with(
-                            ->(p) { p.path == (archive_dir / "20220434-2023.tar").to_s },
-                            dataset0,
-                            hsh(full: true)
-                        ).once.pass_thru
-                    flexmock(LogRuntimeArchive)
-                        .should_receive(:archive_dataset)
-                        .with(
-                            ->(p) { p.path == (archive_dir / "20220434-2024.tar").to_s },
-                            dataset1,
-                            hsh(full: true)
-                        ).once.pass_thru
-                    flexmock(LogRuntimeArchive)
-                        .should_receive(:archive_dataset)
-                        .with(
-                            ->(p) { p.path == (archive_dir / "20220434-2025.tar").to_s },
-                            dataset2,
-                            hsh(full: false)
-                        ).once.pass_thru
+                    should_archive_dataset(dataset0, "20220434-2023.0.tar", full: true)
+                    should_archive_dataset(dataset1, "20220434-2024.0.tar", full: true)
+                    should_archive_dataset(dataset2, "20220434-2025.0.tar", full: false)
+                    @process.process_root_folder
 
-                    LogRuntimeArchive.process_root_folder(@root, archive_dir)
+                    assert (@archive_dir / "20220434-2023.0.tar").file?
+                    assert (@archive_dir / "20220434-2024.0.tar").file?
+                    assert (@archive_dir / "20220434-2025.0.tar").file?
+                end
 
-                    assert (archive_dir / "20220434-2023.tar").file?
-                    assert (archive_dir / "20220434-2024.tar").file?
-                    assert (archive_dir / "20220434-2025.tar").file?
+                it "splits the archive according to the max size" do
+                    dataset = make_valid_folder("20220434-2023")
+                    (dataset / "test.0.log")
+                        .write(test0 = Base64.encode64(Random.bytes(1024)))
+                    (dataset / "test.1.log")
+                        .write(test1 = Base64.encode64(Random.bytes(1024)))
+                    (dataset / "test.2.log").write(Base64.encode64(Random.bytes(1024)))
+                    process = LogRuntimeArchive.new(
+                        @root, @archive_dir, max_archive_size: 1024
+                    )
+                    process.process_root_folder
+
+                    entries = read_archive(path: @archive_dir / "20220434-2023.0.tar")
+                    assert_equal 1, entries.size
+                    assert_entry_matches(
+                        *entries[0], name: "test.0.log.zst", content: test0
+                    )
+
+                    entries = read_archive(path: @archive_dir / "20220434-2023.1.tar")
+                    assert_equal 1, entries.size
+                    assert_entry_matches(
+                        *entries[0], name: "test.1.log.zst", content: test1
+                    )
+
+                    refute (@archive_dir / "20220434-2023.2.tar").exist?
+                end
+
+                it "appends to the last created archive" do
+                    dataset = make_valid_folder("20220434-2023")
+                    (dataset / "test.0.log")
+                        .write(Base64.encode64(Random.bytes(1024)))
+                    (dataset / "test.1.log")
+                        .write(test1 = Base64.encode64(Random.bytes(128)))
+                    (dataset / "test.2.log")
+                        .write(test2 = Base64.encode64(Random.bytes(128)))
+                    process = LogRuntimeArchive.new(
+                        @root, @archive_dir, max_archive_size: 1024
+                    )
+                    process.process_root_folder
+
+                    (dataset / "test.3.log").write(Base64.encode64(Random.bytes(1024)))
+                    process.process_root_folder
+
+                    entries = read_archive(path: @archive_dir / "20220434-2023.1.tar")
+                    assert_equal 2, entries.size
+                    assert_entry_matches(
+                        *entries[0], name: "test.1.log.zst", content: test1
+                    )
+                    assert_entry_matches(
+                        *entries[1], name: "test.2.log.zst", content: test2
+                    )
+
+                    refute (@archive_dir / "20220434-2023.2.tar").exist?
+                end
+
+                it "creates a new archive if the last archive is already "\
+                   "above the limit" do
+                    dataset = make_valid_folder("20220434-2023")
+                    (dataset / "test.0.log")
+                        .write(Base64.encode64(Random.bytes(1024)))
+                    (dataset / "test.1.log")
+                        .write(test1 = Base64.encode64(Random.bytes(1024)))
+                    (dataset / "test.2.log")
+                        .write(test2 = Base64.encode64(Random.bytes(1024)))
+                    process = LogRuntimeArchive.new(
+                        @root, @archive_dir, max_archive_size: 1024
+                    )
+                    process.process_root_folder
+
+                    (dataset / "test.3.log").write(Base64.encode64(Random.bytes(1024)))
+                    process.process_root_folder
+
+                    entries = read_archive(path: @archive_dir / "20220434-2023.1.tar")
+                    assert_equal 1, entries.size
+                    assert_entry_matches(
+                        *entries[0], name: "test.1.log.zst", content: test1
+                    )
+
+                    entries = read_archive(path: @archive_dir / "20220434-2023.2.tar")
+                    assert_equal 1, entries.size
+                    assert_entry_matches(
+                        *entries[0], name: "test.2.log.zst", content: test2
+                    )
+
+                    refute (@archive_dir / "20220434-2023.3.tar").exist?
                 end
 
                 it "appends to existing archives" do
@@ -232,12 +304,11 @@ module Syskit
                     make_in_file "test.0.log", "test0", root: dataset
                     make_in_file "test.1.log", "test1", root: dataset
 
-                    archive_dir = make_tmppath
-                    LogRuntimeArchive.process_root_folder(@root, archive_dir)
+                    @process.process_root_folder
                     make_in_file "test.2.log", "test2", root: dataset
-                    LogRuntimeArchive.process_root_folder(@root, archive_dir)
+                    @process.process_root_folder
 
-                    entries = read_archive(path: archive_dir / "20220434-2023.tar")
+                    entries = read_archive(path: @archive_dir / "20220434-2023.0.tar")
                     assert_equal 2, entries.size
                     assert_entry_matches(
                         *entries[0], name: "test.0.log.zst", content: "test0"
@@ -245,6 +316,15 @@ module Syskit
                     assert_entry_matches(
                         *entries[1], name: "test.1.log.zst", content: "test1"
                     )
+                end
+
+                def should_archive_dataset(dataset, archive_basename, full:)
+                    flexmock(LogRuntimeArchive)
+                        .should_receive(:archive_dataset)
+                        .with(
+                            ->(p) { p.path == (@archive_dir / archive_basename).to_s },
+                            dataset, hsh(full: full)
+                        ).once.pass_thru
                 end
             end
 


### PR DESCRIPTION
This PR expands on the log runtime archive command to offer splitting the archive on the basis of a max size.
In addition, the implementation takes great care to gather all logs that are not rotated (that is, that are relevant
for the complete execution) in separate archive(s) so that one can delete partial archives of rotated logs that were
not meant to be logged at all (e.g. being at the marina)