### PR TITLE
fix: heisenbug in remote process server's #reap_dead_subprocesses

### DIFF
--- a/lib/syskit/roby_app/remote_processes/server.rb
+++ b/lib/syskit/roby_app/remote_processes/server.rb
@@ -254,7 +254,9 @@ module Syskit
                 def reap_dead_subprocesses
                     dead_processes = []
                     while (exited = try_wait_pid(-1))
-                        dead_processes << handle_dead_subprocess(*exited)
+                        if (process = handle_dead_subprocess(*exited))
+                            dead_processes << process
+                        end
                     end
                     dead_processes
                 rescue Errno::ECHILD

--- a/lib/syskit/roby_app/remote_processes/server.rb
+++ b/lib/syskit/roby_app/remote_processes/server.rb
@@ -281,7 +281,10 @@ module Syskit
                 def handle_dead_subprocess(exit_pid, exit_status)
                     process_name, process =
                         processes.find { |_, p| p.pid == exit_pid }
-                    return unless process_name
+                    unless process_name
+                        warn "wait2 returned PID #{exit_pid}, which is not known"
+                        return
+                    end
 
                     process.dead!(exit_status)
                     processes.delete(process_name)


### PR DESCRIPTION
We sometimes we get a PID that has no corresponding registered process
and handlee_dead_subprocess returns nil. Do not notify the client about
these processes as it possibly can't do anything about them.

This was causing an exception in announce_dead_processes as it could
not handle the nil.

The reason for this process ID not being known is unknown right now.

Original error:

![image](https://github.com/rock-core/tools-syskit/assets/292/79d0d347-5dff-46cd-9a08-3a9a7945c7fa)
