### PR TITLE
fix: use job task itself when it does not have a planned_task

### DIFF
--- a/lib/syskit/gui/job_status_display.rb
+++ b/lib/syskit/gui/job_status_display.rb
@@ -39,7 +39,7 @@ module Syskit
             ].freeze
 
             def label
-                "##{job.job_id} #{job.action_name}"
+                "##{job.job_id} #{job.job_name}"
             end
 
             def create_ui

--- a/lib/syskit/gui/runtime_state.rb
+++ b/lib/syskit/gui/runtime_state.rb
@@ -335,7 +335,7 @@ module Syskit
                                                 .first
                     return unless job_task
 
-                    placeholder_task = job_task.planned_task
+                    placeholder_task = job_task.planned_task || job_task
                     return unless placeholder_task
 
                     dependency = placeholder_task.relation_graph_for(Roby::TaskStructure::Dependency)
@@ -368,9 +368,8 @@ module Syskit
                 all_tasks.merge(tasks)
                 tasks.each do |job|
                     if job.kind_of?(Roby::Interface::Job)
-                        if placeholder_task = job.planned_task
-                            all_job_info[placeholder_task] = job
-                        end
+                        placeholder_task = job.planned_task || job
+                        all_job_info[placeholder_task] = job
                     end
                 end
                 update_orocos_tasks


### PR DESCRIPTION
Depends on:
  - [ ] https://github.com/rock-core/tools-roby/pull/255
  
Uses the job task itself when it does not have a planned_task, and also display the job name instead of the action model name in the job list.