### PR TITLE
fix: setup log rotation for runtime only

### DIFF
--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -261,10 +261,11 @@ module Syskit
                 @handler_ids = plug_engine_in_roby(app.execution_engine)
 
                 if Syskit.conf.log_rotation_period
-                    app.execution_engine.every(Syskit.conf.log_rotation_period) do
-                        app.syskit_log_perform_rotation_and_transfer
-                        app.syskit_log_transfer_poll_state
-                    end
+                    @log_rotation_poll_handler =
+                        app.execution_engine.every(Syskit.conf.log_rotation_period) do
+                            app.syskit_log_perform_rotation_and_transfer
+                            app.syskit_log_transfer_poll_state
+                        end
                 end
             end
 
@@ -280,6 +281,8 @@ module Syskit
                     unplug_engine_from_roby(@handler_ids.values, app.execution_engine)
                     @handler_ids = nil
                 end
+
+                @log_rotation_poll_handler&.dispose
                 app.syskit_log_transfer_shutdown
             end
 

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -161,11 +161,9 @@ module Syskit
 
                 rtt_core_model = app.default_loader.task_model_from_name("RTT::TaskContext")
                 Syskit::TaskContext.define_from_orogen(rtt_core_model, register: true)
-
-                app.syskit_log_transfer_setup
             end
 
-            def syskit_log_transfer_setup
+            def syskit_log_transfer_prepare
                 return unless Syskit.conf.log_transfer.ip
 
                 unless Syskit.conf.log_rotation_period
@@ -178,7 +176,7 @@ module Syskit
                 @syskit_log_transfer_manager = LogTransferManager.new(conf)
             end
 
-            def syskit_log_transfer_cleanup
+            def syskit_log_transfer_shutdown
                 syskit_log_transfer_manager&.dispose(syskit_log_transfer_process_servers)
                 @syskit_log_transfer_manager = nil
             end
@@ -253,13 +251,13 @@ module Syskit
                     app.syskit_remove_configuration_changes_listener
                 end
 
-                app.syskit_log_transfer_cleanup
                 stop_local_process_server(app)
                 disconnect_all_process_servers
             end
 
             # Hook called by the main application to prepare for execution
             def self.prepare(app)
+                app.syskit_log_transfer_prepare
                 @handler_ids = plug_engine_in_roby(app.execution_engine)
 
                 if Syskit.conf.log_rotation_period
@@ -282,6 +280,7 @@ module Syskit
                     unplug_engine_from_roby(@handler_ids.values, app.execution_engine)
                     @handler_ids = nil
                 end
+                app.syskit_log_transfer_shutdown
             end
 
             def default_loader

--- a/test/roby_app/test_plugin.rb
+++ b/test/roby_app/test_plugin.rb
@@ -225,7 +225,7 @@ module Syskit
                 after do
                     Syskit.conf.log_rotation_period = nil
                     Syskit.conf.log_transfer.ip = nil
-                    app.syskit_log_transfer_cleanup
+                    app.syskit_log_transfer_shutdown
                 end
 
                 it "rotates logs and returns which logs were rotated" do
@@ -256,7 +256,7 @@ module Syskit
                 end
 
                 it "returns the list of process servers whose logs we want to transfer" do
-                    app.syskit_log_transfer_setup
+                    app.syskit_log_transfer_prepare
 
                     conf = Syskit.conf.process_server_config_for("localhost")
                     flexmock(conf).should_receive(supports_log_transfer?: true)
@@ -266,7 +266,7 @@ module Syskit
                 it "ignores local process servers if they have the same directory than "\
                    "the transfer's target dir" do
                     Syskit.conf.log_transfer.target_dir = app.log_dir
-                    app.syskit_log_transfer_setup
+                    app.syskit_log_transfer_prepare
 
                     conf = Syskit.conf.process_server_config_for("localhost")
                     flexmock(conf).should_receive(supports_log_transfer?: true)
@@ -288,7 +288,7 @@ module Syskit
                               Configuration::ProcessServerConfig.new => ["some_file"] }
                         )
 
-                    app.syskit_log_transfer_setup
+                    app.syskit_log_transfer_prepare
                     flexmock(conf.client)
                         .should_receive(:log_upload_file).explicitly
                         .with("127.0.0.1", 42, "cert", "user", "pass",


### PR DESCRIPTION
This pull request fixes problems opening, with e.g. the syskit IDE, a Syskit application that sets up log transfer. In that
case, the built-in log transfer server was setup in `#setup`, that is was actually setup when opening `syskit ide`,
and that failed because we can't bind to the target address. 