### PR TITLE
fix: resolve all syskit app unit test warnings

### DIFF
--- a/lib/syskit/deployment.rb
+++ b/lib/syskit/deployment.rb
@@ -33,6 +33,7 @@ module Syskit
         argument :ready_polling_period, default: 0.1
         argument :logger_task, default: nil
         argument :logger_name, default: nil
+        argument :logging_enabled, default: nil
         argument :read_only, default: nil
 
         # The underlying process object
@@ -369,6 +370,8 @@ module Syskit
         # @return [TaskContext,nil] either the logging task, or nil if this
         #   deployment has none
         def logger_task
+            return unless logging_enabled?
+
             if arguments[:logger_task]
                 @logger_task = arguments[:logger_task]
             elsif @logger_task&.reusable?
@@ -928,6 +931,14 @@ module Syskit
             # What could be stopped cleanly has been stopped cleanly (not
             # cleaned up, but stopped). Kill the process to avoid further damage
             kill! if running?
+        end
+
+        def logging_enabled?
+            if logging_enabled.nil?
+                process_server_config.logging_enabled?
+            else
+                logging_enabled
+            end
         end
     end
 end

--- a/lib/syskit/deployment.rb
+++ b/lib/syskit/deployment.rb
@@ -34,6 +34,7 @@ module Syskit
         argument :logger_task, default: nil
         argument :logger_name, default: nil
         argument :logging_enabled, default: nil
+        argument :register_on_name_server, default: nil
         argument :read_only, default: nil
 
         # The underlying process object
@@ -295,7 +296,8 @@ module Syskit
             spawn_options = spawn_options.merge(
                 output: "%m-%p.txt",
                 wait: false,
-                cmdline_args: options
+                cmdline_args: options,
+                register_on_name_server: register_on_name_server
             )
 
             if log_dir
@@ -938,6 +940,14 @@ module Syskit
                 process_server_config.logging_enabled?
             else
                 logging_enabled
+            end
+        end
+
+        def register_on_name_server?
+            if register_on_name_server.nil?
+                process_server_config.register_on_name_server?
+            else
+                register_on_name_server
             end
         end
     end

--- a/lib/syskit/network_generation/logger.rb
+++ b/lib/syskit/network_generation/logger.rb
@@ -103,6 +103,7 @@ module Syskit
                 required_loggers = []
                 engine.deployment_tasks.each do |deployment|
                     next unless deployment.plan
+                    next unless deployment.logging_enabled?
 
                     required_logging_ports = []
                     required_connections   = []

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -108,9 +108,12 @@ module Syskit
                         "ros", fake_client, app.log_dir, host_id: "syskit"
                     )
                 elsif Syskit.conf.define_default_process_managers?
-                    Syskit.conf.register_process_server("ruby_tasks",
-                                                        Orocos::RubyTasks::ProcessManager.new(app.default_loader),
-                                                        app.log_dir, host_id: "syskit")
+                    Syskit.conf.register_process_server(
+                        "ruby_tasks",
+                        Orocos::RubyTasks::ProcessManager.new(app.default_loader),
+                        app.log_dir,
+                        host_id: "syskit", logging_enabled: !app.testing?
+                    )
 
                     Syskit.conf.register_process_server(
                         "unmanaged_tasks", UnmanagedTasksManager.new, app.log_dir

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -112,7 +112,8 @@ module Syskit
                         "ruby_tasks",
                         Orocos::RubyTasks::ProcessManager.new(app.default_loader),
                         app.log_dir,
-                        host_id: "syskit", logging_enabled: !app.testing?
+                        host_id: "syskit", logging_enabled: !app.testing?,
+                        register_on_name_server: !app.testing?
                     )
 
                     Syskit.conf.register_process_server(

--- a/lib/syskit/roby_app/remote_processes/client.rb
+++ b/lib/syskit/roby_app/remote_processes/client.rb
@@ -65,6 +65,7 @@ module Syskit
                 def initialize(
                     host = "localhost", port = DEFAULT_PORT,
                     response_timeout: 10, root_loader: Orocos.default_loader,
+                    register_on_name_server: true
                 )
                     @host = host
                     @port = port
@@ -90,6 +91,7 @@ module Syskit
                     @processes = {}
                     @death_queue = []
                     @host_id = "#{host}:#{port}:#{server_pid}"
+                    @register_on_name_server = register_on_name_server
                     @response_timeout = response_timeout
                 end
 
@@ -177,6 +179,8 @@ module Syskit
                         deployment_model, options.delete(:prefix)
                     )
                     name_mappings = prefix_mappings.merge(name_mappings)
+                    options[:register_on_name_server] =
+                        options.fetch(:register_on_name_server, @register_on_name_server)
 
                     socket.write(COMMAND_START)
                     Marshal.dump(

--- a/lib/syskit/roby_app/remote_processes/client.rb
+++ b/lib/syskit/roby_app/remote_processes/client.rb
@@ -48,9 +48,6 @@ module Syskit
                 attr_reader :server_pid
                 # A string that allows to uniquely identify this process server
                 attr_reader :host_id
-                # The name service object that allows to resolve tasks from this process
-                # server
-                attr_reader :name_service
 
                 def to_s
                     "#<Syskit::RobyApp::RemoteProcesses::Client #{host}:#{port}>"
@@ -62,16 +59,12 @@ module Syskit
 
                 # Connects to the process server at +host+:+port+
                 #
-                # @option options [Orocos::NameService] :name_service
-                #   (Orocos.name_service). The name service object that should be used
-                #   to resolve tasks started by this process server
                 # @option options [OroGen::Loaders::Base] :root_loader
                 #   (Orocos.default_loader). The loader object that should be used as
                 #   root for this client's loader
                 def initialize(
                     host = "localhost", port = DEFAULT_PORT,
                     response_timeout: 10, root_loader: Orocos.default_loader,
-                    name_service: Orocos.name_service
                 )
                     @host = host
                     @port = port
@@ -86,7 +79,6 @@ module Syskit
                     socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, true)
                     socket.fcntl(Fcntl::FD_CLOEXEC, 1)
 
-                    @name_service = name_service
                     begin
                         @server_pid = pid
                     rescue EOFError

--- a/lib/syskit/test/network_manipulation.rb
+++ b/lib/syskit/test/network_manipulation.rb
@@ -353,14 +353,16 @@ module Syskit
             # @param [Boolean] read_only (see #syskit_stub_configured_deployment)
             def syskit_stub_deployment( # rubocop:disable Metrics/ParameterLists
                 name = "deployment", deployment_model = nil,
-                task_model: nil, read_only: [],
+                task_model: nil, read_only: [], logging_enabled: nil,
                 remote_task: syskit_stub_resolves_remote_tasks?, &block
             )
                 deployment_model ||= syskit_stub_configured_deployment(
                     task_model, name,
                     read_only: read_only, remote_task: remote_task, &block
                 )
-                task = deployment_model.new(process_name: name, on: "stubs")
+                task = deployment_model.new(
+                    process_name: name, on: "stubs", logging_enabled: logging_enabled
+                )
                 plan.add_permanent_task(task)
                 task
             end

--- a/lib/syskit/test/self.rb
+++ b/lib/syskit/test/self.rb
@@ -86,8 +86,8 @@ module Syskit
                     "stubs",
                     Orocos::RubyTasks::ProcessManager.new(
                         Roby.app.default_loader,
-                        task_context_class: Orocos::RubyTasks::StubTaskContext
-                    ), "", host_id: "syskit"
+                        task_context_class: Orocos::RubyTasks::StubTaskContext,
+                    ), "", host_id: "syskit", logging_enabled: false
                 )
                 Syskit.conf.logs.create_configuration_log(
                     File.join(app.log_dir, "properties")

--- a/lib/syskit/test/self.rb
+++ b/lib/syskit/test/self.rb
@@ -82,12 +82,15 @@ module Syskit
                     Syskit::RobyApp::Plugin.connect_to_local_process_server
                 end
 
+                stubs_process_manager = Orocos::RubyTasks::ProcessManager.new(
+                    Roby.app.default_loader,
+                    task_context_class: Orocos::RubyTasks::StubTaskContext
+                )
+
                 Syskit.conf.register_process_server(
-                    "stubs",
-                    Orocos::RubyTasks::ProcessManager.new(
-                        Roby.app.default_loader,
-                        task_context_class: Orocos::RubyTasks::StubTaskContext,
-                    ), "", host_id: "syskit", logging_enabled: false
+                    "stubs", stubs_process_manager, "",
+                    host_id: "syskit", logging_enabled: false,
+                    register_on_name_server: false
                 )
                 Syskit.conf.logs.create_configuration_log(
                     File.join(app.log_dir, "properties")

--- a/test/network_generation/test_logger.rb
+++ b/test/network_generation/test_logger.rb
@@ -142,7 +142,9 @@ describe Syskit::NetworkGeneration::LoggerConfigurationSupport do
         end
 
         it "sets up logging while sharing a logger across deployments" do
-            deployment2 = syskit_stub_deployment("deployment2", deployment_m)
+            deployment2 = syskit_stub_deployment(
+                "deployment2", deployment_m, logging_enabled: true
+            )
             task2 = deployment2.task "task"
             syskit_engine.should_receive(:deployment_tasks)
                          .and_return([@deployment, deployment2])
@@ -278,6 +280,6 @@ describe Syskit::NetworkGeneration::LoggerConfigurationSupport do
             task "task", task_m.orogen_model
             task "deployment_Logger", logger_m.orogen_model
         end
-        syskit_stub_deployment("deployment", deployment_m)
+        syskit_stub_deployment("deployment", deployment_m, logging_enabled: true)
     end
 end

--- a/test/roby_app/test_log_transfer_manager.rb
+++ b/test/roby_app/test_log_transfer_manager.rb
@@ -102,7 +102,8 @@ module Syskit
                 client = RemoteProcesses::Client.new("localhost", server.port)
                 log_dir = config_log_dir(client)
                 config = Configuration::ProcessServerConfig.new(
-                    name: "test", client: client, log_dir: log_dir
+                    name: "test", client: client, log_dir: log_dir,
+                    logging_enabled: false, register_on_name_server: false
                 )
                 @server_threads << thread
                 @process_servers << config

--- a/test/roby_app/test_log_transfer_manager.rb
+++ b/test/roby_app/test_log_transfer_manager.rb
@@ -101,7 +101,9 @@ module Syskit
 
                 client = RemoteProcesses::Client.new("localhost", server.port)
                 log_dir = config_log_dir(client)
-                config = Configuration::ProcessServerConfig.new("test", client, log_dir)
+                config = Configuration::ProcessServerConfig.new(
+                    name: "test", client: client, log_dir: log_dir
+                )
                 @server_threads << thread
                 @process_servers << config
                 config

--- a/test/test_ruby_tasks_context.rb
+++ b/test/test_ruby_tasks_context.rb
@@ -27,7 +27,9 @@ module Syskit
             assert_kind_of RubyTaskContext, task
             assert_equal "test", task.orocos_name
 
-            remote_task = Orocos.allow_blocking_calls { Orocos.name_service.get("test") }
+            remote_task = Orocos.allow_blocking_calls do
+                Orocos::TaskContext.new(task.orocos_task.ior)
+            end
             assert_equal remote_task, task.orocos_task
             Orocos.allow_blocking_calls do
                 assert_equal remote_task.in, task.orocos_task.in


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-orocosrb/pull/153
- [ ] https://github.com/rock-core/tools-orogen/pull/14

Running a bundle's unit test suite generated a lot of warnings. The main offender is the warning that ruby tasks don't have a logger, which is now disabled by specifying that all deployments of a given process server should not be logged. 

The second warning, of rebinding existing CORBA naming service entries, happens when running unit test suites in parallel, or - worse - when running a unit test suite while a system is running on the same machine. This is resolved by making registration optional. Note that to not get another warning in its place, one has to set ORO_NO_EMIT_CORBA_IOR while building RTT, like this:

```
setup_package "rtt" do |pkg|
    pkg.define "ORO_NO_EMIT_CORBA_IOR", true
end
```