### PR TITLE
fix: instanciate data readers accessors on copy

### DIFF
--- a/lib/syskit/component.rb
+++ b/lib/syskit/component.rb
@@ -53,12 +53,7 @@ module Syskit
             super
             @requirements = InstanceRequirements.new
 
-            @registered_data_writers =
-                instanciate_data_accessors(model.each_data_writer)
-            @registered_data_readers =
-                instanciate_data_accessors(model.each_data_reader)
-            @data_readers = @registered_data_readers.values
-            @data_writers = @registered_data_writers.values
+            setup_data_accessors
         end
 
         def initialize_copy(source)
@@ -66,6 +61,16 @@ module Syskit
             @requirements = @requirements.dup
             specialize if source.specialized_model?
             duplicate_missing_services_from(source)
+            setup_data_accessors
+        end
+
+        def setup_data_accessors
+            @registered_data_writers =
+                instanciate_data_accessors(model.each_data_writer)
+            @registered_data_readers =
+                instanciate_data_accessors(model.each_data_reader)
+            @data_readers = @registered_data_readers.values
+            @data_writers = @registered_data_writers.values
         end
 
         def create_fresh_copy

--- a/test/test_component.rb
+++ b/test/test_component.rb
@@ -735,6 +735,13 @@ describe Syskit::Component do
             @task = syskit_stub_deploy_and_configure(@task_m)
         end
 
+        it "instanciates new data readers on dup" do
+            @task_m.data_reader @task_m.out_port, as: "test"
+            task1 = @task_m.new
+            task2 = task1.dup
+            refute_equal task1.test_reader, task2.test_reader
+        end
+
         describe "without a given accessor name" do
             it "creates an unbound accessor" do
                 reader = @task.data_reader(@task_m.out_port)
@@ -958,6 +965,13 @@ describe Syskit::Component do
             flexmock(Syskit::DynamicPortBinding::BoundInputWriter)
 
             @task = syskit_stub_deploy_and_configure(@task_m)
+        end
+
+        it "instanciates new data writers on dup" do
+            @task_m.data_writer @task_m.in_port, as: "test"
+            task1 = @task_m.new
+            task2 = task1.dup
+            refute_equal task1.test_writer, task2.test_writer
         end
 
         describe "without a given accessor name" do


### PR DESCRIPTION
We found out a bug where data accessors wouldnt be re-instanciated on a copy, causing find_registered_data_readers/writers to point to accessors from the old task instance.