### PR TITLE
fix: disable name server registration for stubs

### DIFF
--- a/lib/syskit/test/spec.rb
+++ b/lib/syskit/test/spec.rb
@@ -19,7 +19,8 @@ module Syskit
                     loader, task_context_class: Orocos::RubyTasks::StubTaskContext
                 )
                 Syskit.conf.register_process_server(
-                    "stubs", stub_manager, nil, host_id: "syskit"
+                    "stubs", stub_manager, nil,
+                    host_id: "syskit", register_on_name_server: false
                 )
 
                 super


### PR DESCRIPTION
It was disabled in Syskit's self-test stubs process server, but I missed the one for the bundles' tests. This was hidden by the bug that actually disabled name service registration for all deployments.