### PR TITLE
fix: handle a delay between the fatal error and the component returning from stop

### DIFF
--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -1143,7 +1143,9 @@ module Syskit
                         stop_orocos_task
                     end
                 promise.on_error(description: "#{self}#interrupt#error") do |error|
-                    quarantined! unless error.kind_of?(Orocos::StateTransitionFailed)
+                    if execution_agent && !error.kind_of?(Orocos::StateTransitionFailed)
+                        quarantined!
+                    end
                 end
 
                 interrupt_event.achieve_asynchronously(promise, emit_on_success: false)


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-orogen_syskit_tests/pull/5

Syskit has two communication channels with components. One is the return of state transition commands (start/stop essentially) and one is the state port.

When a component goes to FATAL while it's being stopped, the fatal might have been processed before stop gets to return. If a response to the transition to fatal is to kill the deployment - something we have to do on our system - it might be that the deployment is down and the component aborted when stop returns. This is (rather obviously) not a normal condition in quarantined!, and the method was raising.

Handle this case, and test for it.