### PR TITLE
fix: log_runtime_archive `watch` subcommand

### DIFF
--- a/lib/syskit/cli/log_runtime_archive_main.rb
+++ b/lib/syskit/cli/log_runtime_archive_main.rb
@@ -29,7 +29,11 @@ module Syskit
                     available space is above this threshold (threshold in MB)"
             default_task def watch(root_dir, target_dir)
                 loop do
-                    archive(root_dir, target_dir)
+                    begin
+                        archive(root_dir, target_dir)
+                    rescue Errno::ENOSPC
+                        next
+                    end
 
                     puts "Archived pending logs, sleeping #{options[:period]}s"
                     sleep options[:period]

--- a/lib/syskit/cli/log_runtime_archive_main.rb
+++ b/lib/syskit/cli/log_runtime_archive_main.rb
@@ -21,6 +21,12 @@ module Syskit
                    type: :numeric, default: 600, desc: "polling period in seconds"
             option :max_size,
                    type: :numeric, default: 10_000, desc: "max log size in MB"
+            option :free_space_low_limit,
+                   type: :numeric, default: 5_000, desc: "start deleting files if \
+                    available space is below this threshold (threshold in MB)"
+            option :free_space_freed_limit,
+                   type: :numeric, default: 25_000, desc: "stop deleting files if \
+                    available space is above this threshold (threshold in MB)"
             default_task def watch(root_dir, target_dir)
                 loop do
                     archive(root_dir, target_dir)

--- a/lib/syskit/cli/log_runtime_archive_main.rb
+++ b/lib/syskit/cli/log_runtime_archive_main.rb
@@ -10,7 +10,7 @@ require "syskit/cli/log_runtime_archive"
 module Syskit
     module CLI
         # Command-line definition for the cli-archive-main syskit subcommand
-        class CLIArchiveMain < Thor
+        class LogRuntimeArchiveMain < Thor
             def self.exit_on_failure?
                 true
             end

--- a/lib/syskit/cli/log_runtime_archive_main.rb
+++ b/lib/syskit/cli/log_runtime_archive_main.rb
@@ -51,8 +51,8 @@ module Syskit
                 archiver = make_archiver(root_dir, target_dir)
 
                 archiver.ensure_free_space(
-                    options[:free_space_low_limit] * 1e6,
-                    options[:free_space_freed_limit] * 1e6
+                    options[:free_space_low_limit] * 1_000_000,
+                    options[:free_space_freed_limit] * 1_000_000
                 )
                 archiver.process_root_folder
             end

--- a/test/cli/test_log_runtime_archive_main.rb
+++ b/test/cli/test_log_runtime_archive_main.rb
@@ -17,8 +17,7 @@ module Syskit
                 end
 
                 it "calls archive with the specified period" do
-                    size_files = [75, 40, 90, 60, 70]
-                    mock_files_size(size_files)
+                    mock_files_size([])
                     mock_available_space(200) # 70 MB
 
                     quit = Class.new(RuntimeError)
@@ -31,6 +30,7 @@ module Syskit
                             raise quit if called == 3
                         end
 
+                    tic = Time.now
                     assert_raises(quit) do
                         LogRuntimeArchiveMain.start(
                             ["watch", @root, @archive_dir, "--period", 0.5]
@@ -38,6 +38,7 @@ module Syskit
                     end
 
                     assert called == 3
+                    assert_operator(Time.now - tic, :>, 0.9)
                 end
             end
 

--- a/test/cli/test_log_runtime_archive_main.rb
+++ b/test/cli/test_log_runtime_archive_main.rb
@@ -6,7 +6,7 @@ require "syskit/cli/log_runtime_archive_main"
 module Syskit
     module CLI
         # Tests CLI command "archive" from syskit/cli/log_runtime_archive_main.rb
-        describe CLIArchiveMain do
+        describe LogRuntimeArchiveMain do
             it "raises ArgumentError if some of the directories do not exist" do
                 root = "make_tmppath"
 
@@ -94,7 +94,7 @@ module Syskit
 
             # Call 'archive' function instead of 'watch' to call archiver once
             def call_command_line(root_path, archive_path, low_limit, freed_limit)
-                Syskit::CLI::CLIArchiveMain.start(
+                LogRuntimeArchiveMain.start(
                     ["archive", root_path, archive_path,
                      "--free-space-low-limit", low_limit,
                      "--free-space-freed-limit", freed_limit]


### PR DESCRIPTION
The name in scripts/log_runtime_archive_main did not match the definition in cli/log_runtime_archive_main. Pick the name that maches the file name.