### PR TITLE
fix: use bytes_available instead of bytes_free to determine free space

### DIFF
--- a/lib/syskit/cli/log_runtime_archive.rb
+++ b/lib/syskit/cli/log_runtime_archive.rb
@@ -59,7 +59,7 @@ module Syskit
                 end
 
                 stat = Sys::Filesystem.stat(@target_dir)
-                available_space = stat.bytes_free
+                available_space = stat.bytes_available
 
                 return if available_space > free_space_low_limit
 

--- a/test/cli/test_log_runtime_archive.rb
+++ b/test/cli/test_log_runtime_archive.rb
@@ -557,7 +557,7 @@ module Syskit
                         .should_receive(:stat).with(@archive_dir)
                         .and_return do
                             flexmock(
-                                bytes_free: total_available_disk_space
+                                bytes_available: total_available_disk_space
                             )
                         end
                 end

--- a/test/cli/test_log_runtime_archive_main.rb
+++ b/test/cli/test_log_runtime_archive_main.rb
@@ -144,7 +144,7 @@ module Syskit
                     .should_receive(:stat).with(@archive_dir)
                     .and_return do
                         flexmock(
-                            bytes_free: total_available_disk_space * 1e6
+                            bytes_available: total_available_disk_space * 1e6
                         )
                     end
             end


### PR DESCRIPTION
The former is the total amount free on disk, the latter takes into account space reserved for priviledged users (e.g. root)