### PR TITLE
fix: register "simulated" tasks on the corba naming services when in `syskit run`

### DIFF
--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -414,7 +414,8 @@ module Syskit
                     )
                     register_process_server(
                         sim_name, mng,
-                        logging_enabled: false, register_on_name_server: false
+                        logging_enabled: false,
+                        register_on_name_server: !app.testing?
                     )
                 end
                 process_server_config_for(sim_name)


### PR DESCRIPTION
These are the tasks that come from `syskit run --sim`, which we definitely want to see.