### PR TITLE
fix: handle resolution raising an error while all InstanceRequirements task have been removed

### DIFF
--- a/lib/syskit/runtime/apply_requirement_modifications.rb
+++ b/lib/syskit/runtime/apply_requirement_modifications.rb
@@ -113,13 +113,8 @@ module Syskit
                 end
                 nil
             rescue ::Exception => e # rubocop:disable Lint/RescueException
-                if running_requirement_tasks.empty?
-                    add_framework_error(e, "deployment error without "\
-                        "requirement tasks")
-                else
-                    running_requirement_tasks.each do |t|
-                        t.failed_event.emit(e)
-                    end
+                running_requirement_tasks.each do |t|
+                    t.failed_event.emit(e)
                 end
                 e
             end


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-drivers/drivers-orogen-controldev_websocket/pull/13
- [ ] https://github.com/rock-drivers/drivers-orogen-controldev_websocket/pull/15

This was triggering a (wrong) sanity check in the async resolution error handling, that was in the end killing syskit.