### PR TITLE
feat: use the v2 interface in `telemetry ui`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -573,6 +573,7 @@ Metrics/ClassLength:
     - 'lib/syskit/network_generation/engine.rb'
     - 'lib/syskit/runtime/connection_management.rb'
     - 'lib/syskit/task_context.rb'
+    - 'lib/syskit/telemetry/ui/runtime_state.rb'
 
 # Offense count: 105
 # Configuration parameters: Max.

--- a/lib/syskit/interface/v2.rb
+++ b/lib/syskit/interface/v2.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require "syskit/interface/v2/protocol"
+require "syskit/interface/commands"

--- a/lib/syskit/interface/v2/protocol.rb
+++ b/lib/syskit/interface/v2/protocol.rb
@@ -1,21 +1,36 @@
 # frozen_string_literal: true
 
+require "roby/interface/v2"
+
 module Syskit
     module Interface
         module V2
             # Syskit extensions to Roby's v2 interface wire protocol
             module Protocol
+                ROBY_TASK_MEMBERS = Roby::Interface::V2::Protocol::Task.new.members
+
                 Deployment = Struct.new(
-                    :roby_task, :pid, :ready_since, :iors, keyword_init: true
+                    *ROBY_TASK_MEMBERS,
+                    :pid, :ready_since, :deployed_tasks, keyword_init: true
                 ) do
                     def pretty_print(pp)
-                        roby_task.pretty_print(pp)
+                        roby_task = ROBY_TASK_MEMBERS.map do |name|
+                            [name, self[name]]
+                        end
+                        Roby::Interface::V2::Protocol::Task
+                            .new(**Hash[roby_task])
+                            .pretty_print(pp)
                         pp.breakable
                         pp.text "PID: #{pid}"
                         pp.breakable
-                        pp.text "Deployed tasks: #{iors.keys.join(', ')}"
+                        names = deployed_tasks.map(&:name)
+                        pp.text "Deployed tasks: #{names.join(', ')}"
                     end
                 end
+
+                DeployedTask = Struct.new(
+                    :name, :ior, :orogen_model_name, keyword_init: true
+                )
 
                 def self.register_marshallers(protocol)
                     protocol.add_marshaller(
@@ -23,14 +38,26 @@ module Syskit
                     )
                 end
 
+                def self.register_remote_task_handle(name, remote_task_handle)
+                    ior = remote_task_handle.handle.ior
+                    model_name = remote_task_handle.handle.model.name
+                    DeployedTask.new(
+                        name: name, ior: ior, orogen_model_name: model_name
+                    )
+                end
+
                 def self.marshal_deployment_task(channel, task)
+                    deployed_tasks =
+                        task.remote_task_handles.map do |name, remote_task_handle|
+                            register_remote_task_handle(name, remote_task_handle)
+                        end
+
+                    roby_task = Roby::Interface::V2::Protocol.marshal_task(channel, task)
                     Deployment.new(
-                        roby_task: Roby::Interface::V2::Protocol.marshal_task(
-                            channel, task
-                        ),
+                        **roby_task.to_h,
                         pid: task.pid,
                         ready_since: task.ready_event.last&.time,
-                        iors: task.remote_task_handles.transform_values { _1.handle.ior }
+                        deployed_tasks: deployed_tasks
                     )
                 end
             end

--- a/lib/syskit/telemetry/cli.rb
+++ b/lib/syskit/telemetry/cli.rb
@@ -2,7 +2,6 @@
 
 require "roby"
 require "roby/interface/base"
-require "roby/interface/v1/async"
 
 module Syskit
     module Telemetry
@@ -12,11 +11,11 @@ module Syskit
                  "open a UI to interface with a running Syskit system"
             option :host,
                    type: :string, doc: "host[:port] to connect to",
-                   default: "localhost:#{Roby::Interface::DEFAULT_PORT}"
+                   default: "localhost:#{Roby::Interface::DEFAULT_PORT_V2}"
             def ui
                 roby_setup
                 host, port = parse_host_port(
-                    options[:host], default_port: Roby::Interface::DEFAULT_PORT
+                    options[:host], default_port: Roby::Interface::DEFAULT_PORT_V2
                 )
 
                 require "syskit/telemetry/ui/runtime_state"
@@ -49,8 +48,8 @@ module Syskit
 
                 def runtime_state(host, port)
                     Orocos.initialize
-                    interface =
-                        Roby::Interface::V1::Async::Interface.new(host, port: port)
+                    interface = Roby::Interface::V2::Async::Interface
+                                .new(host, port: port)
                     main = UI::RuntimeState.new(syskit: interface)
                     main.window_title = "Syskit @#{options[:host]}"
 

--- a/lib/syskit/telemetry/ui/name_service.rb
+++ b/lib/syskit/telemetry/ui/name_service.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Syskit
+    module Telemetry
+        module UI
+            # Copy of Runkit's local name service to use with orocos.rb
+            class NameService < Orocos::NameServiceBase
+                # A new NameService instance
+                #
+                # @param [Hash<String,Orocos::TaskContext>] tasks The tasks which are
+                #        known by the name service.
+                # @note The namespace is always "Local"
+                def initialize(tasks = [])
+                    @registered_tasks = Concurrent::Hash.new
+                    tasks.each { |task| register(task) }
+                end
+
+                def names
+                    @registered_tasks.keys
+                end
+
+                def include?(name)
+                    puts @registered_tasks.keys
+                    @registered_tasks.key?(name)
+                end
+
+                # (see NameServiceBase#get)
+                def ior(name)
+                    task = @registered_tasks[name]
+                    return task.ior if task.respond_to?(:ior)
+
+                    raise Orocos::NotFound, "task context #{name} cannot be found."
+                end
+
+                # (see NameServiceBase#get)
+                def get(name, **)
+                    task = @registered_tasks[name]
+                    return task if task
+
+                    raise Orocos::NotFound, "task context #{name} cannot be found."
+                end
+
+                # Registers the given {Orocos::TaskContext} on the name service.
+                # If a name is provided, it will be used as an alias. If no name is
+                # provided, the name of the task is used. This is true even if the
+                # task name is renamed later.
+                #
+                # @param [Orocos::TaskContext] task The task.
+                # @param [String] name Optional name which is used to register the task.
+                def register(task, name: task.name)
+                    @registered_tasks[name] = task
+                end
+
+                # Deregisters the given name or task from the name service.
+                #
+                # @param [String,TaskContext] name The name or task
+                def deregister(name)
+                    @registered_tasks.delete(name)
+                end
+
+                # (see Base#cleanup)
+                def cleanup
+                    @registered_tasks.clear
+                end
+            end
+        end
+    end
+end

--- a/lib/syskit/telemetry/ui/runtime_state.rb
+++ b/lib/syskit/telemetry/ui/runtime_state.rb
@@ -6,7 +6,6 @@ require "vizkit"
 require "syskit"
 require "metaruby/gui/exception_view"
 require "roby/interface/v2/async"
-require "roby/interface/v2/async/log"
 require "roby/gui/exception_view"
 require "syskit/telemetry/ui/logging_configuration"
 require "syskit/telemetry/ui/job_status_display"
@@ -15,6 +14,8 @@ require "syskit/telemetry/ui/expanded_job_status"
 require "syskit/telemetry/ui/global_state_label"
 require "syskit/telemetry/ui/app_start_dialog"
 require "syskit/telemetry/ui/batch_manager"
+require "syskit/telemetry/ui/name_service"
+require "syskit/interface/v2"
 
 module Syskit
     module Telemetry
@@ -27,8 +28,6 @@ module Syskit
                 # @return [Roby::Interface::V2::Async::Interface] the underlying syskit
                 #   interface
                 attr_reader :syskit
-                # An async object to access the log stream
-                attr_reader :syskit_log_stream
 
                 # The toplevel layout
                 attr_reader :main_layout
@@ -47,11 +46,6 @@ module Syskit
                 # The connection state, which gives access to the global Syskit
                 # state
                 attr_reader :connection_state
-
-                # All known tasks
-                attr_reader :all_tasks
-                # Job information for tasks in the rebuilt plan
-                attr_reader :all_job_info
 
                 # The name service which allows us to resolve Rock task contexts
                 attr_reader :name_service
@@ -141,9 +135,7 @@ module Syskit
                     connect syskit_poll, SIGNAL("timeout()"),
                             self, SLOT("poll_syskit_interface()")
 
-                    if poll_period
-                        @syskit_poll.start(poll_period)
-                    end
+                    @syskit_poll.start(poll_period) if poll_period
 
                     create_ui
 
@@ -166,15 +158,15 @@ module Syskit
 
                     @current_job = nil
                     @current_orocos_tasks = Set.new
-                    @all_tasks = Set.new
-                    @known_loggers = nil
-                    @all_job_info = {}
+                    @proxies = {}
+
                     syskit.on_ui_event do |event_name, *args|
-                        if w = @ui_event_widgets[event_name]
+                        if (w = @ui_event_widgets[event_name])
                             w.show
                             w.update(*args)
                         else
-                            puts "don't know what to do with UI event #{event_name}, known events: #{@ui_event_widgets}"
+                            puts "don't know what to do with UI event #{event_name}, "\
+                                 "known events: #{@ui_event_widgets}"
                         end
                     end
                     on_connection_state_changed do |state|
@@ -183,7 +175,6 @@ module Syskit
                     end
                     syskit.on_reachable do
                         @syskit_commands = syskit.client.syskit
-                        update_log_server_connection(syskit.log_server_port)
                         @job_status_list.each_widget do |w|
                             w.show_actions = true
                         end
@@ -192,7 +183,9 @@ module Syskit
                         syskit.actions.sort_by(&:name).each do |action|
                             next if action.advanced?
 
-                            action_combo.add_item(action.name, Qt::Variant.new(action.doc))
+                            action_combo.add_item(
+                                action.name, Qt::Variant.new(action.doc)
+                            )
                         end
                         ui_logging_configuration.refresh
                         global_actions[:start].visible = false
@@ -247,37 +240,11 @@ module Syskit
                 def reset
                     Orocos.initialize
                     @logger_m = nil
-                    orocos_corba_nameservice = Orocos::CORBA::NameService.new(syskit.remote_name)
-                    @name_service = Orocos::Async::NameService.new(orocos_corba_nameservice)
-                end
+                    @call_guards = {}
+                    @orogen_models = {}
 
-                def update_log_server_connection(port)
-                    if syskit_log_stream && (syskit_log_stream.port == port)
-                        return
-                    elsif syskit_log_stream
-                        syskit_log_stream.close
-                    end
-
-                    @syskit_log_stream = Roby::Interface::V2::Async::Log.new(syskit.remote_name, port: port)
-                    syskit_log_stream.on_reachable do
-                        deselect_job
-                    end
-                    syskit_log_stream.on_init_progress do |rx, expected|
-                        run_hook :on_progress, format("loading %02i", Float(rx) / expected * 100)
-                    end
-                    syskit_log_stream.on_update do |cycle_index, cycle_time|
-                        if syskit_log_stream.init_done?
-                            time_s = cycle_time.strftime("%H:%M:%S.%3N").to_s
-                            run_hook :on_progress, format("@%i %s", cycle_index, time_s)
-
-                            job_expanded_status.update_time(cycle_index, cycle_time)
-                            update_tasks_info
-                            job_expanded_status.add_tasks_info(all_tasks, all_job_info)
-                            job_expanded_status.scheduler_state = syskit_log_stream.scheduler_state
-                            job_expanded_status.update_chronicle unless hide_expanded_jobs?
-                        end
-                        syskit_log_stream.clear_integrated
-                    end
+                    @name_service = NameService.new
+                    @async_name_service = Orocos::Async::NameService.new(@name_service)
                 end
 
                 def hide_loggers?
@@ -332,68 +299,6 @@ module Syskit
                     @logger_m ||= Syskit::TaskContext
                                   .find_model_from_orogen_name("logger::Logger") || false
                     t.kind_of?(@logger_m) if @logger_m
-                end
-
-                def update_tasks_info
-                    if current_job
-                        job_task = syskit_log_stream.plan.find_tasks(Roby::Interface::Job)
-                                                    .with_arguments(job_id: current_job.job_id)
-                                                    .first
-                        return unless job_task
-
-                        placeholder_task = job_task.planned_task || job_task
-                        return unless placeholder_task
-
-                        dependency = placeholder_task.relation_graph_for(Roby::TaskStructure::Dependency)
-                        tasks = dependency.enum_for(:depth_first_visit, placeholder_task).to_a
-                        tasks << job_task
-                    else
-                        tasks = syskit_log_stream.plan.tasks
-                    end
-
-                    if hide_loggers?
-                        unless @known_loggers
-                            @known_loggers = Set.new
-                            all_tasks.delete_if do |t|
-                                @known_loggers << t if logger_task?(t)
-                            end
-                        end
-
-                        tasks = tasks.find_all do |t|
-                            if all_tasks.include?(t)
-                                true
-                            elsif @known_loggers.include?(t)
-                                false
-                            elsif logger_task?(t)
-                                @known_loggers << t
-                                false
-                            else true
-                            end
-                        end
-                    end
-                    all_tasks.merge(tasks)
-                    tasks.each do |job|
-                        if job.kind_of?(Roby::Interface::Job)
-                            placeholder_task = job.planned_task || job
-                            all_job_info[placeholder_task] = job
-                        end
-                    end
-                    update_orocos_tasks
-                end
-
-                def update_orocos_tasks
-                    candidate_tasks = all_tasks
-                                      .find_all { |t| t.kind_of?(Syskit::TaskContext) }
-                    orocos_tasks = candidate_tasks.map { |t| t.arguments[:orocos_name] }.compact.to_set
-                    removed = current_orocos_tasks - orocos_tasks
-                    new     = orocos_tasks - current_orocos_tasks
-                    removed.each do |task_name|
-                        ui_task_inspector.remove_task(task_name)
-                    end
-                    new.each do |task_name|
-                        ui_task_inspector.add_task(name_service.proxy(task_name))
-                    end
-                    @current_orocos_tasks = orocos_tasks
                 end
 
                 EventWidget = Struct.new :name, :widget, :hook do
@@ -479,7 +384,6 @@ module Syskit
                     )
                     @ui_hide_loggers.checked = false
                     @ui_hide_loggers.connect SIGNAL("toggled(bool)") do |checked|
-                        @known_loggers = nil
                         update_tasks_info
                     end
                     @ui_show_expanded_job.checked = true
@@ -599,23 +503,173 @@ module Syskit
                 #
                 # Sets up polling on a given syskit interface
                 def poll_syskit_interface
+                    if syskit.connected?
+                        begin
+                            display_current_cycle_index_and_time
+                            update_current_deployments
+                            update_current_job_task_names if current_job
+                        rescue Roby::Interface::ComError # rubocop:disable Lint/SuppressedException
+                        end
+                    else
+                        reset_current_deployments
+                        reset_current_job
+                        reset_name_service
+                        reset_task_inspector
+                    end
+
                     syskit.poll
-                    if syskit_log_stream
-                        if syskit_log_stream.poll(max: 0.05) == Roby::Interface::V2::Async::Log::STATE_PENDING_DATA
-                            syskit_poll.interval = 0
+                end
+                slots "poll_syskit_interface()"
+
+                def display_current_cycle_index_and_time
+                    return unless syskit.cycle_start_time
+
+                    time_s = syskit.cycle_start_time.strftime("%H:%M:%S.%3N").to_s
+                    progress_s = format(
+                        "@%<index>i %<time>s", index: syskit.cycle_index, time: time_s
+                    )
+                    run_hook :on_progress, progress_s
+                end
+
+                def reset_current_job
+                    @current_job = nil
+                    @current_job_task_names = []
+
+                    update_task_inspector(@name_service.names)
+                end
+
+                def update_current_deployments
+                    polling_call ["syskit"], "deployments" do |deployments|
+                        @current_deployments = deployments
+                        update_name_service(deployments)
+
+                        names = @name_service.names
+                        names &= @current_job_task_names if @current_job
+                        update_task_inspector(names)
+                    end
+                end
+
+                def reset_current_deployments
+                    @current_deployments = []
+                    reset_task_inspector
+                end
+
+                def update_current_job_task_names
+                    polling_call [], "tasks_of_job", @current_job.job_id do |tasks|
+                        @current_job_task_names =
+                            tasks
+                            .map { _1.arguments[:orocos_name] }
+                            .compact
+                    end
+                end
+
+                def update_task_inspector(task_names)
+                    orocos_tasks = task_names.to_set
+                    removed = current_orocos_tasks - orocos_tasks
+                    new     = orocos_tasks - current_orocos_tasks
+                    removed.each do |task_name|
+                        ui_task_inspector.remove_task(task_name)
+                    end
+                    new.each do |task_name|
+                        @proxies[task_name] ||= Orocos::Async::TaskContextProxy.new(
+                            task_name, name_service: @async_name_service
+                        )
+
+                        ui_task_inspector.add_task(@proxies[task_name])
+                    end
+                    @current_orocos_tasks = orocos_tasks.dup
+                end
+
+                def reset_task_inspector
+                    update_task_inspector([])
+                end
+
+                def polling_call(path, method_name, *args)
+                    key = [path, method_name, args]
+                    if @call_guards.key?(key)
+                        return unless @call_guards[key]
+                    end
+
+                    @call_guards[key] = false
+                    syskit.async_call(path, method_name, *args) do |error, ret|
+                        @call_guards[key] = true
+                        if error
+                            report_app_error(error)
                         else
-                            syskit_poll.interval = @syskit_poll_period
+                            yield(ret)
                         end
                     end
                 end
-                slots "poll_syskit_interface()"
+
+                def async_call(path, method_name, *args)
+                    syskit.async_call(path, method_name, *args) do |error, ret|
+                        if error
+                            report_app_error(error)
+                        else
+                            yield(ret)
+                        end
+                    end
+                end
+
+                def report_app_error(error)
+                    warn error.message
+                    error.backtrace.each do |line|
+                        warn "  #{line}"
+                    end
+                end
+
+                def update_name_service(deployments)
+                    # Now remove all tasks that are not in deployments
+                    existing = @name_service.names
+
+                    deployments.each do |d|
+                        d.deployed_tasks.each do |deployed_task|
+                            task_name = deployed_task.name
+                            if existing.include?(task_name)
+                                existing.delete(task_name)
+                                next if deployed_task.ior == @name_service.ior(task_name)
+                            end
+
+                            existing.delete(task_name)
+                            task = Orocos::TaskContext.new(
+                                deployed_task.ior,
+                                name: task_name,
+                                model: orogen_model_from_name(
+                                    deployed_task.orogen_model_name
+                                )
+                            )
+
+                            @name_service.register(task, name: task_name)
+                        end
+                    end
+
+                    existing.each { @name_service.deregister(_1) }
+                    @name_service.names
+                end
+
+                def reset_name_service
+                    all = @name_service.names.dup
+                    all.each { @name_service.deregister(_1) }
+                end
+
+                def orogen_model_from_name(name)
+                    @orogen_models[name] ||= Orocos.default_loader.task_model_from_name(name)
+                rescue OroGen::NotFound
+                    Orocos.warn "#{name} is a task context of class #{name}, but I cannot find the description for it, falling back"
+                    @orogen_models[name] ||= Orocos.create_orogen_task_context_model(name)
+                end
 
                 # @api private
                 #
                 # Create the UI elements for the given job
                 #
-                # @param [Roby::Interface::V2::Async::JobMonitor] job
+                # @param [Roby::Interface::Async::JobMonitor] job
                 def monitor_job(job)
+                    if job.respond_to?(:message)
+                        puts job.message
+                        return
+                    end
+
                     job_status = JobStatusDisplay.new(job, @batch_manager)
                     job_status_list.add_widget job_status
                     job_status.connect(SIGNAL("clicked()")) do
@@ -629,25 +683,14 @@ module Syskit
                 end
 
                 def deselect_job
-                    @current_job = nil
+                    reset_current_job
                     job_expanded_status.deselect
-                    all_tasks.clear
-                    @known_loggers = nil
-                    all_job_info.clear
-                    if syskit_log_stream
-                        update_tasks_info
-                    end
-                    job_expanded_status.add_tasks_info(all_tasks, all_job_info)
                 end
 
                 def select_job(job_status)
                     @current_job = job_status.job
-                    all_tasks.clear
-                    @known_loggers = nil
-                    all_job_info.clear
-                    update_tasks_info
+                    @current_job_names = []
                     job_expanded_status.select(job_status)
-                    job_expanded_status.add_tasks_info(all_tasks, all_job_info)
                 end
 
                 def settings

--- a/lib/syskit/telemetry/ui/runtime_state.rb
+++ b/lib/syskit/telemetry/ui/runtime_state.rb
@@ -4,6 +4,7 @@ require "Qt"
 require "qtwebkit"
 require "vizkit"
 require "syskit"
+require "orocos/async"
 require "metaruby/gui/exception_view"
 require "roby/interface/v2/async"
 require "roby/gui/exception_view"
@@ -639,7 +640,8 @@ module Syskit
                                 )
                             )
 
-                            @name_service.register(task, name: task_name)
+                            async_task = Orocos::Async::CORBA::TaskContext.new(use: task)
+                            @name_service.register(async_task, name: task_name)
                         end
                     end
 

--- a/test/interface/v2/test_protocol.rb
+++ b/test/interface/v2/test_protocol.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "syskit/test/self"
+require "syskit/interface/v2"
+
+module Syskit
+    module Interface
+        module V2
+            module Protocol
+                describe Deployment do
+                    before do
+                        @channel = Roby::Interface::V2::Channel.new(
+                            IO.pipe.last, flexmock
+                        )
+                        Protocol.register_marshallers(@channel)
+
+                        deployment_m = Syskit::Deployment.new_submodel
+                        @deployment = deployment_m.new(
+                            process_name: "test", spawn_options: { some: "options" }
+                        )
+                    end
+
+                    it "is marshalled as if a standard Roby task" do
+                        marshalled = @channel.marshal_filter_object(@deployment)
+
+                        assert_equal "test", marshalled.arguments[:process_name]
+                        assert_equal @deployment.droby_id.id, marshalled.id
+                    end
+
+                    it "adds deployment-specific info" do
+                        flexmock(@deployment, pid: 200)
+                        handles = {
+                            "test" => Syskit::Deployment::RemoteTaskHandles.new(
+                                flexmock(
+                                    ior: "some_ior",
+                                    model: flexmock(name: "orogen::Name")
+                                )
+                            )
+                        }
+                        flexmock(@deployment, remote_task_handles: handles)
+                        marshalled = @channel.marshal_filter_object(@deployment)
+
+                        assert_equal 200, marshalled.pid
+
+                        expected_task = {
+                            name: "test",
+                            ior: "some_ior",
+                            orogen_model_name: "orogen::Name"
+                        }
+                        assert_equal [expected_task],
+                                     marshalled.deployed_tasks.map(&:to_h)
+                    end
+                end
+            end
+        end
+    end
+end

--- a/test/telemetry/ui/test_name_service.rb
+++ b/test/telemetry/ui/test_name_service.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "syskit/test/self"
+require "syskit/telemetry/ui/name_service"
+
+module Syskit
+    module Telemetry
+        module UI
+            describe NameService do
+                before do
+                    @name_service = NameService.new
+                end
+
+                describe "on_task_added" do
+                    it "calls the block when a new task is registered" do
+                        mock = flexmock
+                        mock.should_receive(:registered).with("test").once
+                        @name_service.on_task_added { |name| mock.registered(name) }
+                        @name_service.register(flexmock, name: "test")
+                    end
+
+                    it "already has registered the task when the callback is called" do
+                        test_task = flexmock
+                        mock = flexmock
+                        mock.should_receive(:registered).with(test_task).once
+                        @name_service.on_task_added do |name|
+                            mock.registered(@name_service.get(name))
+                        end
+
+                        @name_service.register(test_task, name: "test")
+                    end
+
+                    it "accepts more than one callback" do
+                        mock = flexmock
+                        mock.should_receive(:registered).with("test", 1).once
+                        mock.should_receive(:registered).with("test", 2).once
+                        @name_service.on_task_added { |name| mock.registered(name, 1) }
+                        @name_service.on_task_added { |name| mock.registered(name, 2) }
+
+                        @name_service.register(flexmock, name: "test")
+                    end
+
+                    it "processes all callbacks even if one raises" do
+                        mock = flexmock
+                        mock.should_receive(:registered).with("test", 1).once
+                        mock.should_receive(:registered).with("test", 2).once
+                        error_m = Class.new(RuntimeError)
+                        @name_service.on_task_added do |name|
+                            mock.registered(name, 1)
+                            raise error_m
+                        end
+                        @name_service.on_task_added { |name| mock.registered(name, 2) }
+
+                        assert_raises(error_m) do
+                            @name_service.register(flexmock, name: "test")
+                        end
+                    end
+
+                    it "stops calling after the callback is disposed" do
+                        mock = flexmock
+                        mock.should_receive(:registered).never
+                        @name_service.on_task_added { |name| mock.registered(name) }
+                                     .dispose
+
+                        @name_service.register(flexmock, name: "test")
+                    end
+                end
+
+                describe "on_task_removed" do
+                    before do
+                        @name_service.register(@test_task = flexmock, name: "test")
+                    end
+
+                    it "calls the block when a task is removed" do
+                        mock = flexmock
+                        mock.should_receive(:removed).with("test").once
+                        @name_service.on_task_removed { |name| mock.removed(name) }
+                        @name_service.deregister("test")
+                    end
+
+                    it "already has removed the task when the callback is called" do
+                        @name_service.on_task_removed do |name|
+                            refute @name_service.include?(name)
+                        end
+
+                        @name_service.deregister("test")
+                    end
+
+                    it "accepts more than one callback" do
+                        mock = flexmock
+                        mock.should_receive(:removed).with("test", 1).once
+                        mock.should_receive(:removed).with("test", 2).once
+                        @name_service.on_task_removed { |name| mock.removed(name, 1) }
+                        @name_service.on_task_removed { |name| mock.removed(name, 2) }
+
+                        @name_service.deregister("test")
+                    end
+
+                    it "processes all callbacks even if one raises" do
+                        mock = flexmock
+                        mock.should_receive(:removed).with("test", 1).once
+                        mock.should_receive(:removed).with("test", 2).once
+                        error_m = Class.new(RuntimeError)
+                        @name_service.on_task_removed do |name|
+                            mock.removed(name, 1)
+                            raise error_m
+                        end
+                        @name_service.on_task_removed { |name| mock.removed(name, 2) }
+
+                        assert_raises(error_m) { @name_service.deregister("test") }
+                    end
+
+                    it "stops calling after the callback is disposed" do
+                        mock = flexmock
+                        mock.should_receive(:removed).never
+                        @name_service.on_task_removed { |name| mock.removed(name) }
+                                     .dispose
+
+                        @name_service.deregister("test")
+                    end
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
On top of #400 

This uses Syskit to resolve orocos tasks, and uses the new protocol to show data. At least, it tremendously speeds up task resolution, and ensures that we see all the tasks Syskit sees (instead of only the tasks that are present on the main computer)

It removes the use / display of the task log, which does remove some information. This will be fixed in future PRs.

[sc-43835] [sc-43836] [sc-43837]