### PR TITLE
fix: allow passing a Syskit model as a deployment task's model (on top of #409)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,7 @@ Naming/MethodParameterName:
   AllowedNames:
   - as
   - fd
+  - kw
 
 Security/MarshalLoad:
   Exclude:

--- a/lib/syskit/models/deployment.rb
+++ b/lib/syskit/models/deployment.rb
@@ -86,12 +86,17 @@ module Syskit
                 klass = super(name: name, **options) do
                     self.orogen_model = orogen_model ||
                         Models.create_orogen_deployment_model(name)
+
+                    @task_name_to_syskit_model = {}
+                    self.orogen_model.task_activities.each do |act|
+                        @task_name_to_syskit_model[act.name] =
+                            ::Syskit::TaskContext.model_for(act.task_model)
+                    end
+
                     if block
                         ctxt = OroGenEvaluationContext.new(self)
                         ctxt.instance_eval(&block)
-                        @task_name_to_syskit_model = ctxt.task_name_to_syskit_model
-                    else
-                        @task_name_to_syskit_model = {}
+                        @task_name_to_syskit_model.merge!(ctxt.task_name_to_syskit_model)
                     end
                 end
                 klass.each_deployed_task_name do |name|

--- a/lib/syskit/models/deployment.rb
+++ b/lib/syskit/models/deployment.rb
@@ -59,9 +59,9 @@ module Syskit
                         @orogen_model.task(name, model.orogen_model)
                         @task_name_to_syskit_model[name] = model
                     else
-                        @orogen_model.task(name, model)
+                        deployed_task = @orogen_model.task(name, model)
                         @task_name_to_syskit_model[name] =
-                            ::Syskit::TaskContext.model_for(model)
+                            ::Syskit::TaskContext.model_for(task.task_model)
                     end
                 end
 

--- a/lib/syskit/models/deployment.rb
+++ b/lib/syskit/models/deployment.rb
@@ -56,13 +56,15 @@ module Syskit
 
                 def task(name, model)
                     if model.respond_to?(:orogen_model)
-                        @orogen_model.task(name, model.orogen_model)
+                        deployed_task = @orogen_model.task(name, model.orogen_model)
                         @task_name_to_syskit_model[name] = model
                     else
                         deployed_task = @orogen_model.task(name, model)
                         @task_name_to_syskit_model[name] =
-                            ::Syskit::TaskContext.model_for(task.task_model)
+                            ::Syskit::TaskContext.model_for(deployed_task.task_model)
                     end
+
+                    deployed_task
                 end
 
                 def respond_to_missing?(name, _private = false)

--- a/lib/syskit/models/deployment.rb
+++ b/lib/syskit/models/deployment.rb
@@ -42,6 +42,38 @@ module Syskit
                 task
             end
 
+            # @api private
+            #
+            # Context object used to evaluate the block given to new_submodel
+            class OroGenEvaluationContext < BasicObject
+                attr_reader :task_name_to_syskit_model
+
+                def initialize(task_m)
+                    @task_m = task_m
+                    @orogen_model = task_m.orogen_model
+                    @task_name_to_syskit_model = {}
+                end
+
+                def task(name, model)
+                    if model.respond_to?(:orogen_model)
+                        @orogen_model.task(name, model.orogen_model)
+                        @task_name_to_syskit_model[name] = model
+                    else
+                        @orogen_model.task(name, model)
+                        @task_name_to_syskit_model[name] =
+                            ::Syskit::TaskContext.model_for(model)
+                    end
+                end
+
+                def respond_to_missing?(name, _private = false)
+                    @orogen_model.respond_to?(name)
+                end
+
+                def method_missing(name, *args, **kw) # rubocop:disable Style/MethodMissingSuper
+                    @orogen_model.send(name, *args, **kw)
+                end
+            end
+
             # Creates a new deployment model
             #
             # @option options [OroGen::Spec::Deployment] orogen_model the oroGen
@@ -55,7 +87,11 @@ module Syskit
                     self.orogen_model = orogen_model ||
                         Models.create_orogen_deployment_model(name)
                     if block
-                        self.orogen_model.instance_eval(&block)
+                        ctxt = OroGenEvaluationContext.new(self)
+                        ctxt.instance_eval(&block)
+                        @task_name_to_syskit_model = ctxt.task_name_to_syskit_model
+                    else
+                        @task_name_to_syskit_model = {}
                     end
                 end
                 klass.each_deployed_task_name do |name|
@@ -91,7 +127,7 @@ module Syskit
                 orogen_model.task_activities
             end
 
-            # Enumerate the names of the tasks deployed by self
+            # Enumerate the unmapped names of the tasks deployed by self
             def each_deployed_task_name
                 return enum_for(__method__) unless block_given?
 
@@ -102,13 +138,13 @@ module Syskit
 
             # Enumerate the tasks that are deployed in self
             #
-            # @yieldparam [String] name the task name
+            # @yieldparam [String] name the unmapped task name
             # @yieldparam [Models::TaskContext] model the deployed task model
             def each_deployed_task_model
                 return enum_for(__method__) unless block_given?
 
                 each_orogen_deployed_task_context_model do |deployed_task|
-                    task_model = Syskit::TaskContext.model_for(deployed_task.task_model)
+                    task_model = @task_name_to_syskit_model.fetch(deployed_task.name)
                     yield(deployed_task.name, task_model)
                 end
             end

--- a/lib/syskit/models/orogen_base.rb
+++ b/lib/syskit/models/orogen_base.rb
@@ -20,6 +20,18 @@ module Syskit
                 nil
             end
 
+            # Return all syskit models subclasses of self that represent the
+            # given oroGen model
+            #
+            # @param orogen_model the oroGen model
+            # @return [Array<Syskit::TaskContext,Syskit::Deployment>] the
+            #   corresponding syskit model, or nil if there are none registered
+            def find_all_models_by_orogen(orogen_model)
+                each_submodel.find_all do |syskit_model|
+                    syskit_model.orogen_model == orogen_model
+                end
+            end
+
             # Return the syskit model that represents the given oroGen model
             #
             # @param orogen_model the oroGen model
@@ -34,13 +46,34 @@ module Syskit
                 nil
             end
 
-            # Returns the syskit model for the given oroGen model
+            # Returns the syskit model subclass of self for the given oroGen model
             #
             # @raise ArgumentError if no syskit model exists
+            # @raise ArgumentError if more than one matching syskit model exists,
+            #   and Conf.syskit.strict_model_for is set to true
             def model_for(orogen_model)
-                if m = find_model_by_orogen(orogen_model)
+                if Syskit.conf.strict_model_for?
+                    strict_model_for(orogen_model)
+                elsif (m = find_model_by_orogen(orogen_model))
                     m
-                else raise ArgumentError, "there is no syskit model for #{orogen_model.name}"
+                else
+                    raise ArgumentError, "there is no Syskit model for #{orogen_model.name}"
+                end
+            end
+
+            # @api private
+            #
+            # Implementation of {#model_for} when Syskit.conf.strict_model_for is set
+            def strict_model_for(orogen_model)
+                matches = find_all_models_by_orogen(orogen_model)
+                if matches.size == 1
+                    matches.first
+                elsif matches.empty?
+                    raise ArgumentError,
+                          "there is no Syskit model for #{orogen_model.name}"
+                else
+                    raise ArgumentError,
+                          "more than one Syskit model matches #{orogen_model.name}"
                 end
             end
         end

--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -81,6 +81,13 @@ module Syskit
             # @deprecated Unused, kept here for historical reasons
             attr_predicate :use_only_model_pack?, true
 
+            # Controls whether Models::TaskContext.model_for raises if there is more
+            # than one Syskit model matching the given orogen model
+            #
+            # This is false for backward compatibility reasons, and will eventually
+            # become the default behavior.
+            attr_predicate :strict_model_for, true
+
             # Data logging configuration
             #
             # @return [LoggingConfiguration]
@@ -144,6 +151,7 @@ module Syskit
                 @exception_transition_timeout = 20.0
                 @kill_all_on_process_server_connection = false
                 @register_self_on_name_server = (ENV["SYSKIT_REGISTER_SELF_ON_NAME_SERVER"] != "0")
+                @strict_model_for = false
 
                 @log_rotation_period = nil
                 @log_transfer = LogTransferManager::Configuration.new(

--- a/test/models/test_deployment.rb
+++ b/test/models/test_deployment.rb
@@ -74,20 +74,38 @@ module Syskit
     end
 end
 
-describe Syskit::Models::Deployment do
-    describe "#new_submodel" do
-        it "registers the corresponding orogen to syskit model mapping" do
-            submodel = Syskit::Deployment.new_submodel
-            subsubmodel = submodel.new_submodel
-            assert_equal subsubmodel, Syskit::Deployment.model_for(subsubmodel.orogen_model)
-        end
-    end
-    describe "#clear_submodels" do
-        it "removes the corresponding orogen to syskit model mapping" do
-            submodel = Syskit::Deployment.new_submodel
-            subsubmodel = submodel.new_submodel
-            submodel.clear_submodels
-            assert !Syskit::Deployment.has_model_for?(subsubmodel.orogen_model)
+module Syskit
+    module Models
+        describe Deployment do
+            describe "#new_submodel" do
+                it "registers the corresponding orogen to syskit model mapping" do
+                    submodel = Syskit::Deployment.new_submodel
+                    subsubmodel = submodel.new_submodel
+                    assert_equal subsubmodel,
+                                 Syskit::Deployment.model_for(subsubmodel.orogen_model)
+                end
+            end
+
+            describe "#clear_submodels" do
+                it "removes the corresponding orogen to syskit model mapping" do
+                    submodel = Syskit::Deployment.new_submodel
+                    subsubmodel = submodel.new_submodel
+                    submodel.clear_submodels
+                    assert !Syskit::Deployment.has_model_for?(subsubmodel.orogen_model)
+                end
+            end
+
+            describe "#each_deployed_task_model" do
+                it "enumerates the task names and their syskit model" do
+                    task_m = Syskit::TaskContext.new_submodel
+                    deployment_m = Syskit::Deployment.new_submodel do
+                        task "name", task_m
+                    end
+
+                    assert_equal [["name", task_m]],
+                                 deployment_m.each_deployed_task_model.to_a
+                end
+            end
         end
     end
 end

--- a/test/models/test_deployment.rb
+++ b/test/models/test_deployment.rb
@@ -29,6 +29,69 @@ module Syskit
             assert submodel.has_submodel?(subsubmodel)
         end
 
+        describe "the block passed to new_submodel" do
+            it "lets the caller define the deployment model, "\
+               "using orogen models for the tasks" do
+                task1_m = Syskit::TaskContext.new_submodel
+                task2_m = Syskit::TaskContext.new_submodel
+                deployment_m = Syskit::Deployment.new_submodel do
+                    task "task1", task1_m.orogen_model
+                    task "task2", task2_m.orogen_model
+                end
+
+                assert_equal [task1_m.orogen_model, task2_m.orogen_model],
+                             deployment_m.each_orogen_deployed_task_context_model
+                                         .sort_by(&:name).map(&:task_model)
+                assert_equal [["task1", task1_m], ["task2", task2_m]],
+                             deployment_m.each_deployed_task_model
+                                         .sort_by(&:first)
+            end
+
+            it "lets the caller define the deployment model, "\
+               "using orogen model names for the tasks" do
+                project = Models.create_orogen_project
+                project.name "m"
+                task1_orogen_m = project.task_context "M"
+                task1_m = Syskit::TaskContext.new_submodel(orogen_model: task1_orogen_m)
+                task2_orogen_m = project.task_context "N"
+                task2_m = Syskit::TaskContext.new_submodel(orogen_model: task2_orogen_m)
+                deployment_m = Syskit::Deployment.new_submodel do
+                    task "task1", "m::M"
+                    task "task2", "m::N"
+                end
+
+                assert_equal [task1_m.orogen_model, task2_m.orogen_model],
+                             deployment_m.each_orogen_deployed_task_context_model
+                                         .sort_by(&:name).map(&:task_model)
+                assert_equal [["task1", task1_m], ["task2", task2_m]],
+                             deployment_m.each_deployed_task_model
+                                         .sort_by(&:first)
+            end
+
+            it "lets the caller define the deployment model, "\
+               "passing the deployment orogen model" do
+                project = Models.create_orogen_project
+                project.name "m"
+                task1_orogen_m = project.task_context "M"
+                task1_m = Syskit::TaskContext.new_submodel(orogen_model: task1_orogen_m)
+                task2_orogen_m = project.task_context "N"
+                task2_m = Syskit::TaskContext.new_submodel(orogen_model: task2_orogen_m)
+                deployment_orogen_m = project.deployment "d" do
+                    task "task1", "m::M"
+                    task "task2", "m::N"
+                end
+                deployment_m =
+                    Syskit::Deployment.new_submodel(orogen_model: deployment_orogen_m)
+
+                assert_equal [task1_m.orogen_model, task2_m.orogen_model],
+                             deployment_m.each_orogen_deployed_task_context_model
+                                         .sort_by(&:name).map(&:task_model)
+                assert_equal [["task1", task1_m], ["task2", task2_m]],
+                             deployment_m.each_deployed_task_model
+                                         .sort_by(&:first)
+            end
+        end
+
         describe "#define_from_orogen" do
             before do
                 @orogen_deployment = Models.create_orogen_deployment_model

--- a/test/models/test_deployment.rb
+++ b/test/models/test_deployment.rb
@@ -63,6 +63,14 @@ module Syskit
                 )
                 assert_same model, Deployments::MotorController
             end
+
+            it "resolves the orogen-to-syskit mapping for the orogen model tasks" do
+                model = Syskit::Deployment.define_from_orogen(
+                    @orogen_deployment, register: false
+                )
+                assert_equal ["task", @syskit_task_m],
+                             model.each_deployed_task_model.first
+            end
         end
 
         def test_clear_submodels_removes_registered_submodels

--- a/test/models/test_orogen_base.rb
+++ b/test/models/test_orogen_base.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "syskit/test/self"
+
+module Syskit
+    module Models
+        describe OrogenBase do
+            before do
+                model = Module.new do
+                    include MetaRuby::ModelAsClass
+                    include OrogenBase
+
+                    attr_accessor :orogen_model
+                end
+                @root_m = Class.new do
+                    extend model
+                end
+            end
+
+            describe "#find_all_models_by_orogen" do
+                it "returns an empty array if there are no submodels" do
+                    assert_equal [], @root_m.find_all_models_by_orogen(Object.new)
+                end
+
+                it "returns the list of submodels that " \
+                   "have the provided orogen model" do
+                    orogen_model = Object.new
+                    a = @root_m.new_submodel
+                    b = @root_m.new_submodel
+                    @root_m.new_submodel
+                    a.orogen_model = b.orogen_model = orogen_model
+                    assert_equal [a, b], @root_m.find_all_models_by_orogen(orogen_model)
+                end
+            end
+
+            describe "#find_model_by_orogen" do
+                it "returns nil if there are no matches" do
+                    assert_nil @root_m.find_model_by_orogen(Object.new)
+                end
+
+                it "returns the first submodel that matches the given orogen model" do
+                    orogen_model = Object.new
+                    a = @root_m.new_submodel
+                    b = @root_m.new_submodel
+                    @root_m.new_submodel
+                    a.orogen_model = b.orogen_model = orogen_model
+                    assert_equal a, @root_m.find_model_by_orogen(orogen_model)
+                end
+            end
+
+            describe "#model_for" do
+                before do
+                    @strict_model_for = Syskit.conf.strict_model_for?
+                end
+
+                after do
+                    Syskit.conf.strict_model_for = @strict_model_for
+                end
+
+                describe "without strict_model_for" do
+                    before do
+                        Syskit.conf.strict_model_for = false
+                    end
+
+                    it "raises if there are no matches" do
+                        orogen_model = flexmock(name: "orogen::Model")
+                        e = assert_raises(ArgumentError) do
+                            @root_m.model_for(orogen_model)
+                        end
+                        assert_equal "there is no Syskit model for orogen::Model",
+                                     e.message
+                    end
+
+                    it "returns the submodel that matches the given orogen model " \
+                       "if only one matches" do
+                        orogen_model = flexmock(name: "orogen::Model")
+                        @root_m.new_submodel
+                        @root_m.new_submodel
+                        c = @root_m.new_submodel
+                        c.orogen_model = orogen_model
+                        assert_equal c, @root_m.model_for(orogen_model)
+                    end
+
+                    it "returns the first submodel that matches the given orogen model " \
+                       "if there is more than one match" do
+                        orogen_model = flexmock(name: "orogen::Model")
+                        a = @root_m.new_submodel
+                        @root_m.new_submodel
+                        c = @root_m.new_submodel
+                        a.orogen_model = c.orogen_model = orogen_model
+                        assert_equal a, @root_m.model_for(orogen_model)
+                    end
+                end
+
+                describe "with strict_model_for" do
+                    before do
+                        Syskit.conf.strict_model_for = true
+                    end
+
+                    it "raises if there are no matches" do
+                        orogen_model = flexmock(name: "orogen::Model")
+                        e = assert_raises(ArgumentError) do
+                            @root_m.model_for(orogen_model)
+                        end
+                        assert_equal "there is no Syskit model for orogen::Model",
+                                     e.message
+                    end
+
+                    it "returns the submodel that matches the given orogen model " \
+                       "if only one matches" do
+                        orogen_model = flexmock(name: "orogen::Model")
+                        @root_m.new_submodel
+                        @root_m.new_submodel
+                        c = @root_m.new_submodel
+                        c.orogen_model = orogen_model
+                        assert_equal c, @root_m.model_for(orogen_model)
+                    end
+
+                    it "raises if there is more than one match" do
+                        orogen_model = flexmock(name: "orogen::Model")
+                        a = @root_m.new_submodel
+                        @root_m.new_submodel
+                        c = @root_m.new_submodel
+                        a.orogen_model = c.orogen_model = orogen_model
+                        e = assert_raises(ArgumentError) do
+                            @root_m.model_for(orogen_model)
+                        end
+                        assert_equal "more than one Syskit model matches orogen::Model",
+                                     e.message
+                    end
+                end
+            end
+        end
+    end
+end

--- a/test/roby_app/test_configuration.rb
+++ b/test/roby_app/test_configuration.rb
@@ -94,6 +94,7 @@ describe Syskit::RobyApp::Configuration do
                 @ruby_task = ruby_task = Orocos.allow_blocking_calls do
                     Orocos::RubyTasks::TaskContext.new "remote-task"
                 end
+                Syskit::TaskContext.new_submodel(orogen_model: ruby_task.model)
                 @deployment_m = Syskit::Deployment.new_submodel do
                     task "name", ruby_task.model
                 end


### PR DESCRIPTION
On top of #409 

We were currently passing the orogen model, which was resolved
to a Syskit model using TaskContext.model_for

This is based on the obvious assumption that only one Syskit model
may ever have a given orogen model, which is broken by syskit-log.
In addition, it would not protect the syskit models against Ruby's
garbage collector, which is I believe why we were having random
failures in tests for Syskit models that did not exist.