### PR TITLE
fix: allow passing the supermodel explicitly in define_from_orogen (on top of #407)

### DIFF
--- a/lib/syskit/models/task_context.rb
+++ b/lib/syskit/models/task_context.rb
@@ -94,7 +94,8 @@ module Syskit
             # specification. The class is registered as
             # Roby::Orogen::ProjectName::ClassName.
             def define_from_orogen(orogen_model, register: false)
-                if model = find_model_by_orogen(orogen_model) # already defined, probably because of dependencies
+                # Already defined, probably because of dependencies
+                if (model = find_model_by_orogen(orogen_model))
                     return model
                 end
 

--- a/lib/syskit/models/task_context.rb
+++ b/lib/syskit/models/task_context.rb
@@ -93,7 +93,7 @@ module Syskit
             # Creates a subclass of TaskContext that represents the given task
             # specification. The class is registered as
             # Roby::Orogen::ProjectName::ClassName.
-            def define_from_orogen(orogen_model, register: false)
+            def define_from_orogen(orogen_model, register: false, **kw)
                 # Already defined, probably because of dependencies
                 if (model = find_model_by_orogen(orogen_model))
                     return model
@@ -109,6 +109,7 @@ module Syskit
                     end
                 klass = supermodel.new_submodel(orogen_model: orogen_model)
 
+                klass = supermodel.new_submodel(orogen_model: orogen_model, **kw)
                 klass.register_model if register && orogen_model.name
                 klass
             end

--- a/lib/syskit/models/task_context.rb
+++ b/lib/syskit/models/task_context.rb
@@ -93,25 +93,24 @@ module Syskit
             # Creates a subclass of TaskContext that represents the given task
             # specification. The class is registered as
             # Roby::Orogen::ProjectName::ClassName.
-            def define_from_orogen(orogen_model, register: false, **kw)
+            def define_from_orogen(orogen_model, supermodel: nil, register: false, **kw)
                 # Already defined, probably because of dependencies
                 if (model = find_model_by_orogen(orogen_model))
                     return model
                 end
 
-                superclass = orogen_model.superclass
-                supermodel =
-                    if superclass # we are defining a root model
-                        find_model_by_orogen(superclass) ||
-                            define_from_orogen(superclass, register: register)
-                    else
-                        self
-                    end
-                klass = supermodel.new_submodel(orogen_model: orogen_model)
-
+                supermodel ||= supermodel_from_orogen(orogen_model)
                 klass = supermodel.new_submodel(orogen_model: orogen_model, **kw)
                 klass.register_model if register && orogen_model.name
                 klass
+            end
+
+            def supermodel_from_orogen(orogen_model, register: false)
+                superclass = orogen_model.superclass
+                return self unless superclass # we are defining a root model
+
+                find_model_by_orogen(superclass) ||
+                    define_from_orogen(superclass, register: register)
             end
 
             def register_model


### PR DESCRIPTION
On top of #407 

While with the "normal" workflow - that is mapping the orogen C++ model
hierarchy - the automated mechanism works great, it is not suitable
for more exotic uses, such as in syskit-log.

Bypass the automatic resolution when the supermodel is given explicitly