### PR TITLE
chore: remove unused task variable

### DIFF
--- a/lib/syskit/cli/gen/cmp/test.rb.erb
+++ b/lib/syskit/cli/gen/cmp/test.rb.erb
@@ -9,7 +9,7 @@ require "<%= require_path %>"
 <%= indent %>        # here, but it is not strictly required. The syskit_stub_*
 <%= indent %>        # methods generate what is needed to have a run-able
 <%= indent %>        # composition
-<%= indent %>        cmp_task = syskit_stub_deploy_configure_and_start(
+<%= indent %>        syskit_stub_deploy_configure_and_start(
 <%= indent %>            <%= class_name.last %>
 <%= indent %>        )
 

--- a/lib/syskit/cli/gen/ruby_task/test.rb.erb
+++ b/lib/syskit/cli/gen/ruby_task/test.rb.erb
@@ -5,7 +5,7 @@ require "<%= require_path %>"
 <%= open %>
 <%= indent %>describe <%= class_name.last %> do
 <%= indent %>    it "starts" do
-<%= indent %>        task = syskit_stub_deploy_configure_and_start(
+<%= indent %>        syskit_stub_deploy_configure_and_start(
 <%= indent %>            <%= class_name.last %>
 <%= indent %>        )
 <%= indent %>    end


### PR DESCRIPTION
Rubocop detects this as an offense