### PR TITLE
fix: make `syskit telemetry ui` usable

### DIFF
--- a/lib/syskit/interface/v2/protocol.rb
+++ b/lib/syskit/interface/v2/protocol.rb
@@ -42,7 +42,7 @@ module Syskit
                     )
                 end
 
-                def self.register_remote_task_handle(name, remote_task_handle)
+                def self.marshal_remote_task_handle(name, remote_task_handle)
                     ior = remote_task_handle.handle.ior
                     model_name = remote_task_handle.handle.model.name
                     DeployedTask.new(
@@ -53,7 +53,7 @@ module Syskit
                 def self.marshal_deployment_task(channel, task)
                     deployed_tasks =
                         task.remote_task_handles.map do |name, remote_task_handle|
-                            register_remote_task_handle(name, remote_task_handle)
+                            marshal_remote_task_handle(name, remote_task_handle)
                         end
 
                     roby_task = Roby::Interface::V2::Protocol.marshal_task(channel, task)

--- a/lib/syskit/interface/v2/protocol.rb
+++ b/lib/syskit/interface/v2/protocol.rb
@@ -36,6 +36,10 @@ module Syskit
                     protocol.add_marshaller(
                         Syskit::Deployment, &method(:marshal_deployment_task)
                     )
+                    protocol.allow_objects(
+                        Orocos::RubyTasks::TaskContext,
+                        Orocos::RubyTasks::StubTaskContext
+                    )
                 end
 
                 def self.register_remote_task_handle(name, remote_task_handle)

--- a/lib/syskit/telemetry/ui/runtime_state.rb
+++ b/lib/syskit/telemetry/ui/runtime_state.rb
@@ -302,6 +302,7 @@ module Syskit
                     extra_args = []
                     extra_args << "-r" << robot_name
                     extra_args << "-c" if start_controller
+                    extra_args << "--interface-versions=2"
                     extra_args << "--port-v2=#{port}" if port
                     extra_args << "--single" if single
                     extra_args.concat(@syskit_run_arguments.set.map { "--set=#{_1}" })

--- a/lib/syskit/telemetry/ui/runtime_state.rb
+++ b/lib/syskit/telemetry/ui/runtime_state.rb
@@ -275,14 +275,32 @@ module Syskit
                     actions
                 end
 
+                def require_app_dir
+                    begin
+                        Roby.app.require_app_dir
+                    rescue ArgumentError
+                        Qt::MessageBox.warning(
+                            self, "Wrong current directory",
+                            "Current directory is not a Roby app, cannot start"
+                        )
+                        return
+                    end
+
+                    Roby.app.setup_robot_names_from_config_dir
+                    true
+                end
+
                 def app_start(port: nil)
+                    return unless require_app_dir
+
                     robot_name, start_controller, single = AppStartDialog.exec(
-                        Roby.app.robots.names, self, default_robot_name: robot_name
+                        Roby.app.robots.names, self,
+                        default_robot_name: @syskit_run_arguments.robot
                     )
                     return unless robot_name
 
                     extra_args = []
-                    extra_args << "-r" << @syskit_run_arguments.robot
+                    extra_args << "-r" << robot_name
                     extra_args << "-c" if start_controller
                     extra_args << "--port-v2=#{port}" if port
                     extra_args << "--single" if single

--- a/lib/syskit/telemetry/ui/runtime_state.rb
+++ b/lib/syskit/telemetry/ui/runtime_state.rb
@@ -734,6 +734,9 @@ module Syskit
                 end
 
                 def restore_from_settings(settings = self.settings)
+                    self.size = settings.value(
+                        "MainWindow/size", Qt::Variant.new(Qt::Size.new(800, 600))
+                    ).to_size
                     %w{ui_hide_loggers ui_show_expanded_job}.each do |checkbox_name|
                         default = Qt::Variant.new(send(checkbox_name).checked)
                         send(checkbox_name).checked = settings.value(checkbox_name, default).to_bool
@@ -741,6 +744,7 @@ module Syskit
                 end
 
                 def save_to_settings(settings = self.settings)
+                    settings.set_value("MainWindow/size", Qt::Variant.new(size))
                     %w(ui_hide_loggers ui_show_expanded_job).each do |checkbox_name|
                         settings.set_value checkbox_name, Qt::Variant.new(send(checkbox_name).checked)
                     end

--- a/lib/syskit/telemetry/ui/runtime_state.rb
+++ b/lib/syskit/telemetry/ui/runtime_state.rb
@@ -622,12 +622,12 @@ module Syskit
                 def polling_call(path, method_name, *args)
                     key = [path, method_name, args]
                     if @call_guards.key?(key)
-                        return unless @call_guards[key]
+                        return if @call_guards[key]
                     end
 
-                    @call_guards[key] = false
+                    @call_guards[key] = true
                     syskit.async_call(path, method_name, *args) do |error, ret|
-                        @call_guards[key] = true
+                        @call_guards[key] = false
                         if error
                             report_app_error(error)
                         else

--- a/lib/syskit/telemetry/ui/runtime_state.rb
+++ b/lib/syskit/telemetry/ui/runtime_state.rb
@@ -275,7 +275,7 @@ module Syskit
                     extra_args = []
                     extra_args << "-r" << robot_name unless robot_name.empty?
                     extra_args << "-c" if start_controller
-                    extra_args << "--port=#{port}" if port
+                    extra_args << "--port-v2=#{port}" if port
                     extra_args << "--single" if single
                     extra_args.concat(
                         Roby.app.argv_set.flat_map { |arg| ["--set", arg] }


### PR DESCRIPTION
This PR fixes issues with `telemetry ui` that was making it unusable, that is:
- broken (`polling_call` fix)
- spamming to the point of unusability (letting `Orocos::RubyTasks::TaskContext` go through the protocol)
- not a replacement to `syskit ide` (re-implementation of the ability to start/stop/restart apps)