### PR TITLE
fix: properly terminate unmanaged processes with success when everything is fine

### DIFF
--- a/lib/syskit/roby_app/unmanaged_process.rb
+++ b/lib/syskit/roby_app/unmanaged_process.rb
@@ -170,6 +170,7 @@ module Syskit
                 @ior_mappings = tasks.transform_values(&:ior)
                 @deployed_tasks = tasks
                 @monitor_thread = Thread.new { monitor(tasks) }
+                @monitor_thread.report_on_exception = false
                 @ior_mappings
             end
 
@@ -204,11 +205,7 @@ module Syskit
             # @param [Float] period polling period in seconds
             def monitor(tasks, period: 0.1)
                 until quitting?
-                    tasks.each_value do |task|
-                        task.ping
-                    rescue Orocos::ComError
-                        return # rubocop:disable Lint/NonLocalExitFromIterator
-                    end
+                    tasks.each_value(&:ping)
                     sleep period
                 end
             end


### PR DESCRIPTION
UnmanagedTasksManager#wait_termination was not returning a status, which is interpreted by the runtime code as having an error.