### PR TITLE
fix: exception in `syskit ide` when show loggers has been enabled but there is no connection

### DIFF
--- a/lib/syskit/gui/runtime_state.rb
+++ b/lib/syskit/gui/runtime_state.rb
@@ -474,7 +474,7 @@ module Syskit
                 @ui_hide_loggers.checked = false
                 @ui_hide_loggers.connect SIGNAL("toggled(bool)") do |checked|
                     @known_loggers = nil
-                    update_tasks_info
+                    update_tasks_info if syskit_log_stream
                 end
                 @ui_show_expanded_job.checked = true
                 @ui_show_expanded_job.connect SIGNAL("toggled(bool)") do |checked|


### PR DESCRIPTION
update tasks info at UI creation only if there is connection with a log server