### PR TITLE
fix: provide the Syskit model to define deployment tasks in stub_deployment_model

### DIFF
--- a/lib/syskit/models/ruby_task_context.rb
+++ b/lib/syskit/models/ruby_task_context.rb
@@ -27,11 +27,11 @@ module Syskit
             #
             # The deployment is created with a single task named 'task'
             def deployment_model
-                orogen_model = self.orogen_model
                 deployment_name = "Deployments::RubyTasks::#{name}"
+                task_model = self
                 @deployment_model ||=
                     Syskit::Deployment.new_submodel(name: deployment_name) do
-                        task "task", orogen_model
+                        task "task", task_model
                     end
             end
         end

--- a/lib/syskit/test/stubs.rb
+++ b/lib/syskit/test/stubs.rb
@@ -65,7 +65,7 @@ module Syskit
 
                 deployment_model = Deployment.new_submodel(name: name,
                                                            logger_name: logger_name) do
-                    task(name, task_model.orogen_model) if task_model
+                    task(name, task_model) if task_model
                     instance_eval(&block) if block
                 end
 

--- a/lib/syskit/test/stubs.rb
+++ b/lib/syskit/test/stubs.rb
@@ -63,11 +63,11 @@ module Syskit
                 task_model = task_model&.to_component_model
                 process_server = Syskit.conf.process_server_for("stubs")
 
-                deployment_model = Deployment.new_submodel(name: name,
-                                                           logger_name: logger_name) do
-                    task(name, task_model) if task_model
-                    instance_eval(&block) if block
-                end
+                deployment_model =
+                    Deployment.new_submodel(name: name, logger_name: logger_name) do
+                        task(name, task_model) if task_model
+                        instance_eval(&block) if block
+                    end
 
                 if register
                     process_server.loader.register_deployment_model(

--- a/test/models/test_deployment_group.rb
+++ b/test/models/test_deployment_group.rb
@@ -40,7 +40,7 @@ module Syskit
                 before do
                     @task_m = task_m = Syskit::TaskContext.new_submodel
                     @deployment_m = Syskit::Deployment.new_submodel do
-                        task "task", task_m.orogen_model
+                        task "task", task_m
                     end
                     @other_group = DeploymentGroup.new
                     @other_deployment = other_group.use_deployment(
@@ -123,7 +123,7 @@ module Syskit
                 before do
                     @task_m = task_m = Syskit::TaskContext.new_submodel
                     @deployment_m = Syskit::Deployment.new_submodel do
-                        task "task", task_m.orogen_model
+                        task "task", task_m
                     end
                 end
 
@@ -170,7 +170,7 @@ module Syskit
                 before do
                     @task_m = task_m = Syskit::TaskContext.new_submodel
                     @deployment_m = Syskit::Deployment.new_submodel do
-                        task "task", task_m.orogen_model
+                        task "task", task_m
                     end
                 end
 
@@ -223,7 +223,7 @@ module Syskit
                 before do
                     @task_m = task_m = Syskit::TaskContext.new_submodel
                     @deployment_m = Syskit::Deployment.new_submodel do
-                        task "task", task_m.orogen_model
+                        task "task", task_m
                     end
                 end
 
@@ -879,7 +879,7 @@ module Syskit
             def stub_deployment(name)
                 task_m = @task_m
                 Syskit::Deployment.new_submodel(name: name) do
-                    task("task", task_m.orogen_model)
+                    task("task", task_m)
                 end
             end
         end

--- a/test/models/test_task_context.rb
+++ b/test/models/test_task_context.rb
@@ -485,7 +485,7 @@ module Syskit # :nodoc:
                 default_name = OroGen::Spec::Project.default_deployment_name("test::Task")
                 @default_deployment_name = default_name
                 @deployment_m = Deployment.new_submodel(name: "test_deployment") do
-                    task default_name, task_m.orogen_model
+                    task default_name, task_m
                 end
                 flexmock(@loader).should_receive(:deployment_model_from_name)
                                  .with(default_name)

--- a/test/network_generation/test_dataflow_dynamics.rb
+++ b/test/network_generation/test_dataflow_dynamics.rb
@@ -136,9 +136,9 @@ module Syskit
                             output_port "out", "/double"
                         end
                         deployment_m = Syskit::Deployment.new_submodel do
-                            master = task("master", task_m.orogen_model)
+                            master = task("master", task_m)
                                      .periodic(0.1)
-                            slave  = task "slave", task_m.orogen_model
+                            slave  = task "slave", task_m
                             slave.slave_of(master)
                         end
 
@@ -184,11 +184,11 @@ module Syskit
                             output_port("out", "/double").triggered_on("in")
                         end
                         deployment_m = Syskit::Deployment.new_submodel do
-                            task("source", source_m.orogen_model)
+                            task("source", source_m)
                                 .periodic(0.01)
-                            master = task("master", master_m.orogen_model)
+                            master = task("master", master_m)
                                      .periodic(0.1)
-                            slave  = task "slave", sink_m.orogen_model
+                            slave  = task "slave", sink_m
                             slave.slave_of(master)
                         end
 

--- a/test/network_generation/test_engine.rb
+++ b/test/network_generation/test_engine.rb
@@ -521,7 +521,7 @@ module Syskit
 
                     Deployment.new_submodel do
                         task_m.each_with_index do |m, i|
-                            task "task#{i}", m.orogen_model
+                            task "task#{i}", m
                         end
                     end
                 end

--- a/test/network_generation/test_logger.rb
+++ b/test/network_generation/test_logger.rb
@@ -277,8 +277,8 @@ describe Syskit::NetworkGeneration::LoggerConfigurationSupport do
         logger_m = @logger_m = create_logger_model
 
         @deployment_m = Syskit::Deployment.new_submodel(name: "deployment") do
-            task "task", task_m.orogen_model
-            task "deployment_Logger", logger_m.orogen_model
+            task "task", task_m
+            task "deployment_Logger", logger_m
         end
         syskit_stub_deployment("deployment", deployment_m, logging_enabled: true)
     end

--- a/test/network_generation/test_system_network_deployer.rb
+++ b/test/network_generation/test_system_network_deployer.rb
@@ -344,10 +344,10 @@ module Syskit
                     ]
                     @deployment_models = [
                         Deployment.new_submodel do
-                            task "task", task_models[0].orogen_model
+                            task "task", task_models[0]
                         end,
                         Deployment.new_submodel do
-                            task "other_task", task_models[1].orogen_model
+                            task "other_task", task_models[1]
                         end
                     ]
 
@@ -415,8 +415,8 @@ module Syskit
                     root.depends_on(task1 = task_m.new(orocos_name: "t1"), role: "t1")
 
                     deployment_m = Deployment.new_submodel do
-                        task "t0", task_m.orogen_model
-                        task "t1", task_m.orogen_model
+                        task "t0", task_m
+                        task "t1", task_m
                     end
 
                     task0.requirements.use_configured_deployment(

--- a/test/robot/test_master_device_instance.rb
+++ b/test/robot/test_master_device_instance.rb
@@ -258,7 +258,7 @@ module Syskit
                                    .default_deployment_name("test::Task")
                     @default_deployment_name = default_name
                     @deployment_m = Syskit::Deployment.new_submodel(name: "d") do
-                        task default_name, driver_m.orogen_model
+                        task default_name, driver_m
                     end
                     flexmock(@loader).should_receive(:deployment_model_from_name)
                                      .with(default_name)

--- a/test/roby_app/test_configuration.rb
+++ b/test/roby_app/test_configuration.rb
@@ -16,7 +16,7 @@ describe Syskit::RobyApp::Configuration do
         def stub_deployment(name)
             task_m = @task_m
             Syskit::Deployment.new_submodel(name: name) do
-                task("task", task_m.orogen_model)
+                task("task", task_m)
             end
         end
 
@@ -94,9 +94,9 @@ describe Syskit::RobyApp::Configuration do
                 @ruby_task = ruby_task = Orocos.allow_blocking_calls do
                     Orocos::RubyTasks::TaskContext.new "remote-task"
                 end
-                Syskit::TaskContext.new_submodel(orogen_model: ruby_task.model)
+                task_m = Syskit::TaskContext.new_submodel(orogen_model: ruby_task.model)
                 @deployment_m = Syskit::Deployment.new_submodel do
-                    task "name", ruby_task.model
+                    task "name", task_m
                 end
                 server = process_server_create
                 server.should_receive(:start_process)

--- a/test/roby_app/test_logging_group.rb
+++ b/test/roby_app/test_logging_group.rb
@@ -12,7 +12,7 @@ module Syskit
                     output_port "out", "/double"
                 end
                 @deployment_m = Syskit::Deployment.new_submodel(name: "TestDeployment") do
-                    task "task", task_m.orogen_model
+                    task "task", task_m
                 end
             end
 

--- a/test/test_deployment.rb
+++ b/test/test_deployment.rb
@@ -805,7 +805,7 @@ module Syskit
                 end
                 @task_name = task_name = "syskit-ruby-tasks-test-#{Process.pid}"
                 @deployment_m = Deployment.new_submodel(name: "deployment") do
-                    task task_name, task_m.orogen_model
+                    task task_name, task_m
                 end
                 Syskit.conf.process_server_for("test")
                       .register_deployment_model(deployment_m.orogen_model)


### PR DESCRIPTION
To avoid the "there is no Syskit model for ..." error