### PR TITLE
fix: speedup Syskit's own test suite

### DIFF
--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -185,10 +185,12 @@ module Syskit
                     "unmanaged_tasks", UnmanagedTasksManager.new, app.log_dir
                 )
 
-                Syskit.conf.register_process_server(
-                    "ros", Orocos::ROS::ProcessManager.new(app.ros_loader),
-                    app.log_dir
-                )
+                if Orocos::ROS.enabled?
+                    Syskit.conf.register_process_server(
+                        "ros", Orocos::ROS::ProcessManager.new(app.ros_loader),
+                        app.log_dir
+                    )
+                end
             end
 
             # Register the default process managers when only_load_models? is set
@@ -355,7 +357,7 @@ module Syskit
                         project_define_from_orogen(project)
                     end
                     orogen_pack_loader
-                    ros_loader
+                    ros_loader if Orocos::ROS.enabled?
                 end
                 @default_loader
             end
@@ -507,10 +509,12 @@ module Syskit
                     app.orogen_pack_loader.register_typekit dir, name
                 end
 
-                app.ros_loader.search_path
-                   .concat(Roby.app.find_dirs("models", "ROBOT", "orogen", "ros", :all => app.auto_load_all?, :order => :specific_first))
-                app.ros_loader.packs
-                   .concat(Roby.app.find_dirs("models", "ROBOT", "pack", "ros", :all => true, :order => :specific_last))
+                if Orocos::ROS.enabled?
+                    app.ros_loader.search_path
+                       .concat(Roby.app.find_dirs("models", "ROBOT", "orogen", "ros", :all => app.auto_load_all?, :order => :specific_first))
+                    app.ros_loader.packs
+                       .concat(Roby.app.find_dirs("models", "ROBOT", "pack", "ros", :all => true, :order => :specific_last))
+                end
             end
 
             def syskit_listen_to_configuration_changes

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -39,11 +39,6 @@ module Syskit
 
             attr_writer :syskit_use_update_properties
 
-            # Object that allows in-process instantiation of RTT task contexts
-            #
-            # @return [Orocos::ComponentLoader]
-            attr_accessor :syskit_component_loader
-
             # The deployed in-process logger for ruby tasks
             attr_accessor :syskit_in_process_logger_deployment
 
@@ -103,13 +98,6 @@ module Syskit
                         File.join(app.log_dir, "properties")
                     )
                 end
-
-                app.syskit_component_loader = Orocos::ComponentLoader.new(
-                    loader: OroGen::Loaders::PkgConfig.new(
-                        app.default_pkgconfig_loader.orocos_target,
-                        app.default_loader
-                    )
-                )
 
                 if Syskit.conf.define_default_process_managers?
                     if Syskit.conf.only_load_models?
@@ -360,6 +348,15 @@ module Syskit
                     ros_loader if Orocos::ROS.enabled?
                 end
                 @default_loader
+            end
+
+            def syskit_component_loader
+                @syskit_component_loader ||= Orocos::ComponentLoader.new(
+                    loader: OroGen::Loaders::PkgConfig.new(
+                        default_pkgconfig_loader.orocos_target,
+                        default_loader
+                    )
+                )
             end
 
             def default_pkgconfig_loader


### PR DESCRIPTION
I did some quick profiling, and turns out that the suite was wasting a significant amount of time looking for pkg-config packages. One source of this was the ROS loader. The other was that the component loader was adding a new Loaders::PkgConfig to the default loader, one per test, which is a rather massive memory leak over time.

On my machine, the suite went from 12 min to 4 when [this PR](https://github.com/rock-core/tools-orocosrb/pull/157) was also added