### PR TITLE
integrate `rr` as an execution mode (on top of #427)

### DIFF
--- a/lib/syskit/process_managers/remote/server/process.rb
+++ b/lib/syskit/process_managers/remote/server/process.rb
@@ -370,7 +370,7 @@ module Syskit
                         JSON.parse(message)
                     rescue JSON::ParserError
                         raise Orocos::InvalidIORMessage,
-                              "received IOR message is not valid JSON"
+                              "received IOR message is not valid JSON: #{message}"
                     end
 
                     SIGNAL_NUMBERS = {

--- a/lib/syskit/process_managers/remote/server/process.rb
+++ b/lib/syskit/process_managers/remote/server/process.rb
@@ -118,6 +118,21 @@ module Syskit
                         self
                     end
 
+                    def setup_rr
+                        @arguments.unshift(@command)
+                        @arguments.unshift(
+                            proc do
+                                trace_dir_basename =
+                                    resolve_file_pattern("rr-%m-%p", ::Process.pid)
+                                "--output-trace-dir=#{trace_dir_basename}"
+                            end
+                        )
+                        @arguments.unshift("record")
+                        @command = "rr"
+                        @execution_mode = { type: "rr" }
+                        self
+                    end
+
                     def setup_gdbserver(port: Process.allocate_gdb_port)
                         @arguments.unshift(@command)
                         @arguments.unshift(":#{port}")

--- a/lib/syskit/process_managers/remote/server/process.rb
+++ b/lib/syskit/process_managers/remote/server/process.rb
@@ -272,7 +272,7 @@ module Syskit
                         end
                         ior_write_fd.close
                         write.close
-                        raise "cannot start #{@name}" if read.read == "FAILED"
+                        raise "cannot start #{@name}" if read.read
 
                         spawn_gdb_warning if @execution_mode[:type] == "gdb"
                     end
@@ -336,8 +336,7 @@ module Syskit
                                  ior_write_fd => ior_write_fd, **output_redirect,
                                  chdir: @working_directory)
                         rescue Exception => e # rubocop:disable Lint/RescueException
-                            pp e
-                            write_pipe.write("FAILED")
+                            write_pipe.write("FAILED: #{e}")
                         end
                     end
 

--- a/lib/syskit/process_managers/remote/server/process.rb
+++ b/lib/syskit/process_managers/remote/server/process.rb
@@ -413,7 +413,6 @@ module Syskit
                         return unless tpid # already dead
 
                         if hard
-                            puts "KILL"
                             @expected_exit = 9
                             begin
                                 ::Process.kill(9, tpid)

--- a/lib/syskit/process_managers/remote/server/process.rb
+++ b/lib/syskit/process_managers/remote/server/process.rb
@@ -339,6 +339,7 @@ module Syskit
                         ENV["ORO_LOGFILE"] = resolve_orocos_logger_output(pid)
 
                         ::Process.setpgrp
+                        debug "command line: #{@command} #{arguments.join(' ')}"
                         begin
                             exec(@command, *arguments,
                                  control_read_fd => control_read_fd,

--- a/lib/syskit/process_managers/remote/server/server.rb
+++ b/lib/syskit/process_managers/remote/server/server.rb
@@ -287,7 +287,7 @@ module Syskit
                     #   terminated processes
                     def announce_dead_processes(dead_processes)
                         dead_processes.each do |process, exit_status|
-                            debug "announcing death of #{process.name}"
+                            debug "announcing death of #{process.name} - #{exit_status}"
                             each_client do |socket|
                                 debug "  announcing to #{socket}"
                                 socket.write(EVENT_DEAD_PROCESS)

--- a/lib/syskit/process_managers/remote/server/server.rb
+++ b/lib/syskit/process_managers/remote/server/server.rb
@@ -371,7 +371,7 @@ module Syskit
                             end
                         elsif cmd_code == COMMAND_END
                             name, hard = Marshal.load(socket)
-                            debug "#{socket} requested end of #{name}"
+                            debug "#{socket} requested end of #{name} (hard: #{hard})"
                             if (p = processes[name])
                                 begin
                                     end_process(p, hard: hard)


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-orogen/pull/20

On top of #427 

rr is a reverse debugger (https://rr-project.org/). It allows to record the state of a program while it is being executed, and then debug back-and-forth deterministically over and over again.

This PR implements `rr` as an execution mode. Simply do

`deployed_as("name", execution_mode: { type: "rr" })`

The recorded states are saved in the log folder.