### PR TITLE
chore: reduce the impact of listening to configuration changes

### DIFF
--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -517,6 +517,7 @@ module Syskit
                         ui_event "syskit_orogen_config_changed"
                     end
                 end
+                @conf_listener.only(/\.yml$/)
                 @conf_listener.start
             end
 

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -83,7 +83,7 @@ module Syskit
 
                 require "orocos/async" if Conf.ui?
 
-                if app.development_mode?
+                if app.development_mode? && !app.testing?
                     require "listen"
                     app.syskit_listen_to_configuration_changes
                 end


### PR DESCRIPTION
In my tests, this seems to have fixed an issue in bundles test suites, where we would run out of open file descriptors. This could to have been the source of some of the crashes in tests (the ones caused by typelib, that were caused by exceptions thrown during filesystem access).