### PR TITLE
fix: race condition in the determination of 'pending' in log upload state

### DIFF
--- a/lib/syskit/process_managers/remote/server.rb
+++ b/lib/syskit/process_managers/remote/server.rb
@@ -12,7 +12,7 @@ module Syskit
         module Remote
             # Implementation of the syskit process server
             module Server
-                extend Logger::Root(self.class.to_s, Logger::INFO)
+                extend Logger::Root(to_s, Logger::INFO)
             end
         end
     end


### PR DESCRIPTION
There is a gap between the dequeue-ing of an item from the upload queue,
and the set of @log_upload_current where pending would be zero. This
showed up as a heisenbug during tests.
