### PR TITLE
fix: isolate any error coming from resolve_all_tasks by failing the deployment's ready event

### DIFF
--- a/lib/syskit/deployment.rb
+++ b/lib/syskit/deployment.rb
@@ -485,7 +485,7 @@ module Syskit
             orocos_process.define_ior_mappings(ior_mappings)
             begin
                 remote_tasks = orocos_process.resolve_all_tasks
-            rescue ProcessManagers::IORNotRegisteredError, ArgumentError => e
+            rescue StandardError => e
                 ready_event.emit_failed(e)
                 return
             end

--- a/test/test_deployment.rb
+++ b/test/test_deployment.rb
@@ -478,11 +478,14 @@ module Syskit
                    "tasks raises an exception" do
                     flexmock(process)
                         .should_receive(:resolve_all_tasks)
-                        .and_raise(ProcessManagers::IORNotRegisteredError, "some error")
+                        .and_raise(StandardError, "some error")
                     expect_execution do
                         deployment_task.start!
                     end.to do
-                        flexmock(execution_engine).should_receive(:promise).never
+                        have_error_matching(
+                            Roby::EmissionFailed
+                            .match.with_origin(deployment_task.ready_event)
+                        )
                     end
                 end
 


### PR DESCRIPTION
Turns out that resolve_all_tasks does access the network somehow, and may fail with ComError. In any case, it makes sense to isolate all errors coming from it to the deployment itself, since the call is deployment-specific.