### PR TITLE
fix: make sure LogUploadState is defined in Remote::Manager

### DIFF
--- a/lib/syskit.rb
+++ b/lib/syskit.rb
@@ -42,6 +42,7 @@ end
 require "syskit/roby_app/log_transfer_server"
 require "syskit/process_managers/process_base"
 require "syskit/process_managers/status"
+require "syskit/process_managers/remote/server/log_upload_state"
 require "syskit/process_managers/remote/protocol"
 require "syskit/process_managers/remote/loader"
 require "syskit/process_managers/remote/manager"

--- a/lib/syskit/process_managers/remote/manager.rb
+++ b/lib/syskit/process_managers/remote/manager.rb
@@ -11,6 +11,13 @@ module Syskit
         #
         # @see Configuration#use_deployment DeploymentGroup#use_deployment
         module Remote
+            # Type transferred between the server and the manager to report on log updates
+            #
+            # Defined here to make sure it is actually defined. Otherwise, the log
+            # state reporting would fail at runtime, and unit-testing for this is
+            # very hard.
+            LogUploadState = Server::LogUploadState
+
             # Syskit-side interface to the remote process server
             class Manager
                 # Emitted when an operation fails


### PR DESCRIPTION
It is sent by the server, and if not defined in the Syskit process, leads to a failure at runtime (type does not exist).