### PR TITLE
chore: propage permanent mark to task instance generated from deployment

### DIFF
--- a/lib/syskit/deployment.rb
+++ b/lib/syskit/deployment.rb
@@ -183,7 +183,7 @@ module Syskit
         # @see find_or_create_task task
         def create_deployed_task(
             orogen_task_deployment_model,
-            syskit_task_model, scheduler_task, auto_conf: false
+            syskit_task_model, scheduler_task, auto_conf: false, permanent: false
         )
             mapped_name = name_mappings[orogen_task_deployment_model.name]
             if ready? && !(remote_handles = remote_task_handles[mapped_name])
@@ -212,6 +212,7 @@ module Syskit
             task = syskit_task_model
                    .new(orocos_name: mapped_name, read_only: read_only?(mapped_name))
             plan.add(task)
+            plan.add_permanent_task(task) if permanent
             task.executed_by self
             if scheduler_task
                 task.depends_on scheduler_task, role: "scheduler"
@@ -236,7 +237,7 @@ module Syskit
         #   model that should be used to create the task, if it is not the
         #   same as the base model. This is used for specialized models (e.g.
         #   dynamic services)
-        def task(name, syskit_task_model = nil)
+        def task(name, syskit_task_model = nil, permanent: false)
             if finishing? || finished?
                 raise InvalidState,
                       "#{self} is either finishing or already " \
@@ -252,7 +253,7 @@ module Syskit
             end
             create_deployed_task(
                 orogen_task_deployment_model,
-                syskit_task_model, scheduler_task
+                syskit_task_model, scheduler_task, permanent: permanent
             )
         end
 

--- a/lib/syskit/models/deployment_group.rb
+++ b/lib/syskit/models/deployment_group.rb
@@ -26,7 +26,8 @@ module Syskit
                 # @param [ConfiguredDeployment=>Syskit::Deployment] already
                 #    instanciated deployment tasks, to be reused if self
                 #    is part of the same ConfiguredDeployment
-                def instanciate(plan, permanent: true, deployment_tasks: {})
+                def instanciate(plan, permanent: true, deployment_tasks: {},
+                    propagate_permanent_to_instance: false)
                     deployment_task = (
                         deployment_tasks[[configured_deployment]] ||=
                             configured_deployment.new
@@ -37,7 +38,13 @@ module Syskit
                     else
                         plan.add(deployment_task)
                     end
-                    [deployment_task.task(mapped_task_name), deployment_task]
+
+                    mapped_task_context = deployment_task.task(
+                        mapped_task_name,
+                        permanent: (permanent if propagate_permanent_to_instance)
+                    )
+
+                    [mapped_task_context, deployment_task]
                 end
             end
 

--- a/test/models/test_deployment_group.rb
+++ b/test/models/test_deployment_group.rb
@@ -877,5 +877,38 @@ module Syskit
                 end
             end
         end
+
+        describe DeploymentGroup::DeployedTask do
+            before do
+            end
+
+            it "propagates deployment permanent mark to task instance from deployment" do
+                task_model = Syskit::TaskContext.new_submodel
+
+                deployment_model =
+                    Syskit::Deployment.new_submodel do
+                        task "task", task_model
+                    end
+
+                deployment_group = Models::DeploymentGroup.new
+
+                configured_deployment = deployment_group.use_deployment(
+                        { deployment_model => "1_" },
+                        on: "stubs"
+                ).first
+
+                deployed_task = DeploymentGroup::DeployedTask.new(configured_deployment,
+                    "1_task")
+
+                permanent_task_instance, _ = deployed_task.instanciate(plan,
+                    permanent: true, propagate_permanent_to_instance: true)
+                assert plan.permanent_task? permanent_task_instance
+
+                not_permanent_task_instance, _ = deployed_task.instanciate(plan,
+                    permanent: false, propagate_permanent_to_instance: true)
+                refute plan.permanent_task? not_permanent_task_instance
+            end
+        end
+
     end
 end


### PR DESCRIPTION
It is not strictly needed since the deployment task instance is added to the plan after generation. But as we pretend to do early deployment at generation, the garbage collection would throw away tasks contexts that got merged into this instances.
