### PR TITLE
 chore: copy plan marks when applying merge group

### DIFF
--- a/lib/syskit/network_generation/merge_solver.rb
+++ b/lib/syskit/network_generation/merge_solver.rb
@@ -138,6 +138,7 @@ module Syskit
 
                 merged_task_to_task.each do |merged_task, task|
                     unless merged_task.transaction_proxy?
+                        plan.copy_task_marks(from: merged_task, to: task)
                         plan.remove_task(merged_task)
                     end
                     register_replacement(merged_task, task)

--- a/test/network_generation/test_merge_solver.rb
+++ b/test/network_generation/test_merge_solver.rb
@@ -358,6 +358,31 @@ describe Syskit::NetworkGeneration::MergeSolver do
         end
     end
 
+    describe "#apply_merge_group" do
+        attr_reader :local_plan, :solver
+
+        before do
+            @local_plan = Roby::Plan.new
+            @solver = Syskit::NetworkGeneration::MergeSolver.new(@local_plan)
+        end
+
+        it "applyes merged task plan marks to the destination task" do
+            task1 = Roby::Task.new
+            task2 = Roby::Task.new
+
+            local_plan.add_permanent_task task1
+            local_plan.add_mission_task task1
+
+            refute local_plan.permanent_task? task2
+            refute local_plan.mission_task? task2
+
+            solver.apply_merge_group({ task1 => task2 })
+
+            assert local_plan.permanent_task? task2
+            assert local_plan.mission_task? task2
+        end
+    end
+
     describe "functional tests" do
         describe "merging compositions" do
             attr_reader :plan, :srv_m, :task_m, :cmp_m


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-roby/pull/304

This became a necessity as we pretend to do early deployments at network generation. In this scenario, when a "free" task context is merged into its deployed counter part its plan marks is not carried out to the deployment task instance. Then, this task instance would be garbage collected because it did not carried the permanent mark from the replace "free" task context

https://buildbot.tidewise.io/#/builders/1791/builds/15