### PR TITLE
feat: capture errors that shouldnt cause the whole plan to be discarded during network resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ coverage/
 
 tmp/
 syskit-0.1.gem
+testfile
 
 lib/syskit/telemetry/agent/*_pb.rb
 .test-results/

--- a/Rakefile
+++ b/Rakefile
@@ -28,18 +28,12 @@ def minitest_set_options(test_task, name)
     test_task.options = "#{TESTOPTS} #{minitest_args} -- --simplecov-name=#{name}"
 end
 
-def core(early_deploy: false)
-    s = ":no-early-deploy"
-    if early_deploy
-        s = ":early-deploy"
-        early_deploy_setup = ["test/features/early_deploy.rb"]
-    end
-
-    Rake::TestTask.new("test:core#{s}") do |t|
+def core_task(name, files_setup)
+    Rake::TestTask.new("test:core#{name}") do |t|
         t.libs << "."
         t.libs << "lib"
         minitest_set_options(t, "core")
-        test_files = FileList["test/**/test_*.rb", *early_deploy_setup]
+        test_files = FileList["test/**/test_*.rb", *files_setup]
         test_files = test_files
                      .exclude("test/ros/**/*.rb")
                      .exclude("test/gui/**/*.rb")
@@ -48,6 +42,23 @@ def core(early_deploy: false)
         t.test_files = test_files
         t.warning = false
     end
+end
+
+def core(early_deploy: false, capture_errors_during_network_resolution: false,
+    all_features: false)
+    s = ":no-features"
+    if capture_errors_during_network_resolution
+        s = ":capture-errors"
+        files_setup = ["test/features/capture_errors.rb"]
+    elsif early_deploy
+        s = ":early-deploy"
+        files_setup = ["test/features/early_deploy.rb"]
+    elsif all_features
+        s = ":all-features"
+        files_setup = ["test/features/all_features.rb"]
+    end
+
+    core_task(s, files_setup)
 end
 
 Rake::TestTask.new("test:telemetry") do |t|
@@ -78,9 +89,12 @@ Rake::TestTask.new("test:gui") do |t|
 end
 
 core early_deploy: true
+core capture_errors_during_network_resolution: true
+core all_features: true
 core
 desc "Run core library tests, excluding GUI and live tests"
-task "test:core" => ["test:core:no-early-deploy", "test:core:early-deploy"]
+task "test:core" => %w[test:core:no-features test:core:early-deploy
+                       test:core:capture-errors test:core:all-features]
 
 desc "Run all tests"
 task "test" => ["test:gui", "test:core", "test:live", "test:telemetry"]

--- a/lib/syskit/cli/doc/gen.rb
+++ b/lib/syskit/cli/doc/gen.rb
@@ -266,7 +266,7 @@ module Syskit
                 main_plan.add(original_task = model.as_plan)
                 engine = Syskit::NetworkGeneration::Engine.new(main_plan)
                 planning_task = original_task.planning_task
-                mapping = engine.compute_system_network([planning_task], **options)
+                mapping, = engine.compute_system_network([planning_task], **options)
 
                 if engine.work_plan.respond_to?(:commit_transaction)
                     engine.work_plan.commit_transaction

--- a/lib/syskit/exceptions.rb
+++ b/lib/syskit/exceptions.rb
@@ -353,22 +353,20 @@ module Syskit
     # Exception raised when we could not find devices to allocate for tasks
     # that are device drivers
     class DeviceAllocationFailed < SpecError
-        # The set of tasks that failed allocation
-        attr_reader :failed_tasks
+        # The task that failed allocation
+        attr_reader :failed_task
         # A task to parents mapping for tasks involved in this error, at the
         # time of the exception creation
         attr_reader :task_parents
         # Existing candidates for this device
         attr_reader :candidates
 
-        def initialize(plan, tasks)
-            @failed_tasks = tasks.dup
+        def initialize(plan, task)
+            @failed_task = task
             @candidates = {}
             @task_parents = {}
 
-            tasks.each do |abstract_task|
-                resolve_device_task(plan, abstract_task)
-            end
+            resolve_device_task(plan, task)
         end
 
         def resolve_device_task(plan, abstract_task)
@@ -383,7 +381,7 @@ module Syskit
                     all_tasks |= candidates[srv]
                 end
             end
-            self.candidates[abstract_task] = candidates
+            @candidates = candidates
 
             all_tasks.each do |t|
                 next if task_parents.key?(t)
@@ -399,35 +397,33 @@ module Syskit
         end
 
         def pretty_print(pp)
-            pp.text "cannot find a device to tie to #{failed_tasks.size} task(s)"
+            pp.text "cannot find a device to tie to a task"
 
-            failed_tasks.each do |task|
-                parents = task_parents[task]
-                candidates = self.candidates[task]
+            parents = task_parents[failed_task]
+            candidates = self.candidates
+
+            pp.breakable
+            pp.text "for #{failed_task.to_s.gsub('Syskit::', '')}"
+            pp.nest(2) do
+                unless parents.empty?
+                    pp.breakable
+                    pp.seplist(parents) do |parent|
+                        role, parent = parent
+                        pp.text "child #{role.to_a.first} of #{parent.to_s.gsub('Syskit::', '')}"
+                    end
+                end
 
                 pp.breakable
-                pp.text "for #{task.to_s.gsub('Syskit::', '')}"
-                pp.nest(2) do
-                    unless parents.empty?
-                        pp.breakable
-                        pp.seplist(parents) do |parent|
-                            role, parent = parent
-                            pp.text "child #{role.to_a.first} of #{parent.to_s.gsub('Syskit::', '')}"
-                        end
-                    end
-
-                    pp.breakable
-                    pp.seplist(candidates) do |cand|
-                        srv, tasks = *cand
-                        if tasks.empty?
-                            pp.text "no candidates for #{srv.short_name}"
-                        else
-                            pp.text "candidates for #{srv.short_name}"
-                            pp.nest(2) do
-                                pp.breakable
-                                pp.seplist(tasks) do |cand_t|
-                                    pp.text cand_t.to_s
-                                end
+                pp.seplist(candidates) do |cand|
+                    srv, tasks = *cand
+                    if tasks.empty?
+                        pp.text "no candidates for #{srv.short_name}"
+                    else
+                        pp.text "candidates for #{srv.short_name}"
+                        pp.nest(2) do
+                            pp.breakable
+                            pp.seplist(tasks) do |cand_t|
+                                pp.text cand_t.to_s
                             end
                         end
                     end
@@ -467,122 +463,119 @@ module Syskit
     class ConflictingDeploymentAllocation < SpecError
         include Syskit::NetworkGenerationsExceptionHelpers
 
-        attr_reader :deployment_to_tasks
+        attr_reader :orocos_name
 
-        def initialize(deployment_to_tasks, toplevel_tasks_to_requirements = {})
-            @deployment_to_tasks = deployment_to_tasks
+        def initialize(orocos_name, tasks, toplevel_tasks_to_requirements = {})
+            @orocos_name = orocos_name
+            @tasks = tasks
             @toplevel_tasks_to_requirements = toplevel_tasks_to_requirements
-            @deployment_to_execution_agent = \
-                deployment_to_tasks.transform_values do |tasks|
-                    tasks.first.execution_agent
-                end
+            @agent = tasks.first.execution_agent
         end
 
         def pretty_print(pp)
-            deployment_to_tasks.each do |orocos_name, tasks|
-                agent = @deployment_to_execution_agent[orocos_name]
-                deployment_m = agent.deployed_orogen_model_by_name(orocos_name)
-                pp.text(
-                    "deployed task '#{orocos_name}' from deployment " \
-                    "'#{deployment_m.name}' defined in " \
-                    "'#{deployment_m.project.name}' on '#{agent.process_server_name}' " \
-                    "is assigned to #{tasks.size} tasks. Below is the list of " \
-                    "the dependent non-deployed actions. Right after the list " \
-                    "is a detailed explanation of why the first two tasks are not merged:"
+            deployment_m = @agent.deployed_orogen_model_by_name(orocos_name)
+            pp.text(
+                "deployed task '#{orocos_name}' from deployment " \
+                "'#{deployment_m.name}' defined in " \
+                "'#{deployment_m.project.name}' on '#{@agent.process_server_name}' " \
+                "is assigned to #{@tasks.size} tasks. Below is the list of " \
+                "the dependent non-deployed actions. Right after the list " \
+                "is a detailed explanation of why the first two tasks are not merged:"
+            )
+            @tasks.each do |t|
+                defs = find_all_related_syskit_actions(
+                    t, @toplevel_tasks_to_requirements
                 )
-                tasks.each do |t|
-                    defs = find_all_related_syskit_actions(
-                        t, @toplevel_tasks_to_requirements
-                    )
-                    print_dependent_definitions(pp, t, defs)
-                end
-                print_failed_merge_chain(pp, tasks[0], tasks[1])
+                print_dependent_definitions(pp, t, defs)
             end
+            print_failed_merge_chain(pp, @tasks[0], @tasks[1])
         end
     end
 
-    # Exception raised at the end of #resolve if some tasks do not have a
+    # Exception raised at the end of #resolve if a task does not have a
     # deployed equivalent
-    class MissingDeployments < SpecError
-        # The tasks that are not deployed, as a hash from the actual task to
+    class MissingDeployment < SpecError
+        # The tasks that is not deployed, as a hash from the actual task to
         # a set of [role_set, parent_task] pairs
         #
         # This is computed in #initialize as the dependency structure will
         # probably change afterwards
-        attr_reader :tasks
+
+        # The task that is not deployed
+        attr_reader :task
+
+        # Parent tasks of the not deployed task
+        attr_reader :parents
+        # All the available deployment candidates
+        attr_reader :candidates
+        # The deployment hints of the not deployed task
+        attr_reader :deployment_hints
 
         # Initializes this exception by providing a mapping from tasks that
-        # have no deployments to the deployment candidates
+        # have no deployments to the deployment candidates, and the specific task the
+        # error refers to.
         #
         # @param [Hash{TaskContext=>[Array<Model<Deployment>>]}] tasks_with_candidates
-        def initialize(tasks_with_candidates)
-            @tasks = {}
-            tasks_with_candidates.each do |task_to_deploy, candidates|
-                parents = task_to_deploy.dependency_context
-                candidates = candidates.map do |deployed_task, existing_tasks|
-                    existing_tasks = existing_tasks.map do |task|
-                        [task, task.dependency_context]
-                    end
-                    [deployed_task, existing_tasks]
+        def initialize(task, candidates)
+            @task = task
+            @parents = task.dependency_context
+            @candidates = candidates.map do |deployed_task, existing_tasks|
+                existing_tasks = existing_tasks.map do |task|
+                    [task, task.dependency_context]
                 end
-
-                @tasks[task_to_deploy] = [
-                    parents, candidates, task_to_deploy.deployment_hints
-                ]
+                [deployed_task, existing_tasks]
             end
+            @deployment_hints = task.deployment_hints
         end
 
         def pretty_print(pp)
-            pp.text "cannot deploy the following tasks"
-            tasks.each do |task, (parents, possible_deployments)|
+            pp.text "cannot deploy the following task"
+            pp.breakable
+            pp.text "#{task} (#{task.orogen_model.name})"
+            pp.nest(2) do
                 pp.breakable
-                pp.text "#{task} (#{task.orogen_model.name})"
-                pp.nest(2) do
-                    pp.breakable
-                    pp.seplist(parents) do |parent_task|
-                        role, parent_task = parent_task
-                        pp.text "child #{role} of #{parent_task}"
-                    end
+                pp.seplist(parents) do |parent_task|
+                    role, parent_task = parent_task
+                    pp.text "child #{role} of #{parent_task}"
                 end
             end
 
-            tasks.each do |task, (_parents, possible_deployments, deployment_hints)|
-                has_free_deployment = possible_deployments.any? { |_, existing| existing.empty? }
-                pp.breakable
-                if has_free_deployment
-                    pp.text "#{task}: multiple possible deployments, choose one with #prefer_deployed_tasks(deployed_task_name)"
-                    unless deployment_hints.empty?
-                        deployment_hints.each do |hint|
-                            pp.text "  current hints: #{deployment_hints.map(&:to_s).join(', ')}"
-                        end
-                    end
-                elsif possible_deployments.empty?
-                    pp.text "#{task}: no deployments available"
-                else
-                    pp.text "#{task}: some deployments exist, but they are already used in this network"
+            has_free_deployment = candidates.any? { |_, existing| existing.empty? }
+            pp.breakable
+            if has_free_deployment
+                pp.text "#{task}: multiple possible deployments, choose one with " \
+                        "#prefer_deployed_tasks(deployed_task_name)"
+                deployment_hints.each do |hint|
+                    pp.text "  current hints: " \
+                            "#{deployment_hints.map(&:to_s).join(', ')}"
                 end
+            elsif candidates.empty?
+                pp.text "#{task}: no deployments available"
+            else
+                pp.text "#{task}: some deployments exist, but they are already used " \
+                        "in this network"
+            end
 
-                pp.nest(2) do
-                    possible_deployments.each do |deployed_task, existing|
-                        pp.breakable
-                        process_server_name = deployed_task.configured_deployment
-                                                           .process_server_name
-                        orogen_model = deployed_task.configured_deployment
-                                                    .orogen_model
-                        pp.text(
-                            "task #{deployed_task.mapped_task_name} from deployment " \
-                            "#{orogen_model.name} defined in " \
-                            "#{orogen_model.project.name} on #{process_server_name}"
-                        )
-                        pp.nest(2) do
-                            existing.each do |task, parents|
-                                pp.breakable
-                                msg = parents.map do |parent_task|
-                                    role, parent_task = *parent_task
-                                    "child #{role} of #{parent_task}"
-                                end
-                                pp.text "already used by #{task}: #{msg.join(', ')}"
+            pp.nest(2) do
+                candidates.each do |deployed_task, existing|
+                    pp.breakable
+                    process_server_name = deployed_task.configured_deployment
+                                                       .process_server_name
+                    orogen_model = deployed_task.configured_deployment
+                                                .orogen_model
+                    pp.text(
+                        "task #{deployed_task.mapped_task_name} from deployment " \
+                        "#{orogen_model.name} defined in " \
+                        "#{orogen_model.project.name} on #{process_server_name}"
+                    )
+                    pp.nest(2) do
+                        existing.each do |task, parents|
+                            pp.breakable
+                            msg = parents.map do |parent_task|
+                                role, parent_task = *parent_task
+                                "child #{role} of #{parent_task}"
                             end
+                            pp.text "already used by #{task}: #{msg.join(', ')}"
                         end
                     end
                 end
@@ -590,24 +583,25 @@ module Syskit
         end
     end
 
-    # Exception raised at the end of #resolve if some tasks are referring to non-existing
-    # configurations
+    # Exception raised at the end of #resolve if a task is referring to non-existing
+    # configuration
     class MissingConfigurationSection < SpecError
-        # Association of tasks and the sections that are missing
-        attr_reader :missing_sections_by_task
+        # The sections that are missing
+        attr_reader :missing_sections
+        # The task with a missing configuration section
+        attr_reader :task
 
-        def initialize(missing_sections_by_task)
-            @missing_sections_by_task = missing_sections_by_task
+        def initialize(task, missing_sections)
+            @task = task
+            @missing_sections = missing_sections
         end
 
         def pretty_print(pp)
             pp.text "the following configuration sections are used but do not exist"
-            @missing_sections_by_task.each do |task, sections|
-                pp.breakable
-                pp.text "'#{sections.join('\', \'')}', in use by:"
-                pp.breakable
-                pp.text "  #{task} (#{task.orogen_model.name})"
-            end
+            pp.breakable
+            pp.text "'#{missing_sections.join('\', \'')}', in use by:"
+            pp.breakable
+            pp.text "  #{task} (#{task.orogen_model.name})"
         end
     end
 

--- a/lib/syskit/gui/component_network_base_view.rb
+++ b/lib/syskit/gui/component_network_base_view.rb
@@ -149,8 +149,9 @@ module Syskit
                 main_plan.add(original_task = model.as_plan)
                 base_task = original_task.as_service
                 engine = Syskit::NetworkGeneration::Engine.new(main_plan)
-                engine.compute_system_network([base_task.task.planning_task])
-                base_task.task
+                _, resolution_errors =
+                    engine.compute_system_network([base_task.task.planning_task])
+                [base_task.task, resolution_errors]
             ensure
                 if engine && engine.work_plan.respond_to?(:commit_transaction)
                     engine.work_plan.commit_transaction

--- a/lib/syskit/gui/component_network_view.rb
+++ b/lib/syskit/gui/component_network_view.rb
@@ -150,11 +150,11 @@ module Syskit
                 begin
                     if method == :compute_system_network
                         tic = Time.now
-                        @task = compute_system_network(model, plan)
+                        @task, = compute_system_network(model, plan)
                         timing = Time.now - tic
                     elsif method == :compute_deployed_network
                         tic = Time.now
-                        @task = compute_deployed_network(model, plan)
+                        @task, = compute_deployed_network(model, plan)
                         timing = Time.now - tic
                     else
                         @task = instanciate_model(model, plan, instanciate_options)

--- a/lib/syskit/instance_requirements_task.rb
+++ b/lib/syskit/instance_requirements_task.rb
@@ -48,7 +48,6 @@ module Syskit
             root = new_spec.create_proxy_task
             planner = new(**arguments)
             planner.requirements = new_spec
-            root.should_start_after(planner)
             planner.schedule_as(root)
             root.planned_by(planner)
             root

--- a/lib/syskit/instance_requirements_task.rb
+++ b/lib/syskit/instance_requirements_task.rb
@@ -21,6 +21,10 @@ module Syskit
         # @return [InstanceRequirements]
         attr_accessor :requirements
 
+        # Marks the successful end of one network resolution that included this instance
+        # requirement
+        event :resolution_success
+
         # This task is executable only if a requirement object has been set
         #
         # We don't use task arguments here as InstanceRequirements is not (yet)
@@ -40,6 +44,7 @@ module Syskit
             unless new_spec.kind_of?(InstanceRequirements)
                 new_spec = InstanceRequirements.new([new_spec])
             end
+
             root = new_spec.create_proxy_task
             planner = new(**arguments)
             planner.requirements = new_spec

--- a/lib/syskit/network_generation.rb
+++ b/lib/syskit/network_generation.rb
@@ -8,11 +8,12 @@ module Syskit
     end
 end
 
+require "syskit/network_generation/async"
 require "syskit/network_generation/dataflow_computation"
 require "syskit/network_generation/dataflow_dynamics"
-require "syskit/network_generation/merge_solver"
-require "syskit/network_generation/system_network_generator"
-require "syskit/network_generation/system_network_deployer"
 require "syskit/network_generation/engine"
-require "syskit/network_generation/async"
 require "syskit/network_generation/logger"
+require "syskit/network_generation/merge_solver"
+require "syskit/network_generation/resolution_error_handler"
+require "syskit/network_generation/system_network_deployer"
+require "syskit/network_generation/system_network_generator"

--- a/lib/syskit/network_generation/async.rb
+++ b/lib/syskit/network_generation/async.rb
@@ -119,6 +119,9 @@ module Syskit
 
             class InvalidState < RuntimeError; end
 
+            SystemNetworkPlanApplyResult =
+                Struct.new :fulfilled, :instances, :errors, keyword_init: true
+
             # Apply the result of the generation
             #
             # @return [Boolean] true if the result has been applied, and false
@@ -133,14 +136,17 @@ module Syskit
                 engine = future.engine
                 if @cancelled
                     engine.discard_work_plan
-                    false
+                    SystemNetworkPlanApplyResult.new(fulfilled: false)
                 elsif future.fulfilled?
-                    required_instances = future.value
+                    required_instances, resolution_errors = future.value
                     begin
                         engine.apply_system_network_to_plan(
                             required_instances, **@apply_system_network_options
                         )
-                        true
+                        SystemNetworkPlanApplyResult.new(
+                            fulfilled: true, instances: required_instances,
+                            errors: resolution_errors
+                        )
                     rescue ::Exception => e
                         engine.handle_resolution_exception(e, on_error: Engine.on_error)
                         raise e

--- a/lib/syskit/network_generation/async.rb
+++ b/lib/syskit/network_generation/async.rb
@@ -119,9 +119,6 @@ module Syskit
 
             class InvalidState < RuntimeError; end
 
-            SystemNetworkPlanApplyResult =
-                Struct.new :fulfilled, :instances, :errors, keyword_init: true
-
             # Apply the result of the generation
             #
             # @return [Boolean] true if the result has been applied, and false
@@ -136,7 +133,7 @@ module Syskit
                 engine = future.engine
                 if @cancelled
                     engine.discard_work_plan
-                    SystemNetworkPlanApplyResult.new(fulfilled: false)
+                    nil
                 elsif future.fulfilled?
                     required_instances, resolution_errors = future.value
                     begin
@@ -144,7 +141,7 @@ module Syskit
                             required_instances, **@apply_system_network_options
                         )
                         SystemNetworkPlanApplyResult.new(
-                            fulfilled: true, instances: required_instances,
+                            instance_requirement_tasks: required_instances.keys,
                             errors: resolution_errors
                         )
                     rescue ::Exception => e

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -689,21 +689,16 @@ module Syskit
             # Computes the set of requirement tasks that should be used for
             # deployment within the given plan
             def self.discover_requirement_tasks_from_plan(plan)
-                req_tasks = plan.find_local_tasks(InstanceRequirementsTask)
-                req_tasks = req_tasks.find_all do |req_task|
-                    if req_task.failed? || req_task.pending?
-                        false
-                    elsif (planned_task = req_task.planned_task)
-                        !planned_task.finished? || planned_task.being_repaired?
-                    else
-                        false
-                    end
-                end
-                needed = plan.useful_tasks(with_transactions: false)
-                req_tasks.delete_if do |t|
-                    !needed.include?(t)
-                end
-                req_tasks
+                req_tasks =
+                    plan.find_local_tasks(InstanceRequirementsTask).running
+                req_tasks = req_tasks.find_all do |t|
+                    planned_task = t.planned_task
+                    next unless planned_task
+
+                    !planned_task.finished? || planned_task.being_repaired?
+                end.to_set
+                needed = plan.useful_tasks(with_transactions: false).to_set
+                req_tasks.intersection(needed)
             end
 
             def compute_system_network(
@@ -874,6 +869,8 @@ module Syskit
                     cleanup_resolution_errors: cleanup_resolution_errors
                 )
 
+                # Can only be reached if the capture_error_during_network_resolution flag
+                # is true
                 if !resolution_errors.empty? && !cleanup_resolution_errors
                     exceptions = resolution_errors.map(&:original_exception)
                     handle_resolution_exception(exceptions, on_error: on_error)
@@ -975,10 +972,10 @@ module Syskit
                             dataflow_path, hierarchy_path =
                                 Engine.autosave_plan_to_dot(work_plan, Roby.app.log_dir)
                             fatal "the generated plan has been saved"
-                            fatal "use dot -Tsvg #{dataflow_path} > #{dataflow_path}.svg " \
-                                  "to convert the dataflow to SVG"
-                            fatal "use dot -Tsvg #{hierarchy_path} > #{hierarchy_path}.svg " \
-                                  "to convert to SVG"
+                            fatal "use dot -Tsvg #{dataflow_path} > " \
+                                  "#{dataflow_path}.svg to convert the dataflow to SVG"
+                            fatal "use dot -Tsvg #{hierarchy_path} > " \
+                                  "#{hierarchy_path}.svg to convert to SVG"
                         rescue Exception => e # rubocop:disable Lint/RescueException
                             Roby.log_exception_with_backtrace(e, self, :fatal)
                         end

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -340,7 +340,10 @@ module Syskit
                         # Need to switch the planning relation as well, it is
                         # not done by #replace
                         placeholder_task.remove_planning_task req_task
-                        actual_task.add_planning_task req_task
+                        # When using Syskit, a toplevel task might have more than
+                        # one planning task - think different requirements that
+                        # resolve to the same place in the network
+                        actual_task.add_planning_task(req_task, {})
                     end
                 end
             end

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -93,10 +93,13 @@ module Syskit
             #
             # This does not access {#real_plan}
             def compute_deployed_network(
+                error_handler: RaiseErrorHandler.new,
+                required_instances: [],
                 default_deployment_group: Syskit.conf.deployment_group,
                 compute_policies: true,
                 validate_deployed_network: true
             )
+                resolution_errors = []
                 log_timepoint_group "deploy_system_network" do
                     deployer = SystemNetworkDeployer.new(
                         work_plan,
@@ -105,7 +108,12 @@ module Syskit
                         default_deployment_group: default_deployment_group
                     )
 
-                    deployer.deploy(validate: validate_deployed_network)
+                    deployer.deploy(
+                        error_handler: error_handler, validate: validate_deployed_network
+                    )
+                    resolution_errors = error_handler.process_failures(
+                        required_instances, cleanup_failed_tasks: true
+                    )
                 end
 
                 # Now that we have a deployed network, we can compute the
@@ -122,7 +130,7 @@ module Syskit
                 @deployment_tasks = work_plan.find_local_tasks(Deployment).to_set
                 @deployed_tasks = work_plan.find_local_tasks(Component).to_set
 
-                nil
+                resolution_errors
             end
 
             # Apply the deployed network created with
@@ -701,32 +709,44 @@ module Syskit
             def compute_system_network(
                 requirement_tasks =
                     Engine.discover_requirement_tasks_from_plan(real_plan),
+                error_handler: RaiseErrorHandler.new,
                 garbage_collect: true,
                 validate_abstract_network: true,
                 validate_generated_network: true,
                 default_deployment_group: Syskit.conf.deployment_group,
-                validate_deployed_network: (true if Syskit.conf.early_deploy?),
-                early_deploy: Syskit.conf.early_deploy?
+                early_deploy: Syskit.conf.early_deploy?,
+                validate_deployed_network: early_deploy,
+                cleanup_resolution_errors: true
             )
                 requirement_tasks = requirement_tasks.to_a
                 instance_requirements = requirement_tasks.map(&:requirements)
                 merge_solver.merge_task_contexts_with_same_agent = early_deploy
+
                 system_network_generator = SystemNetworkGenerator.new(
                     work_plan,
+                    error_handler: error_handler,
                     event_logger: event_logger,
                     merge_solver: merge_solver,
                     default_deployment_group: default_deployment_group,
                     early_deploy: early_deploy
                 )
-                toplevel_tasks = system_network_generator.generate(
-                    instance_requirements,
+                toplevel_tasks =
+                    system_network_generator.instanciate_system_network(
+                        instance_requirements
+                    )
+
+                system_network_generator.resolve_system_network(
                     garbage_collect: garbage_collect,
                     validate_abstract_network: validate_abstract_network,
                     validate_generated_network: validate_generated_network,
                     validate_deployed_network: validate_deployed_network
                 )
+                required_instances = Hash[requirement_tasks.zip(toplevel_tasks)]
 
-                Hash[requirement_tasks.zip(toplevel_tasks)]
+                resolution_errors = error_handler.process_failures(
+                    required_instances, cleanup_failed_tasks: cleanup_resolution_errors
+                )
+                [required_instances, resolution_errors]
             end
 
             # Computes the system network, that is the network that fullfills
@@ -759,30 +779,44 @@ module Syskit
                 compute_deployments: true,
                 default_deployment_group: Syskit.conf.deployment_group,
                 compute_policies: true,
-                early_deploy: Syskit.conf.early_deploy?
+                early_deploy: Syskit.conf.early_deploy?,
+                capture_errors_during_network_resolution:
+                    Syskit.conf.capture_errors_during_network_resolution?,
+                cleanup_resolution_errors: true
             )
-
                 merge_solver.merge_task_contexts_with_same_agent = early_deploy
-                required_instances = compute_system_network(
+
+                error_handler = if capture_errors_during_network_resolution
+                                    ResolutionErrorHandler.new(work_plan, merge_solver)
+                                else
+                                    RaiseErrorHandler.new
+                                end
+                required_instances, resolution_errors = compute_system_network(
                     requirement_tasks,
+                    error_handler: error_handler,
                     garbage_collect: garbage_collect,
                     validate_abstract_network: validate_abstract_network,
                     validate_generated_network: validate_generated_network,
                     default_deployment_group: (default_deployment_group if early_deploy),
                     validate_deployed_network: validate_deployed_network,
-                    early_deploy: early_deploy && compute_deployments
+                    early_deploy: early_deploy && compute_deployments,
+                    cleanup_resolution_errors: cleanup_resolution_errors
                 )
 
                 if compute_deployments
                     log_timepoint_group "compute_deployed_network" do
-                        compute_deployed_network(
-                            default_deployment_group: default_deployment_group,
-                            compute_policies: compute_policies,
-                            validate_deployed_network: validate_deployed_network
-                        )
+                        deployment_resolution_errors =
+                            compute_deployed_network(
+                                error_handler: error_handler,
+                                required_instances: required_instances,
+                                default_deployment_group: default_deployment_group,
+                                compute_policies: compute_policies,
+                                validate_deployed_network: validate_deployed_network
+                            )
+                        resolution_errors.concat(deployment_resolution_errors)
                     end
                 end
-                required_instances
+                [required_instances, resolution_errors]
             end
 
             # Generate the deployment according to the current requirements, and
@@ -819,10 +853,13 @@ module Syskit
                 validate_generated_network: true,
                 validate_deployed_network: true,
                 validate_final_network: true,
-                early_deploy: Syskit.conf.early_deploy?
+                early_deploy: Syskit.conf.early_deploy?,
+                capture_errors_during_network_resolution:
+                    Syskit.conf.capture_errors_during_network_resolution?,
+                cleanup_resolution_errors: on_error != :commit
             )
                 merge_solver.merge_task_contexts_with_same_agent = early_deploy
-                required_instances = resolve_system_network(
+                required_instances, resolution_errors = resolve_system_network(
                     requirement_tasks,
                     garbage_collect: garbage_collect,
                     validate_abstract_network: validate_abstract_network,
@@ -831,8 +868,17 @@ module Syskit
                     default_deployment_group: default_deployment_group,
                     compute_policies: compute_policies,
                     validate_deployed_network: validate_deployed_network,
-                    early_deploy: early_deploy
+                    early_deploy: early_deploy,
+                    capture_errors_during_network_resolution:
+                        capture_errors_during_network_resolution,
+                    cleanup_resolution_errors: cleanup_resolution_errors
                 )
+
+                if !resolution_errors.empty? && !cleanup_resolution_errors
+                    exceptions = resolution_errors.map(&:original_exception)
+                    handle_resolution_exception(exceptions, on_error: on_error)
+                    return resolution_errors
+                end
 
                 apply_system_network_to_plan(
                     required_instances,
@@ -840,6 +886,7 @@ module Syskit
                     garbage_collect: garbage_collect,
                     validate_final_network: validate_final_network
                 )
+                resolution_errors
             rescue Exception => e # rubocop:disable Lint/RescueException
                 handle_resolution_exception(e, on_error: on_error)
                 raise
@@ -916,22 +963,25 @@ module Syskit
                 end
             end
 
-            def handle_resolution_exception(e, on_error: :discard)
+            def handle_resolution_exception(exceptions, on_error: :discard)
                 return if work_plan.finalized? || work_plan == real_plan
 
+                exceptions = [exceptions] unless exceptions.kind_of? Array
                 if on_error == :save
-                    log_pp(:fatal, e)
-                    fatal "Engine#resolve failed"
-                    begin
-                        dataflow_path, hierarchy_path =
-                            Engine.autosave_plan_to_dot(work_plan, Roby.app.log_dir)
-                        fatal "the generated plan has been saved"
-                        fatal "use dot -Tsvg #{dataflow_path} > #{dataflow_path}.svg " \
-                              "to convert the dataflow to SVG"
-                        fatal "use dot -Tsvg #{hierarchy_path} > #{hierarchy_path}.svg " \
-                              "to convert to SVG"
-                    rescue Exception => e # rubocop:disable Lint/RescueException
-                        Roby.log_exception_with_backtrace(e, self, :fatal)
+                    exceptions.each do |e|
+                        log_pp(:fatal, e)
+                        fatal "Engine#resolve failed"
+                        begin
+                            dataflow_path, hierarchy_path =
+                                Engine.autosave_plan_to_dot(work_plan, Roby.app.log_dir)
+                            fatal "the generated plan has been saved"
+                            fatal "use dot -Tsvg #{dataflow_path} > #{dataflow_path}.svg " \
+                                  "to convert the dataflow to SVG"
+                            fatal "use dot -Tsvg #{hierarchy_path} > #{hierarchy_path}.svg " \
+                                  "to convert to SVG"
+                        rescue Exception => e # rubocop:disable Lint/RescueException
+                            Roby.log_exception_with_backtrace(e, self, :fatal)
+                        end
                     end
                 elsif on_error == :commit
                     work_plan.commit_transaction

--- a/lib/syskit/network_generation/resolution_error_handler.rb
+++ b/lib/syskit/network_generation/resolution_error_handler.rb
@@ -11,6 +11,14 @@ module Syskit
             end
         end
 
+        # Reports the result of the network generation application.
+        SystemNetworkPlanApplyResult =
+            Struct.new :instance_requirement_tasks, :errors, keyword_init: true do
+                def error?
+                    !errors.empty?
+                end
+            end
+
         # This is used to capture failures during the network generation process. Each
         # failure bundles the toplevel tasks that are related to the task that originates
         # the failure. It should be transformed into a ResolutionError for each related
@@ -24,13 +32,12 @@ module Syskit
                 # array. Optionally, one can provide the original exception and the error
                 # message as well.
                 def initialize(
-                    failed_task, original_exception, message, merge_solver, plan
+                    failed_task, original_exception, merge_solver, plan
                 )
                     self.failed_task = failed_task
                     self.merge_solver = merge_solver
                     self.plan = plan
                     self.original_exception = original_exception
-                    self.message = message
                 end
 
                 # Convert to ResolutionError by replacing the requirement of a failed task
@@ -38,7 +45,7 @@ module Syskit
                 #
                 # @return [ResolutionError]
                 def to_resolution_errors(instance)
-                    ResolutionError.new(instance, original_exception, message)
+                    ResolutionError.new(instance, original_exception)
                 end
             end
 
@@ -52,10 +59,9 @@ module Syskit
         class ResolutionError
             attr_reader :planned_task, :planning_task, :original_exception
 
-            def initialize(failed_task, original_exception, message = nil)
+            def initialize(failed_task, original_exception)
                 validate(failed_task)
 
-                original_exception = original_exception.exception(message) if message
                 @original_exception = original_exception
                 @planned_task = failed_task.planned_task
                 @planning_task = failed_task
@@ -84,21 +90,14 @@ module Syskit
                 @merge_solver = merge_solver
             end
 
-            def register_resolution_failures(failures, _exception, _message)
-                failures.each do |failure|
-                    @resolution_failures << failure
-                end
-            end
-
-            def register_resolution_failures_from_exception(
-                tasks, exception, message = nil
-            )
+            def register_resolution_failures_from_exception(tasks, exception)
                 tasks = [tasks] unless tasks.kind_of? Array
                 tasks.each do |task|
-                    failures = failures_from_exception(
-                        [task], @plan, @merge_solver, exception, message
-                    )
-                    register_resolution_failures(failures, exception, message)
+                    failures =
+                        failures_from_exception([task], @plan, @merge_solver, exception)
+                    failures.each do |failure|
+                        @resolution_failures << failure
+                    end
                 end
             end
 
@@ -144,12 +143,10 @@ module Syskit
                 indexes
             end
 
-            def failures_from_exception(
-                tasks, plan, merge_solver, exception, message = ""
-            )
+            def failures_from_exception(tasks, plan, merge_solver, exception)
                 tasks.map do |task|
                     NetworkGeneration::InternalResolutionFailure.new(
-                        task, exception, message, merge_solver.dup, plan.dup
+                        task, exception, merge_solver.dup, plan.dup
                     )
                 end
             end
@@ -210,14 +207,8 @@ module Syskit
 
         # A resolution error handler that raises instead of capturing the error
         class RaiseErrorHandler
-            def register_resolution_failures_from_exception(
-                _tasks, exception, message = nil
-            )
-                raise exception, message || ""
-            end
-
-            def register_resolution_failures(_failures, exception, message)
-                raise exception, message || ""
+            def register_resolution_failures_from_exception(_tasks, exception)
+                raise exception
             end
 
             # Noop to satisfy the resolution error handler interface. Should return no

--- a/lib/syskit/network_generation/resolution_error_handler.rb
+++ b/lib/syskit/network_generation/resolution_error_handler.rb
@@ -93,6 +93,7 @@ module Syskit
             def register_resolution_failures_from_exception(
                 tasks, exception, message = nil
             )
+                tasks = [tasks] unless tasks.kind_of? Array
                 tasks.each do |task|
                     failures = failures_from_exception(
                         [task], @plan, @merge_solver, exception, message

--- a/lib/syskit/network_generation/resolution_error_handler.rb
+++ b/lib/syskit/network_generation/resolution_error_handler.rb
@@ -1,0 +1,229 @@
+# frozen_string_literal: true
+
+module Syskit
+    module NetworkGeneration
+        # This collects resolution errors so they can be raised. Useful for testing
+        # contexts, like Syskit::Test::NetworkManipulation.
+        class PartialNetworkResolution < Roby::ExceptionBase
+            def initialize(errors)
+                original_errors = errors.flat_map(&:original_exception)
+                super(original_errors)
+            end
+        end
+
+        # This is used to capture failures during the network generation process. Each
+        # failure bundles the toplevel tasks that are related to the task that originates
+        # the failure. It should be transformed into a ResolutionError for each related
+        # task and propagated.
+        InternalResolutionFailure =
+            Struct.new(:failed_task, :merge_solver, :plan,
+                       :original_exception, :message) do
+                # Constructor for the InternalResolutionFailure.
+                #
+                # Takes an array of toplevel tasks with their index in the toplevel tasks
+                # array. Optionally, one can provide the original exception and the error
+                # message as well.
+                def initialize(
+                    failed_task, original_exception, message, merge_solver, plan
+                )
+                    self.failed_task = failed_task
+                    self.merge_solver = merge_solver
+                    self.plan = plan
+                    self.original_exception = original_exception
+                    self.message = message
+                end
+
+                # Convert to ResolutionError by replacing the requirement of a failed task
+                # with its toplevel version.
+                #
+                # @return [ResolutionError]
+                def to_resolution_errors(instance)
+                    ResolutionError.new(instance, original_exception, message)
+                end
+            end
+
+        # Wraps errors that happened during the network generation and deployment.
+        #
+        # The tasks that relate with wrapped errors are removed from the transaction,
+        # alongside with anything that depend on them.
+        #
+        # This is not meant to be raised, instead it should be propagated using the
+        # execution engine error handling.
+        class ResolutionError
+            attr_reader :planned_task, :planning_task, :original_exception
+
+            def initialize(failed_task, original_exception, message = nil)
+                validate(failed_task)
+
+                original_exception = original_exception.exception(message) if message
+                @original_exception = original_exception
+                @planned_task = failed_task.planned_task
+                @planning_task = failed_task
+            end
+
+            def validate(failed_task)
+                raise ArgumentError, "provided no failed task" unless failed_task
+
+                return if failed_task.planned_task
+
+                raise ArgumentError,
+                      "provided task #{failed_task} has no planned_task"
+            end
+        end
+
+        # Captures resolution failures during the network generation process and process
+        # them into resolution errors. The resolution errors have the necessary
+        # information to propagate the errors in other contexts.
+        class ResolutionErrorHandler
+            # The currently registered failures
+            attr_reader :resolution_failures
+
+            def initialize(plan, merge_solver)
+                @resolution_failures = []
+                @plan = plan
+                @merge_solver = merge_solver
+            end
+
+            def register_resolution_failures(failures, _exception, _message)
+                failures.each do |failure|
+                    @resolution_failures << failure
+                end
+            end
+
+            def register_resolution_failures_from_exception(
+                tasks, exception, message = nil
+            )
+                tasks.each do |task|
+                    failures = failures_from_exception(
+                        [task], @plan, @merge_solver, exception, message
+                    )
+                    register_resolution_failures(failures, exception, message)
+                end
+            end
+
+            # Find the index of the toplevel tasks that depend on the given task
+            #
+            # These tasks are in the work plan. The engine will map them to
+            # the corresponding tasks in the real plan
+            #
+            # @param [Syskit::Component] task the task with are depended by the toplevel
+            #   tasks
+            # @param [Array<Syskit::Component>] toplevel_tasks the list of all the
+            #   toplevel tasks
+            # @param [Roby::Plan] plan the plan on which we are working
+            # @param [NetworkGeneration::MergeSolver] merge_solver the merge solver object
+            #    with records with the task replacements so far
+            # @return [Array<Syskit::Component, Integer>] the list of toplevel tasks
+            #   depending on the given task and their indexes in the provided list of all
+            #   toplevel tasks
+            def find_index_of_toplevel_tasks_depending_on(
+                task, toplevel_tasks, plan, merge_solver
+            )
+                return [] unless toplevel_tasks
+
+                # Build the mapping of the toplevel task into the actual task
+                # in the plan that represents it
+                toplevel_tasks_indexes =
+                    toplevel_tasks
+                    .each_with_index
+                    .group_by { |t, _i| merge_solver.replacement_for(t) }
+                    .transform_values { |v| v.flatten[1] }
+
+                inv_dependency_graph =
+                    plan
+                    .task_relation_graph_for(Roby::TaskStructure::Dependency)
+                    .reverse
+
+                indexes = []
+                inv_dependency_graph.depth_first_visit(task) do |parent|
+                    if (index = toplevel_tasks_indexes[parent])
+                        indexes << index
+                    end
+                end
+                indexes
+            end
+
+            def failures_from_exception(
+                tasks, plan, merge_solver, exception, message = ""
+            )
+                tasks.map do |task|
+                    NetworkGeneration::InternalResolutionFailure.new(
+                        task, exception, message, merge_solver.dup, plan.dup
+                    )
+                end
+            end
+
+            def process_failures(required_instances, cleanup_failed_tasks:)
+                requirement_tasks = required_instances.keys
+                toplevel_tasks = required_instances.values
+
+                resolution_errors = @resolution_failures.flat_map do |failure|
+                    failed_task = failure.failed_task
+                    indexes = find_index_of_toplevel_tasks_depending_on(
+                        failed_task, toplevel_tasks, failure.plan, failure.merge_solver
+                    )
+                    indexes.map do |i|
+                        instance = requirement_tasks[i]
+                        failure.to_resolution_errors(instance)
+                    end
+                end
+
+                if cleanup_failed_tasks
+                    cleanup_resolution_errors(
+                        resolution_errors, required_instances, @plan
+                    )
+                end
+
+                resolution_errors
+            end
+
+            # Cleanup the requirement tasks and toplevel tasks that encountered resolution
+            # failures.
+            #
+            # The resolution errors are used to resolve which tasks should be cleaned up.
+            # Both requirement tasks and toplevel tasks remain one to one mappings of each
+            # other after this operation.
+            def cleanup_resolution_errors(
+                resolution_errors, required_instances, work_plan
+            )
+                cleaned_up = {}
+                resolution_errors.each do |error|
+                    requirement_task = error.planning_task
+                    toplevel_task = required_instances[requirement_task]
+                    if cleaned_up[requirement_task]
+                        # Even if a task have multiple resolution errors, enforce that it
+                        # is only cleaned up once.
+                        next
+                    elsif !toplevel_task
+                        raise "trying to cleanup a requirement task that doesnt have" \
+                              "a top level task assigned to it. Maybe it was already " \
+                              "cleaned up?!"
+                    end
+
+                    required_instances.delete requirement_task
+                    work_plan.remove_task(toplevel_task)
+                    cleaned_up[requirement_task] = toplevel_task
+                end
+            end
+        end
+
+        # A resolution error handler that raises instead of capturing the error
+        class RaiseErrorHandler
+            def register_resolution_failures_from_exception(
+                _tasks, exception, message = nil
+            )
+                raise exception, message || ""
+            end
+
+            def register_resolution_failures(_failures, exception, message)
+                raise exception, message || ""
+            end
+
+            # Noop to satisfy the resolution error handler interface. Should return no
+            # errors, since it raises if any errors happened
+            def process_failures(*)
+                []
+            end
+        end
+    end
+end

--- a/lib/syskit/network_generation/system_network_deployer.rb
+++ b/lib/syskit/network_generation/system_network_deployer.rb
@@ -39,7 +39,6 @@ module Syskit
                 event_logger: plan.event_logger,
                 merge_solver: MergeSolver.new(plan),
                 default_deployment_group: Syskit.conf.deployment_group)
-
                 @plan = plan
                 @event_logger = event_logger
                 @merge_solver = merge_solver
@@ -56,7 +55,8 @@ module Syskit
             #   will run on the generated network
             # @return [Set] the set of tasks for which the deployer could
             #   not find a deployment
-            def deploy(validate: true, reuse_deployments: false, deployment_tasks: {})
+            def deploy(error_handler: RaiseErrorHandler.new, validate: true,
+                reuse_deployments: false, deployment_tasks: {})
                 debug "Deploying the system network"
 
                 all_tasks = plan.find_local_tasks(TaskContext).to_a
@@ -68,7 +68,7 @@ module Syskit
                 log_timepoint "apply_selected_deployments"
 
                 if validate
-                    validate_deployed_network
+                    validate_deployed_network(error_handler: error_handler)
                     log_timepoint "validate_deployed_network"
                 end
 
@@ -204,24 +204,26 @@ module Syskit
             # Sanity checks to verify that the result of #deploy_system_network
             # is valid
             #
-            # @raise [MissingDeployments] if some tasks could not be deployed
-            # @raise [MissingConfigurationSection] if some configuration sections are
-            #   used but do not exist
-            def validate_deployed_network
-                verify_all_tasks_deployed
-                verify_all_configurations_exist
-            end
-
-            def verify_all_tasks_deployed
-                self.class.verify_all_tasks_deployed(plan, default_deployment_group)
+            # @return [Array<ResolutionError>] all the resolution errors of the deployed
+            #   network.
+            def validate_deployed_network(error_handler: RaiseErrorHandler.new)
+                verify_all_tasks_deployed(error_handler: error_handler)
+                verify_all_configurations_exist(error_handler: error_handler)
             end
 
             # Verifies that all tasks in the plan are deployed
             #
-            # @param [Component=>DeploymentGroup] deployment_groups which
-            #   deployment groups has been used for which task. This is used
-            #   to generate the error messages when needed.
-            def self.verify_all_tasks_deployed(plan, default_deployment_group)
+            # @return [Array<ResolutionError>] resolution errors of all the tasks that
+            #   are missing a deployment
+            def verify_all_tasks_deployed(resolution_error_handler)
+                self.class.verify_all_tasks_deployed(
+                    plan, default_deployment_group, resolution_error_handler
+                )
+            end
+
+            def self.verify_all_tasks_deployed(
+                plan, default_deployment_group, error_handler: RaiseErrorHandler.new
+            )
                 not_deployed = plan.find_local_tasks(TaskContext)
                                    .not_finished.not_abstract
                                    .find_all { |t| !t.execution_agent }
@@ -229,7 +231,9 @@ module Syskit
                 return if not_deployed.empty?
 
                 tasks_with_candidates = {}
-                not_deployed.each do |task|
+                # This is reversed to give preference to child tasks, as they contain
+                # more information about the dependency context then their parents
+                not_deployed.reverse_each do |task|
                     candidates = find_all_suitable_deployments_for(
                         default_deployment_group,
                         task
@@ -244,15 +248,21 @@ module Syskit
 
                     tasks_with_candidates[task] = candidates
                 end
-                raise MissingDeployments.new(tasks_with_candidates),
-                      "there are tasks for which it exists no deployed equivalent: " \
-                      "#{not_deployed.map { |m| "#{m}(#{m.orogen_model.name})" }}"
+                tasks_with_candidates.each do |task, candidates|
+                    message =
+                        "#{task}(#{task.orogen_model.name}) has no deployed equivalent"
+                    exception = MissingDeployment.new(task, candidates)
+                    error_handler.register_resolution_failures_from_exception(
+                        [task], exception, message
+                    )
+                end
             end
 
             # Verifies that all selected configuration sections exist
             #
-            # @raise [MissingConfigurationSection]
-            def verify_all_configurations_exist
+            # @return [Array<ResolutionError>] resolution errors of all the tasks that
+            #   are missing a configuration section
+            def verify_all_configurations_exist(error_handler: RaiseErrorHandler.new)
                 tasks = plan.find_local_tasks(TaskContext)
                             .not_finished.not_abstract
 
@@ -273,8 +283,13 @@ module Syskit
 
                 return if missing.empty?
 
-                raise MissingConfigurationSection.new(missing),
-                      "some configuration sections are used but not defined"
+                message = "some configuration sections are used but not defined"
+                missing.each do |task, sections|
+                    exception = MissingConfigurationSection.new(task, sections)
+                    error_handler.register_resolution_failures_from_exception(
+                        [task], exception, message
+                    )
+                end
             end
 
             # Try to resolve a set of deployment candidates for a given task

--- a/lib/syskit/network_generation/system_network_deployer.rb
+++ b/lib/syskit/network_generation/system_network_deployer.rb
@@ -213,14 +213,18 @@ module Syskit
 
             # Verifies that all tasks in the plan are deployed
             #
-            # @return [Array<ResolutionError>] resolution errors of all the tasks that
-            #   are missing a deployment
-            def verify_all_tasks_deployed(resolution_error_handler)
+            # @param [ResolutionErrorHandler | RaiseErrorHandler] error_handler
+            def verify_all_tasks_deployed(error_handler)
                 self.class.verify_all_tasks_deployed(
-                    plan, default_deployment_group, resolution_error_handler
+                    plan, default_deployment_group, error_handler
                 )
             end
 
+            # @see #verify_all_tasks_deployed
+            #
+            # @param [Component=>DeploymentGroup] deployment_groups which
+            #   deployment groups has been used for which task. This is used
+            #   to generate the error messages when needed.
             def self.verify_all_tasks_deployed(
                 plan, default_deployment_group, error_handler: RaiseErrorHandler.new
             )
@@ -231,9 +235,7 @@ module Syskit
                 return if not_deployed.empty?
 
                 tasks_with_candidates = {}
-                # This is reversed to give preference to child tasks, as they contain
-                # more information about the dependency context then their parents
-                not_deployed.reverse_each do |task|
+                not_deployed.each do |task|
                     candidates = find_all_suitable_deployments_for(
                         default_deployment_group,
                         task
@@ -249,12 +251,8 @@ module Syskit
                     tasks_with_candidates[task] = candidates
                 end
                 tasks_with_candidates.each do |task, candidates|
-                    message =
-                        "#{task}(#{task.orogen_model.name}) has no deployed equivalent"
-                    exception = MissingDeployment.new(task, candidates)
-                    error_handler.register_resolution_failures_from_exception(
-                        [task], exception, message
-                    )
+                    e = MissingDeployment.new(task, candidates)
+                    error_handler.register_resolution_failures_from_exception(e.task, e)
                 end
             end
 
@@ -286,8 +284,9 @@ module Syskit
                 message = "some configuration sections are used but not defined"
                 missing.each do |task, sections|
                     exception = MissingConfigurationSection.new(task, sections)
+                    exception = exception.exception(message)
                     error_handler.register_resolution_failures_from_exception(
-                        [task], exception, message
+                        task, exception
                     )
                 end
             end

--- a/lib/syskit/network_generation/system_network_generator.rb
+++ b/lib/syskit/network_generation/system_network_generator.rb
@@ -16,18 +16,24 @@ module Syskit
                         :merge_solver,
                         :default_deployment_group
 
+            # The error handler to register and process resolution errors
+            attr_reader :error_handler
+
             # Indicates if deployment stage happens within network generation
             def early_deploy?
                 @early_deploy
             end
 
-            def initialize(plan,
+            def initialize(plan, # rubocop:disable Metrics/ParameterLists
                 event_logger: plan.event_logger,
                 merge_solver: MergeSolver.new(plan),
                 default_deployment_group: nil,
-                early_deploy: false)
+                early_deploy: false,
+                error_handler: RaiseErrorHandler.new)
                 if merge_solver.plan != plan
-                    raise ArgumentError, "gave #{merge_solver} as merge solver, which applies on #{merge_solver.plan}. Was expecting #{plan}"
+                    raise ArgumentError,
+                          "gave #{merge_solver} as merge solver, which applies on " \
+                          "#{merge_solver.plan}. Was expecting #{plan}"
                 end
 
                 @plan = plan
@@ -35,10 +41,12 @@ module Syskit
                 @merge_solver = merge_solver
                 @default_deployment_group = default_deployment_group
                 @early_deploy = early_deploy
+                @error_handler = error_handler
             end
 
             # Generate the network in the plan
-            # param [bool] validate_deployed_network controls whether or not the
+            #
+            # @param [bool] validate_deployed_network controls whether or not the
             # deployed network is validated, when #early_deploy? is true
             #
             # @return [Hash<Syskit::Component=>Array<InstanceRequirements>>] the
@@ -53,11 +61,13 @@ module Syskit
                 # We first generate a non-deployed network that fits all
                 # requirements.
                 log_timepoint_group "compute_system_network" do
-                    compute_system_network(instance_requirements,
-                                           garbage_collect: garbage_collect,
-                                           validate_abstract_network: validate_abstract_network,
-                                           validate_generated_network: validate_generated_network,
-                                           validate_deployed_network: validate_deployed_network)
+                    compute_system_network(
+                        instance_requirements,
+                        garbage_collect: garbage_collect,
+                        validate_abstract_network: validate_abstract_network,
+                        validate_generated_network: validate_generated_network,
+                        validate_deployed_network: validate_deployed_network
+                    )
                 end
             end
 
@@ -142,10 +152,6 @@ module Syskit
                     end
                 end
                 log_timepoint "device_allocation"
-                Engine.instanciation_postprocessing.each do |block|
-                    block.call(self, plan)
-                    log_timepoint "postprocessing:#{block}"
-                end
                 toplevel_tasks
             end
 
@@ -216,37 +222,40 @@ module Syskit
                                         deployment_tasks: deployment_tasks)
             end
 
-            # Compute in #plan the network needed to fullfill the requirements
-            #
-            # This network is neither validated nor tied to actual deployments
-            def compute_system_network(instance_requirements, garbage_collect: true,
-                validate_abstract_network: true,
-                validate_generated_network: true,
-                validate_deployed_network: true)
-
+            def instanciate_system_network(instance_requirements)
                 @toplevel_tasks = log_timepoint_group "instanciate" do
                     instanciate(instance_requirements)
                 end
-
+                Engine.instanciation_postprocessing.each do |block|
+                    block.call(self, plan)
+                    log_timepoint "postprocessing:#{block}"
+                end
                 @toplevel_instance_requirements = instance_requirements
+                @toplevel_tasks
+            end
 
+            # Compute in #plan the network needed to fullfill the requirements
+            #
+            # This network is neither validated nor tied to actual deployments
+            def resolve_system_network(error_handler: @error_handler,
+                garbage_collect: true,
+                validate_abstract_network: true,
+                validate_generated_network: true,
+                validate_deployed_network: true)
                 deployment_tasks = {}
-
                 deploy(deployment_tasks) if early_deploy?
-
                 merge_solver.merge_identical_tasks
                 log_timepoint "merge"
                 Engine.instanciated_network_postprocessing.each do |block|
                     block.call(self, plan)
                     log_timepoint "postprocessing:#{block}"
                 end
+
                 link_to_busses
                 log_timepoint "link_to_busses"
 
                 deploy(deployment_tasks) if early_deploy?
-
                 merge_solver.merge_identical_tasks
-
                 log_timepoint "merge"
 
                 self.class.remove_abstract_composition_optional_children(plan)
@@ -280,21 +289,52 @@ module Syskit
                 end
                 log_timepoint "postprocessing"
 
+                validate_network(
+                    error_handler: error_handler,
+                    validate_abstract_network: validate_abstract_network,
+                    validate_generated_network: validate_generated_network,
+                    validate_deployed_network:
+                        early_deploy? && validate_deployed_network
+                )
+                @toplevel_tasks
+            end
+
+            # Compute in #plan the network needed to fullfill the requirements
+            #
+            # This network is neither validated nor tied to actual deployments
+            def compute_system_network(instance_requirements,
+                garbage_collect: true,
+                validate_abstract_network: true,
+                validate_generated_network: true,
+                validate_deployed_network: true)
+                error_handler = RaiseErrorHandler.new
+                instanciate_system_network(instance_requirements)
+                resolve_system_network(
+                    error_handler: error_handler,
+                    garbage_collect: garbage_collect,
+                    validate_abstract_network: validate_abstract_network,
+                    validate_generated_network: validate_generated_network,
+                    validate_deployed_network: validate_deployed_network
+                )
+            end
+
+            def validate_network(error_handler: @error_handler,
+                validate_abstract_network: true,
+                validate_generated_network: true,
+                validate_deployed_network: true)
                 if validate_abstract_network
                     self.validate_abstract_network
                     log_timepoint "validate_abstract_network"
                 end
 
                 if validate_generated_network
-                    self.validate_generated_network
+                    self.validate_generated_network(error_handler: error_handler)
                     log_timepoint "validate_generated_network"
                 end
+                return unless early_deploy? && validate_deployed_network
 
-                if early_deploy? && validate_deployed_network
-                    self.validate_deployed_network
-                end
-
-                @toplevel_tasks
+                self.validate_deployed_network(error_handler: error_handler)
+                log_timepoint "validate_deployed_network"
             end
 
             def toplevel_tasks_to_requirements
@@ -304,20 +344,28 @@ module Syskit
                     .each_with_object({}) { |(t, ir), h| (h[t] ||= []) << ir }
             end
 
-            # Verifies that the task allocation is complete
+            # Verifies that the task allocation is complete. Return any
+            # resolution failure.
             #
             # @param [Roby::Plan] plan the plan on which we are working
-            # @raise [TaskAllocationFailed] if some abstract tasks are still in
-            #   the plan
+            # @param [NetworkGeneration::ResolutionErrorHandler] error_handler the error
+            #   handler object to capture or raise any exceptions
+            # @param [Array<Syskit::Component>] components the list of all the abstract
+            #   components
+            # @return [Array] the resolution failures
             def self.verify_task_allocation(
-                plan, components: plan.find_local_tasks(AbstractComponent)
+                plan, error_handler: RaiseErrorHandler.new,
+                components: plan.find_local_tasks(AbstractComponent)
             )
                 still_abstract = components.find_all(&:abstract?)
-                return if still_abstract.empty?
-
-                raise TaskAllocationFailed.new(self, still_abstract),
-                      "could not find implementation for the following abstract " \
-                      "tasks: #{still_abstract}"
+                still_abstract.each do |task|
+                    exception = TaskAllocationFailed.new(self, [task])
+                    error_handler.register_resolution_failures_from_exception(
+                        [task], exception,
+                        "could not find implementation for the following abstract " \
+                        "task: #{task}"
+                    )
+                end
             end
 
             # Verifies that there are no multiple output - single input
@@ -348,36 +396,30 @@ module Syskit
                 end
             end
 
-            # Verifies that all tasks that are device drivers have at least one
-            # device attached, and that the same device is not attached to more
-            # than one task in the plan
+            # Verifies that the same device is not attached to more than one task in the
+            # plan.
             #
-            # @param [Roby::Plan] plan the plan on which we are working
-            # @raise [DeviceAllocationFailed] if some device drivers are not
-            #   attached to any device
-            # @raise [SpecError] if some devices are assigned to more than one
-            #   task
-            def self.verify_device_allocation(plan, toplevel_tasks_to_requirements = {})
-                components = plan.find_local_tasks(Syskit::Device).to_a
-
-                # Check that all devices are properly assigned
-                missing_devices = components.find_all do |t|
-                    t.model.each_master_driver_service
-                     .any? { |srv| !t.find_device_attached_to(srv) }
-                end
-                unless missing_devices.empty?
-                    raise DeviceAllocationFailed.new(plan, missing_devices),
-                          "could not allocate devices for the following tasks: " \
-                          "#{missing_devices}"
-                end
-
+            # @param [Array<Syskit::Component>] components the list of all the abstract
+            #   components
+            # @param [Hash<Syskit::Component, Syskit::InstanceRequirementTask]
+            #   toplevel_tasks_to_requirements mappings of toplevel tasks to their
+            #   instance requirements
+            # @return [Array<InternalResolutionFailure] all resolution failures from the
+            #   components due to a conflicting device allocation
+            def self.verify_conflicting_device_allocation(
+                components, toplevel_tasks_to_requirements = {},
+                error_handler: RaiseErrorHandler.new
+            )
                 devices = {}
                 components.each do |task|
                     task.each_master_device do |dev|
                         device_name = dev.full_name
                         if (old_task = devices[device_name])
-                            raise ConflictingDeviceAllocation.new(
+                            allocation_err = ConflictingDeviceAllocation.new(
                                 dev, task, old_task, toplevel_tasks_to_requirements
+                            )
+                            error_handler.register_resolution_failures_from_exception(
+                                [task, old_task], allocation_err
                             )
                         else
                             devices[device_name] = task
@@ -386,9 +428,51 @@ module Syskit
                 end
             end
 
+            # Verifies that all tasks that are device drivers have at least one
+            # device attached, and that the same device is not attached to more
+            # than one task in the plan. Any resolution failure is stored and return.
+            #
+            # @param [Roby::Plan] plan the plan on which we are working
+            # @param [Array<Syskit::Component>] toplevel_tasks the list of all the
+            #   toplevel tasks
+            # @param [NetworkGeneration::MergeSolver] merge_solver the merge solver object
+            #    with records with the task replacements so far
+            # @param [Hash<Syskit::Component, Syskit::InstanceRequirementTask]
+            #   toplevel_tasks_to_requirements mappings of toplevel tasks to their
+            #   instance requirements
+            # @return [Array<InternalResolutionFailure] all resolution failures from the
+            #   components due to bad device allocation
+            def self.verify_device_allocation(
+                plan, toplevel_tasks_to_requirements = {},
+                error_handler: RaiseErrorHandler.new
+            )
+                components = plan.find_local_tasks(Syskit::Device).to_a
+
+                # Check that all devices are properly assigned
+                missing_devices, allocated_devices = components.partition do |t|
+                    t.model.each_master_driver_service
+                     .any? { |srv| !t.find_device_attached_to(srv) }
+                end
+                missing_devices.each do |driver_task|
+                    allocation_err = DeviceAllocationFailed.new(plan, driver_task)
+                    tasks = allocation_err.task_parents.values.flat_map do |dependency_info|
+                        dependency_info.flat_map do |parent_info|
+                            parent_info[1]
+                        end
+                    end
+                    error_handler.register_resolution_failures_from_exception(
+                        tasks, allocation_err
+                    )
+                end
+
+                verify_conflicting_device_allocation(
+                    allocated_devices, toplevel_tasks_to_requirements,
+                    error_handler: error_handler
+                )
+            end
+
             def self.verify_all_deployments_are_unique(
-                plan,
-                toplevel_tasks_to_requirements
+                plan, toplevel_tasks_to_requirements, error_handler: RaiseErrorHandler.new
             )
                 deployment_to_task_map = plan.find_local_tasks(Syskit::TaskContext)
                                              .group_by(&:orocos_name)
@@ -399,39 +483,52 @@ module Syskit
 
                 return if using_same_deployment.empty?
 
-                raise ConflictingDeploymentAllocation.new(
-                    using_same_deployment, toplevel_tasks_to_requirements
-                ), "there are deployments used multiple times"
+                using_same_deployment.each do |orocos_name, tasks|
+                    exception = ConflictingDeploymentAllocation.new(
+                        orocos_name, tasks, toplevel_tasks_to_requirements
+                    )
+                    error_handler.register_resolution_failures_from_exception(
+                        tasks, exception, "deployment used multiple times"
+                    )
+                end
             end
 
             # Validates the network generated by {#compute_system_network}
             #
             # It performs the tests that are only needed on an abstract network,
             # i.e. on a network in which some tasks are still abstract
-            def validate_abstract_network
+            def validate_abstract_network(error_handler: @error_handler)
                 self.class.verify_no_multiplexing_connections(plan)
                 super if defined? super
             end
 
             # Validates the network generated by {#compute_system_network}
-            def validate_generated_network
-                self.class.verify_task_allocation(plan)
-                self.class.verify_device_allocation(plan, toplevel_tasks_to_requirements)
-                super if defined? super
-            end
+            def validate_generated_network(error_handler: @error_handler)
+                self.class.verify_task_allocation(plan, error_handler: error_handler)
 
-            def validate_deployed_network
-                self.class.verify_all_tasks_deployed(plan, default_deployment_group)
-                self.class.verify_all_deployments_are_unique(
-                    plan, toplevel_tasks_to_requirements.dup
+                self.class.verify_device_allocation(
+                    plan, toplevel_tasks_to_requirements, error_handler: error_handler
                 )
                 super if defined? super
             end
 
-            def self.verify_all_tasks_deployed(plan, default_deployment_group)
+            def validate_deployed_network(error_handler: @error_handler)
+                self.class.verify_all_tasks_deployed(
+                    plan, default_deployment_group, error_handler: error_handler
+                )
+                self.class.verify_all_deployments_are_unique(
+                    plan, toplevel_tasks_to_requirements.dup, error_handler: error_handler
+                )
+                super if defined? super
+            end
+
+            def self.verify_all_tasks_deployed(
+                plan, default_deployment_group, error_handler: RaiseErrorHandler.new
+            )
                 SystemNetworkDeployer.verify_all_tasks_deployed(
                     plan,
-                    default_deployment_group
+                    default_deployment_group,
+                    error_handler: error_handler
                 )
             end
         end

--- a/lib/syskit/network_generation/system_network_generator.rb
+++ b/lib/syskit/network_generation/system_network_generator.rb
@@ -359,11 +359,13 @@ module Syskit
             )
                 still_abstract = components.find_all(&:abstract?)
                 still_abstract.each do |task|
-                    exception = TaskAllocationFailed.new(self, [task])
-                    error_handler.register_resolution_failures_from_exception(
-                        [task], exception,
+                    message =
                         "could not find implementation for the following abstract " \
                         "task: #{task}"
+                    exception = TaskAllocationFailed.new(self, [task])
+                    exception = exception.exception(message)
+                    error_handler.register_resolution_failures_from_exception(
+                        task, exception
                     )
                 end
             end
@@ -483,12 +485,14 @@ module Syskit
 
                 return if using_same_deployment.empty?
 
+                message = "deployment used multiple times"
                 using_same_deployment.each do |orocos_name, tasks|
                     exception = ConflictingDeploymentAllocation.new(
                         orocos_name, tasks, toplevel_tasks_to_requirements
                     )
+                    exception = exception.exception(message)
                     error_handler.register_resolution_failures_from_exception(
-                        tasks, exception, "deployment used multiple times"
+                        tasks, exception
                     )
                 end
             end

--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -134,10 +134,19 @@ module Syskit
                 @early_deploy
             end
 
+            # Whether to capture errors during network resolution instead of raising them.
+            def capture_errors_during_network_resolution?
+                @capture_errors_during_network_resolution
+            end
+
             # Controls where the deployment stage happens
             #
             # @see early_deploy?
             attr_writer :early_deploy
+
+            # Controls whether to capture errors instead of raising them during network
+            # resolution
+            attr_writer :capture_errors_during_network_resolution
 
             # Controls whether the orogen types should be exported as Ruby
             # constants
@@ -173,6 +182,7 @@ module Syskit
                 @register_self_on_name_server = (ENV["SYSKIT_REGISTER_SELF_ON_NAME_SERVER"] != "0")
                 @strict_model_for = false
                 @early_deploy = false
+                @capture_errors_during_network_resolution = false
 
                 @log_rotation_period = nil
                 @log_transfer = LogTransferManager::Configuration.new(

--- a/lib/syskit/runtime/apply_requirement_modifications.rb
+++ b/lib/syskit/runtime/apply_requirement_modifications.rb
@@ -103,24 +103,28 @@ module Syskit
 
                 begin
                     resolution_apply_result = syskit_current_resolution.apply
-                    return unless resolution_apply_result.fulfilled
+
+                    return unless resolution_apply_result
                 ensure
                     syskit_current_resolution_keepalive.discard_transaction
                     @syskit_current_resolution = nil
                 end
 
-                resolution_apply_result.instances.each_key do |t|
-                    t.success_event.emit
+                resolution_apply_result.instance_requirement_tasks.each do |t|
+                    t.resolution_success_event.emit
                 end
-                resolution_apply_result.errors.group_by(&:planning_task).each do |task, e|
-                    task.failed_event.emit e.flat_map(&:original_exception)
+                resolution_apply_result.errors.group_by(&:planning_task).each do |t, e|
+                    t.failed_event.emit(*e.flat_map(&:original_exception)) if t.running?
                 end
-                nil
+                resolution_apply_result
             rescue ::Exception => e # rubocop:disable Lint/RescueException
                 running_requirement_tasks.each do |t|
                     t.failed_event.emit(e)
                 end
-                e
+                NetworkGeneration::SystemNetworkPlanApplyResult.new(
+                    errors: [e],
+                    instance_requirement_tasks: running_requirement_tasks
+                )
             end
         end
 
@@ -150,7 +154,7 @@ module Syskit
             needs_resolution =
                 force || plan.find_tasks(Syskit::InstanceRequirementsTask)
                              .running
-                             .any? { true }
+                             .any? { |t| !t.resolution_success? }
             return unless needs_resolution
 
             requirement_tasks ||= NetworkGeneration::Engine

--- a/lib/syskit/runtime/apply_requirement_modifications.rb
+++ b/lib/syskit/runtime/apply_requirement_modifications.rb
@@ -102,14 +102,18 @@ module Syskit
                     find_tasks(Syskit::InstanceRequirementsTask).running
 
                 begin
-                    return unless syskit_current_resolution.apply
+                    resolution_apply_result = syskit_current_resolution.apply
+                    return unless resolution_apply_result.fulfilled
                 ensure
                     syskit_current_resolution_keepalive.discard_transaction
                     @syskit_current_resolution = nil
                 end
 
-                running_requirement_tasks.each do |t|
+                resolution_apply_result.instances.each_key do |t|
                     t.success_event.emit
+                end
+                resolution_apply_result.errors.group_by(&:planning_task).each do |task, e|
+                    task.failed_event.emit e.flat_map(&:original_exception)
                 end
                 nil
             rescue ::Exception => e # rubocop:disable Lint/RescueException

--- a/lib/syskit/test/instance_requirement_planning_handler.rb
+++ b/lib/syskit/test/instance_requirement_planning_handler.rb
@@ -56,34 +56,47 @@ module Syskit
                 )
             end
 
+            def replace_tasks_for_stub_network(results)
+                root_tasks = results.instance_requirement_tasks.map(&:planned_task)
+                stub_network = StubNetwork.new(@test)
+
+                # NOTE: this is a run-planner equivalent to syskit_stub_network
+                # we will have to investigate whether we could implement one with
+                # the other (probably), but in the meantime we must keep both
+                # in sync
+                mapped_tasks = @plan.in_transaction do |trsc|
+                    mapped_tasks =
+                        stub_network.apply_in_transaction(trsc, root_tasks)
+                    trsc.commit_transaction
+                    mapped_tasks
+                end
+
+                stub_network.announce_replacements(mapped_tasks)
+                stub_network.remove_obsolete_tasks(mapped_tasks)
+            end
+
+            # Consider the resolution finished due to it containing any errors.
+            #
+            # This is only relevant when we arent capturing errors during the network
+            # resolution. When we are capturing errors, the capture pipeline already deals
+            # with the failed task, and can deploy the stub network safely.
+            def consider_finished_due_to_errors?(results)
+                !Syskit.conf.capture_errors_during_network_resolution? && results.error?
+            end
+
             def finished?
                 Thread.pass
 
                 if @plan.syskit_has_async_resolution?
                     return unless @plan.syskit_finished_async_resolution?
 
-                    error = @plan.syskit_apply_async_resolution_results
-                    return true if error
+                    resolution_results = @plan.syskit_apply_async_resolution_results
+                    return true if consider_finished_due_to_errors?(resolution_results)
                     return unless @test.syskit_run_planner_stub?
 
-                    root_tasks = @planning_tasks.map(&:planned_task)
-                    stub_network = StubNetwork.new(@test)
-
-                    # NOTE: this is a run-planner equivalent to syskit_stub_network
-                    # we will have to investigate whether we could implement one with
-                    # the other (probably), but in the meantime we must keep both
-                    # in sync
-                    mapped_tasks = @plan.in_transaction do |trsc|
-                        mapped_tasks =
-                            stub_network.apply_in_transaction(trsc, root_tasks)
-                        trsc.commit_transaction
-                        mapped_tasks
-                    end
-
-                    stub_network.announce_replacements(mapped_tasks)
-                    stub_network.remove_obsolete_tasks(mapped_tasks)
+                    replace_tasks_for_stub_network(resolution_results)
                 end
-                @planning_tasks.all?(&:finished?)
+                @planning_tasks.all? { |t| t.resolution_success? || t.finished? }
             end
 
             # Module that should be included in all classes meant to use the

--- a/lib/syskit/test/network_manipulation.rb
+++ b/lib/syskit/test/network_manipulation.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "roby/standard_errors"
 require "syskit/test/stubs"
 require "syskit/test/stub_network"
 require "syskit/test/instance_requirement_planning_handler"
@@ -160,11 +161,33 @@ module Syskit
                 end
                 task_mapping = plan.in_transaction do |trsc|
                     engine = NetworkGeneration::Engine.new(plan, work_plan: trsc)
-                    mapping = engine.compute_system_network(
+                    planning_tasks = tasks_to_instanciate.map(&:planning_task)
+                    error_handler =
+                        if Syskit.conf.capture_errors_during_network_resolution?
+                            NetworkGeneration::ResolutionErrorHandler.new(
+                                engine.work_plan, engine.merge_solver
+                            )
+                        else
+                            NetworkGeneration::RaiseErrorHandler.new
+                        end
+                    mapping, resolution_errors = engine.compute_system_network(
                         tasks_to_instanciate.map(&:planning_task),
                         validate_generated_network: false,
-                        early_deploy: false
+                        early_deploy: false,
+                        error_handler: error_handler
                     )
+                    unless resolution_errors.empty?
+                        execute do
+                            resolution_errors.each do |error|
+                                t = error.planning_task
+                                next unless t.running?
+
+                                t.failed_event.emit(error.original_exception)
+                            end
+                        end
+
+                        raise NetworkGeneration::PartialNetworkResolution, resolution_errors
+                    end
                     trsc.commit_transaction
                     mapping
                 end
@@ -227,7 +250,7 @@ module Syskit
                     .to { emit(*not_running.map(&:start_event)) }
 
                 resolve_options = Hash[on_error: :commit].merge(resolve_options)
-                begin
+                resolution_errors = begin
                     syskit_engine_resolve_handle_plan_export do
                         syskit_engine ||= Syskit::NetworkGeneration::Engine.new(plan)
                         syskit_engine.resolve(
@@ -236,6 +259,8 @@ module Syskit
                         )
                     end
                 rescue StandardError => e
+                    # The rescue is relevant when the
+                    # capture_errors_during_network_resolution feature flag is off
                     expect_execution do
                         requirement_tasks.each { |t| t.failed_event.emit(e) }
                     end.to do
@@ -246,12 +271,23 @@ module Syskit
                     end
                     raise
                 end
-
-                execute do
-                    placeholder_tasks.each do |task|
-                        plan.remove_task(task)
+                if resolution_errors.empty?
+                    execute do
+                        placeholder_tasks.each do |task|
+                            plan.remove_task(task)
+                        end
+                        requirement_tasks.each do |t|
+                            t.success_event.emit unless t.finished?
+                        end
                     end
-                    requirement_tasks.each { |t| t.success_event.emit unless t.finished? }
+                else
+                    resolution_errors.each do |error|
+                        t = error.planned_task
+                        expect_execution do
+                            t.failed_event.emit(error.original_exception)
+                        end
+                    end
+                    raise NetworkGeneration::PartialNetworkResolution, resolution_errors
                 end
             end
 

--- a/lib/syskit/test/network_manipulation.rb
+++ b/lib/syskit/test/network_manipulation.rb
@@ -171,7 +171,7 @@ module Syskit
                             NetworkGeneration::RaiseErrorHandler.new
                         end
                     mapping, resolution_errors = engine.compute_system_network(
-                        tasks_to_instanciate.map(&:planning_task),
+                        planning_tasks,
                         validate_generated_network: false,
                         early_deploy: false,
                         error_handler: error_handler
@@ -188,6 +188,7 @@ module Syskit
 
                         raise NetworkGeneration::PartialNetworkResolution, resolution_errors
                     end
+
                     trsc.commit_transaction
                     mapping
                 end
@@ -196,7 +197,7 @@ module Syskit
                         replacement = task_mapping[task.planning_task]
                         plan.replace_task(task, replacement)
                         plan.remove_task(task)
-                        replacement.planning_task.success_event.emit
+                        replacement.planning_task.resolution_success_event.emit
                     end
                 end
                 root_tasks.map(&:task)
@@ -277,7 +278,7 @@ module Syskit
                             plan.remove_task(task)
                         end
                         requirement_tasks.each do |t|
-                            t.success_event.emit unless t.finished?
+                            t.resolution_success_event.emit unless t.finished?
                         end
                     end
                 else

--- a/lib/syskit/test/profile_assertions.rb
+++ b/lib/syskit/test/profile_assertions.rb
@@ -341,6 +341,9 @@ module Syskit
                 syskit_run_deploy_in_bulk(
                     actions, compute_policies: false, compute_deployments: false
                 )
+            rescue NetworkGeneration::PartialNetworkResolution => e
+                raise ProfileAssertionFailed.new("configure together", actions,
+                                                 e.original_exceptions)
             rescue Minitest::Assertion, StandardError => e
                 raise ProfileAssertionFailed.new("instanciate together", actions, e),
                       e.message, e.backtrace
@@ -439,6 +442,9 @@ module Syskit
                 syskit_run_deploy_in_bulk(
                     actions, compute_policies: true, compute_deployments: true
                 )
+            rescue NetworkGeneration::PartialNetworkResolution => e
+                raise ProfileAssertionFailed.new("configure together", actions,
+                                                 e.original_exceptions)
             rescue Minitest::Assertion, StandardError => e
                 raise ProfileAssertionFailed.new("deploy together", actions, e),
                       e.message, e.backtrace

--- a/lib/syskit/test/stub_network.rb
+++ b/lib/syskit/test/stub_network.rb
@@ -105,10 +105,13 @@ module Syskit
                 trsc.static_garbage_collect(
                     protected_roots: trsc_new_roots | trsc_other_tasks
                 )
+                error_handler = NetworkGeneration::RaiseErrorHandler.new
                 NetworkGeneration::SystemNetworkGenerator
                     .verify_task_allocation(
-                        trsc, components: trsc_tasks.find_all(&:plan)
+                        trsc, error_handler: error_handler,
+                              components: trsc_tasks.find_all(&:plan)
                     )
+
                 mapped_tasks
             end
 

--- a/test/features/all_features.rb
+++ b/test/features/all_features.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require "test/features/early_deploy"
+require "test/features/capture_errors"

--- a/test/features/capture_errors.rb
+++ b/test/features/capture_errors.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Syskit.conf.capture_errors_during_network_resolution = true

--- a/test/network_generation/test_async.rb
+++ b/test/network_generation/test_async.rb
@@ -68,7 +68,8 @@ module Syskit
                     resolution = subject.prepare(requirements)
                     engine = flexmock(resolution.engine, :strict)
                     engine.should_receive(:resolve_system_network)
-                          .with(requirements, any).once.and_return(ret = flexmock)
+                          .with(requirements, any).once
+                          .and_return(ret = { requirements => [] })
 
                     if RUBY_VERSION >= "2.7"
                         engine.should_receive(:apply_system_network_to_plan).with(ret).once
@@ -89,7 +90,8 @@ module Syskit
                     )
                     engine = flexmock(resolution.engine, :strict)
                     engine.should_receive(:resolve_system_network)
-                          .with(requirements, any).once.and_return(ret = flexmock)
+                          .with(requirements, any).once
+                          .and_return(ret = { requirements => [] })
                     engine.should_receive(:apply_system_network_to_plan)
                           .with(ret, compute_deployments: false).once
                     resolution.execute

--- a/test/network_generation/test_engine.rb
+++ b/test/network_generation/test_engine.rb
@@ -51,14 +51,16 @@ module Syskit
 
                 it "returns running InstanceRequirementsTask tasks" do
                     execute { planning_task.start! }
-                    assert_equal [planning_task], Engine.discover_requirement_tasks_from_plan(plan)
+                    assert_equal [planning_task].to_set,
+                                 Engine.discover_requirement_tasks_from_plan(plan)
                 end
-                it "returns InstanceRequirementsTask tasks that successfully finished" do
+                it "returns InstanceRequirementsTask tasks that finished resolution" do
                     execute do
                         planning_task.start!
-                        planning_task.success_event.emit
+                        planning_task.resolution_success_event.emit
                     end
-                    assert_equal [planning_task], Engine.discover_requirement_tasks_from_plan(plan)
+                    assert_equal [planning_task].to_set,
+                                 Engine.discover_requirement_tasks_from_plan(plan)
                 end
                 it "ignores InstanceRequirementsTask tasks that failed" do
                     execute { planning_task.start! }
@@ -67,15 +69,16 @@ module Syskit
                         have_error_matching Roby::PlanningFailedError.match
                                                                      .with_origin(original_task)
                     end
-                    assert_equal [], Engine.discover_requirement_tasks_from_plan(plan)
+                    assert_equal Set.new, Engine.discover_requirement_tasks_from_plan(plan)
                 end
                 it "ignores InstanceRequirementsTask tasks that are pending" do
-                    assert_equal [], Engine.discover_requirement_tasks_from_plan(plan)
+                    assert_equal Set.new, Engine.discover_requirement_tasks_from_plan(plan)
                 end
                 it "ignores InstanceRequirementsTask tasks whose planned task has finished" do
                     task = syskit_stub_deploy_configure_and_start(simple_component_model)
                     expect_execution { task.stop! }.to { emit task.stop_event }
-                    assert_equal [], Engine.discover_requirement_tasks_from_plan(plan)
+                    assert_equal Set.new,
+                                 Engine.discover_requirement_tasks_from_plan(plan)
                 end
                 it "includes InstanceRequirementsTask tasks whose planned task have finished, but are being repaired" do
                     task = syskit_stub_deploy_configure_and_start(simple_component_model)
@@ -86,7 +89,8 @@ module Syskit
                         task.stop_event.handle_with(repair)
                         repair.start!
                     end.to { emit task.stop_event }
-                    assert_equal [planning_task], Engine.discover_requirement_tasks_from_plan(plan)
+                    assert_equal [planning_task].to_set,
+                                 Engine.discover_requirement_tasks_from_plan(plan)
                 end
             end
 
@@ -298,7 +302,7 @@ module Syskit
             end
 
             describe "when scheduling tasks for reconfiguration" do
-                it "ensures that the old task is gargabe collected " \
+                it "ensures that the old task is garbage collected " \
                    "when child of a composition" do
                     task_m = Syskit::TaskContext.new_submodel
                     cmp_m  = Syskit::Composition.new_submodel
@@ -307,8 +311,11 @@ module Syskit
                     syskit_stub_configured_deployment(task_m)
                     cmp = syskit_deploy(cmp_m)
                     original_task = cmp.test_child
-                    flexmock(task_m).new_instances.should_receive(:can_be_deployed_by?)
-                                    .with(->(proxy) { proxy.__getobj__ == cmp.test_child }).and_return(false)
+                    flexmock(task_m)
+                        .new_instances
+                        .should_receive(:can_be_deployed_by?)
+                        .with(->(proxy) { proxy.__getobj__ == cmp.test_child })
+                        .and_return(false)
                     new_cmp = syskit_deploy(cmp_m)
 
                     # Should have instanciated a new composition since the children
@@ -569,7 +576,7 @@ module Syskit
                     deployed = syskit_deploy(composition_model)
                     # This deregisters the task from the list of requirements in the
                     # syskit engine
-                    execute { plan.remove_task(deployed.planning_task) }
+                    execute { deployed.planning_task.success_event.emit }
 
                     syskit_stub_conf task_model, "non_default"
                     new_deployed = syskit_deploy(
@@ -595,8 +602,9 @@ module Syskit
                     assert_equal [deployed_task.stop_event],
                                  deployed_reconf.start_event.parent_objects(Roby::EventStructure::SyskitConfigurationPrecedence).to_a
                     plan.useful_tasks
-                    assert_equal([planning_task, deployed_task].to_set,
-                                 execute { plan.static_garbage_collect.to_set })
+                    expect_execution.garbage_collect(true).to do
+                        finalize planning_task, deployed_task
+                    end
                     assert(["non_default"], deployed_reconf.conf)
                 end
 
@@ -610,7 +618,8 @@ module Syskit
                     cmp, = syskit_deploy(composition_model.use("child" => task_model))
                     child = cmp.child_child.to_task
                     child.do_not_reuse
-                    execute { plan.remove_task(cmp.planning_task) }
+                    # Deregister the planning task from the list of requirements
+                    execute { cmp.planning_task.success_event.emit }
 
                     new_cmp, = syskit_deploy(composition_model.use("child" => task_model))
                     new_child = new_cmp.child_child

--- a/test/network_generation/test_engine.rb
+++ b/test/network_generation/test_engine.rb
@@ -105,7 +105,7 @@ module Syskit
                     flexmock(requirements).should_receive(:instanciate)
                                           .and_return(instanciated_task = simple_component_model.new)
                     syskit_stub_configured_deployment(simple_component_model)
-                    mapping = syskit_engine.compute_system_network(
+                    mapping, = syskit_engine.compute_system_network(
                         [planning_task],
                         default_deployment_group: default_deployment_group
                     )
@@ -896,6 +896,96 @@ module Syskit
                         mock.should_receive(:call).never
                         plan.add_mission_task(@task_m)
                         syskit_run_planner_with_full_deployment { deploy_current_plan }
+                    end
+                end
+            end
+
+            describe "capture errors during network resolution" do
+                before do
+                    @srv_m = Syskit::DataService.new_submodel
+                    @task_m = Syskit::TaskContext.new_submodel
+                    @task_m.argument :arg
+                    @cmp_m = Syskit::Composition.new_submodel
+                    @cmp_m.add @task_m, as: "test"
+                    @cmp_m.add @srv_m, as: "other"
+                    @deployment_m = syskit_stub_configured_deployment(@task_m, "task1")
+                end
+
+                describe "#resolve_system_network" do
+                    it "capture the errors from the network generator instead of " \
+                       "raising them" do
+                        plan.add(t1 = @cmp_m.as_plan)
+                        _, errors = syskit_engine.resolve_system_network(
+                            [t1.planning_task],
+                            capture_errors_during_network_resolution: true,
+                            default_deployment_group: default_deployment_group,
+                            early_deploy: true
+                        )
+                        assert_equal 1, errors.size
+                        assert_kind_of TaskAllocationFailed,
+                                       errors.first.original_exception
+                    end
+
+                    it "capture the errors from the network deployer instead of " \
+                       "raising them" do
+                        task2_m = Syskit::TaskContext.new_submodel
+                        task2_m.provides @srv_m, as: "srv"
+                        t1 = @cmp_m.use("test" => @task_m.new(arg: 1),
+                                        "other" => task2_m.new).as_plan
+                        plan.add(t1)
+                        _, errors = syskit_engine.resolve_system_network(
+                            [t1.planning_task],
+                            capture_errors_during_network_resolution: true,
+                            default_deployment_group: default_deployment_group,
+                            early_deploy: true
+                        )
+                        assert_equal 1, errors.size
+                        assert_kind_of MissingDeployment,
+                                       errors.first.original_exception
+                    end
+
+                    it "accumulate errors from generator and deployer instead of " \
+                       "raising them" do
+                        not_deployed_task_m = Syskit::TaskContext.new_submodel
+                        not_deployed_task_m.provides @srv_m, as: "srv"
+                        @cmp_m.add @srv_m, as: "yet_another"
+
+                        t1 = @cmp_m.use("other" => not_deployed_task_m.new).as_plan
+                        plan.add(t1)
+                        _, errors = syskit_engine.resolve_system_network(
+                            [t1.planning_task],
+                            capture_errors_during_network_resolution: true,
+                            default_deployment_group: default_deployment_group,
+                            early_deploy: true
+                        )
+                        assert_equal 2, errors.size
+                        assert_kind_of TaskAllocationFailed,
+                                       errors.first.original_exception
+                        assert_kind_of MissingDeployment,
+                                       errors[1].original_exception
+                    end
+
+                    it "goes through the generation for tasks without issues even if " \
+                       "the generation fails for some of them" do
+                        task2_m = Syskit::TaskContext.new_submodel
+                        task2_m.provides @srv_m, as: "srv"
+                        syskit_stub_configured_deployment(task2_m)
+                        t1 = @cmp_m.use("test" => @task_m.new(arg: 1)).as_plan
+                        t2 = @cmp_m.use("test" => @task_m.new(arg: 1),
+                                        "other" => task2_m.new).as_plan
+                        plan.add(t1)
+                        plan.add(t2)
+                        required_instances, errors = syskit_engine.resolve_system_network(
+                            [t1.planning_task, t2.planning_task],
+                            capture_errors_during_network_resolution: true,
+                            default_deployment_group: default_deployment_group,
+                            early_deploy: true
+                        )
+                        assert_equal 1, errors.size
+                        assert_kind_of TaskAllocationFailed,
+                                       errors.first.original_exception
+
+                        assert_equal [t2.planning_task], required_instances.keys
                     end
                 end
             end

--- a/test/network_generation/test_engine.rb
+++ b/test/network_generation/test_engine.rb
@@ -324,8 +324,9 @@ module Syskit
                     # Should have of course created a new task
                     refute_equal new_cmp.test_child, cmp.test_child
                     # And the old tasks should be ready to garbage-collect
-                    assert_equal [cmp, original_task].to_set,
-                                 execute { plan.static_garbage_collect.to_set }
+                    expect_execution.garbage_collect(true).to do
+                        finalize cmp, original_task
+                    end
                 end
 
                 it "ensures that the old task gets garbage collected when child " \
@@ -355,8 +356,9 @@ module Syskit
                     assert_equal new_parent, parent
                     refute_equal new_child, child
                     # And the old tasks should be ready to garbage-collect
-                    assert_equal [child].to_set,
-                                 execute { plan.static_garbage_collect.to_set }
+                    expect_execution.garbage_collect(true).to do
+                        finalize child
+                    end
                 end
 
                 it "ensures that the old task gets garbage collected when child " \
@@ -392,8 +394,9 @@ module Syskit
                     refute_equal new_child, child
                     refute_equal new_child_task, child_task
                     # And the old tasks should be ready to garbage-collect
-                    assert_equal [child, child_task].to_set,
-                                 execute { plan.static_garbage_collect.to_set }
+                    expect_execution.garbage_collect(true).to do
+                        finalize child, child_task
+                    end
                 end
             end
 

--- a/test/network_generation/test_system_network_deployer.rb
+++ b/test/network_generation/test_system_network_deployer.rb
@@ -496,6 +496,24 @@ module Syskit
                         parents = e.parents
                         assert_equal [["test", parent]], parents
                     end
+
+                    it "capture errors instead of raising them" do
+                        error_handler = ResolutionErrorHandler.new(
+                            deployer.plan, deployer.merge_solver
+                        )
+                        task_m = Syskit::TaskContext.new_submodel
+                        d0 = syskit_stub_deployment_model task_m, "task0"
+                        deployer.default_deployment_group
+                                .use_deployment(d0 => "test0_")
+                        deployer.default_deployment_group
+                                .use_deployment(d0 => "test1_")
+
+                        plan.add(parent = task_m.new)
+                        parent.depends_on(task_m.new, role: "test")
+                        deployer.validate_deployed_network(error_handler: error_handler)
+                        assert error_handler.resolution_failures.any? do |f|
+                            f.original_exception.kind_of? MissingDeployment
+                        end
                     end
                 end
 
@@ -538,6 +556,25 @@ module Syskit
                               #{task} (#{task.orogen_model.name})
                         MESSAGE
                         assert_equal expected, PP.pp(e, +"")
+                    end
+
+                    it "capture errors instead of raising them" do
+                        error_handler = ResolutionErrorHandler.new(
+                            deployer.plan, deployer.merge_solver
+                        )
+                        task_m = Syskit::TaskContext.new_submodel
+                        deployment_m.orogen_model.task "task", task_m.orogen_model
+                        plan.add(
+                            deployment = deployment_m.new(
+                                name_mappings: { "task" => "task" }
+                            )
+                        )
+                        plan.add(task = deployment.task("task"))
+                        task.conf = %w[default something]
+                        deployer.validate_deployed_network(error_handler: error_handler)
+                        assert error_handler.resolution_failures.any? do |f|
+                            f.original_exception.kind_of? MissingConfigurationSection
+                        end
                     end
                 end
             end

--- a/test/network_generation/test_system_network_deployer.rb
+++ b/test/network_generation/test_system_network_deployer.rb
@@ -450,7 +450,7 @@ module Syskit
                         task_m = Syskit::TaskContext.new_submodel
                         deployment_m.orogen_model.task "task", task_m.orogen_model
                         plan.add(task_m.new)
-                        assert_raises(MissingDeployments) do
+                        assert_raises(MissingDeployment) do
                             deployer.validate_deployed_network
                         end
                     end
@@ -463,19 +463,20 @@ module Syskit
                         deployer.default_deployment_group
                                 .use_deployment(d0 => "test1_")
 
-                        plan.add(task = task_m.new)
-                        e = assert_raises(MissingDeployments) do
+                        plan.add(task_m.new)
+                        e = assert_raises(MissingDeployment) do
                             deployer.validate_deployed_network
                         end
 
-                        info = e.tasks[task]
-                        assert_equal [], info[0] # parents
-                        candidates = info[1]
+                        parents = e.parents
+                        assert_equal [], parents
+                        candidates = e.candidates
+                        hints = e.deployment_hints
                         assert_equal [d0, d0],
                                      candidates.map { |c, _| c.configured_deployment.model }
                         assert_equal %w[test0_task0 test1_task0],
                                      candidates.map { |c, _| c.mapped_task_name }
-                        assert_equal Set[], info[2]
+                        assert_equal Set[], hints
                     end
 
                     it "snapshots the task's parents at the exception point" do
@@ -487,13 +488,14 @@ module Syskit
                                 .use_deployment(d0 => "test1_")
 
                         plan.add(parent = task_m.new)
-                        parent.depends_on(task = task_m.new, role: "test")
-                        e = assert_raises(MissingDeployments) do
+                        parent.depends_on(task_m.new, role: "test")
+                        e = assert_raises(MissingDeployment) do
                             deployer.validate_deployed_network
                         end
 
-                        info = e.tasks[task]
-                        assert_equal [["test", parent]], info[0] # parents
+                        parents = e.parents
+                        assert_equal [["test", parent]], parents
+                    end
                     end
                 end
 
@@ -512,8 +514,8 @@ module Syskit
                             deployer.validate_deployed_network
                         end
                         assert_equal(
-                            { task => ["something"] },
-                            e.missing_sections_by_task
+                            ["something"],
+                            e.missing_sections
                         )
                     end
 

--- a/test/network_generation/test_system_network_deployer.rb
+++ b/test/network_generation/test_system_network_deployer.rb
@@ -480,15 +480,18 @@ module Syskit
                     end
 
                     it "snapshots the task's parents at the exception point" do
-                        task_m = Syskit::TaskContext.new_submodel
-                        d0 = syskit_stub_deployment_model task_m, "task0"
+                        parent_m = Syskit::TaskContext.new_submodel
+                        child_m = Syskit::TaskContext.new_submodel
+                        parent_d = syskit_stub_deployment_model parent_m, "task0"
+                        child_d = syskit_stub_deployment_model child_m, "task1"
                         deployer.default_deployment_group
-                                .use_deployment(d0 => "test0_")
+                                .use_deployment(child_d => "test0_")
                         deployer.default_deployment_group
-                                .use_deployment(d0 => "test1_")
+                                .use_deployment(child_d => "test1_")
 
-                        plan.add(parent = task_m.new)
-                        parent.depends_on(task_m.new, role: "test")
+                        plan.add(parent_d_task = parent_d.new)
+                        plan.add(parent = parent_d_task.task("task0"))
+                        parent.depends_on(child_m.new, role: "test")
                         e = assert_raises(MissingDeployment) do
                             deployer.validate_deployed_network
                         end

--- a/test/network_generation/test_system_network_generator.rb
+++ b/test/network_generation/test_system_network_generator.rb
@@ -220,6 +220,251 @@ module Syskit
                         end
                     end
                 end
+
+                describe "resolve_system_network with error capture" do
+                    attr_reader :error_handler, :generator
+
+                    before do
+                        Syskit.conf.capture_errors_during_network_resolution = true
+                    end
+
+                    after do
+                        Syskit.conf.capture_errors_during_network_resolution = false
+                    end
+
+                    it "capture errors regarding device allocation conflicts" do
+                        device_m = Device.new_submodel(name: "D")
+                        task_m = TaskContext.new_submodel(name: "T")
+                        task_m.argument :arg
+                        task_m.driver_for device_m, as: "test"
+                        robot = Robot::RobotDefinition.new
+                        robot.device device_m, as: "test"
+                        cmp_m = Syskit::Composition.new_submodel
+                        cmp_m.add task_m.new(arg: 1), as: "t1"
+                        cmp_m.add task_m.new(arg: 2), as: "t2"
+                        t1 = cmp_m
+                             .use("t1" => task_m.new(arg: 1, test_dev: robot.test_dev),
+                                  "t2" => task_m.new(arg: 2, test_dev: robot.test_dev))
+                             .as_plan
+                        plan.add(t1)
+                        generator = make_generator
+                        requirement_tasks = [t1.planning_task]
+                        toplevel_tasks, errors = resolve_system_network(requirement_tasks)
+
+                        errors = assert_relevant_errors(
+                            errors, ConflictingDeviceAllocation, size: 2
+                        )
+
+                        expected_message = <<~PP
+                            device 'test' of type D is assigned to two tasks that cannot be merged
+                            Chain 1 cannot be merged in chain 2:
+                            Chain 1:
+                              T<id:X>
+                                no owners
+                                arguments:
+                                  arg: 2,
+                                  test_dev: MasterDeviceInstance(test[D]_dev),
+                                  conf: ["default"],
+                                  read_only: false
+                            Chain 2:
+                              T<id:X>
+                                no owners
+                                arguments:
+                                  arg: 1,
+                                  test_dev: MasterDeviceInstance(test[D]_dev),
+                                  conf: ["default"],
+                                  read_only: false
+                            T<id:X>(arg: 2, conf: ["default"], read_only: false, test_dev: device(D, as: test)) is needed by the following definitions:
+                              #<Class:0xXXXXXX>.use(t1 => T<id:X>(arg: 1, conf: ["default"], read_only: false, test_dev: device(D, as: test)), t2 => T<id:X>(arg: 2, conf: ["default"], read_only: false, test_dev: device(D, as: test)))
+                            T<id:X>(arg: 1, conf: ["default"], read_only: false, test_dev: device(D, as: test)) is needed by the following definitions:
+                              #<Class:0xXXXXXX>.use(t1 => T<id:X>(arg: 1, conf: ["default"], read_only: false, test_dev: device(D, as: test)), t2 => T<id:X>(arg: 2, conf: ["default"], read_only: false, test_dev: device(D, as: test)))
+                        PP
+                        errors.each do |err|
+                            assert_exception(err, requirement_tasks.first.planned_task,
+                                             expected_message)
+                        end
+                    end
+
+                    it "capture errors regarding missing device allocation" do
+                        srv_m = Syskit::DataService.new_submodel
+                        device_m = Device.new_submodel(name: "D")
+                        device_m.provides srv_m
+
+                        task_m = TaskContext.new_submodel(name: "T")
+                        task_m.argument :arg
+                        task_m.driver_for device_m, as: "test"
+                        cmp_m = Syskit::Composition.new_submodel
+                        cmp_m.add task_m.new(arg: 1), as: "task"
+
+                        plan.add(task1 = cmp_m.as_plan)
+                        generator = make_generator
+                        requirement_tasks = [task1.planning_task]
+                        toplevel_tasks, errors = resolve_system_network(requirement_tasks)
+
+                        error =
+                            assert_relevant_errors(errors, DeviceAllocationFailed).first
+                        expected_message = <<~MSG
+                            cannot find a device to tie to a task
+                            for T<id:X>(arg: 1, conf: ["default"], read_only: false)
+                              child task of <id:X>(conf: [])
+                              no candidates for T:test
+                        MSG
+                        assert_exception(error, requirement_tasks.first.planned_task,
+                                         expected_message)
+                    end
+
+                    it "capture errors related to task allocation" do
+                        srv_m = Syskit::DataService.new_submodel
+                        cmp_m = Syskit::Composition.new_submodel
+                        cmp_m.add srv_m, as: "task"
+
+                        plan.add(task1 = cmp_m.as_plan)
+                        generator = make_generator
+                        requirement_tasks = [task1.planning_task]
+                        toplevel_tasks, errors = resolve_system_network(
+                            requirement_tasks, garbage_collect: false
+                        )
+
+                        error = assert_relevant_errors(errors, TaskAllocationFailed).first
+                        expected_message = <<~MSG
+                            cannot find a concrete implementation for 1 task(s)
+                            Models::Placeholder<#<#<Class:0xXXXXXX>:0xXXXXXX>><id:X>()
+                              no candidates
+                              child task of <id:X>(conf: [])
+                        MSG
+                        assert_exception(error, requirement_tasks.first.planned_task,
+                                         expected_message)
+                    end
+
+                    it "capture errors related to missing deployments" do
+                        skip unless Syskit.conf.early_deploy?
+
+                        task_m = Syskit::TaskContext.new_submodel(name: "T")
+                        task_m.argument :arg
+
+                        cmp_m = Syskit::Composition.new_submodel
+                        cmp_m.add task_m.new(arg: 1), as: "task"
+
+                        plan.add(task1 = cmp_m.as_plan)
+                        generator = make_generator
+
+                        generator.merge_solver
+                                 .merge_task_contexts_with_same_agent = true
+                        requirement_tasks = [task1.planning_task]
+                        toplevel_tasks, errors = resolve_system_network(requirement_tasks)
+
+                        expected_message = <<~MSG
+                            cannot deploy the following task
+                            T<id:X>(arg: 1, conf: ["default"], read_only: false) ()
+                              child task of <id:X>(conf: [])
+                            T<id:X>(arg: 1, conf: ["default"], read_only: false): no deployments available
+                        MSG
+                        error = assert_relevant_errors(errors, MissingDeployment).first
+                        assert_exception(error, requirement_tasks.first.planned_task,
+                                         expected_message)
+                    end
+
+                    it "capture errors related to conflicting deployment allocations" do
+                        skip unless Syskit.conf.early_deploy?
+
+                        task_m = Syskit::TaskContext.new_submodel(name: "T")
+                        task_m.argument :arg
+
+                        cmp_m = Syskit::Composition.new_submodel
+                        cmp_m.add task_m, as: "task"
+
+                        syskit_stub_configured_deployment(task_m, "task1")
+
+                        task1 = cmp_m.use("task" => task_m.with_arguments(arg: 1)).as_plan
+                        task2 = cmp_m.use("task" => task_m.with_arguments(arg: 2)).as_plan
+                        plan.add(task1)
+                        plan.add(task2)
+                        generator = make_generator
+
+                        generator.merge_solver
+                                 .merge_task_contexts_with_same_agent = true
+                        requirement_tasks = [task1, task2].map(&:planning_task)
+                        toplevel_tasks, errors = resolve_system_network(requirement_tasks)
+
+                        errors = assert_relevant_errors(
+                            errors, ConflictingDeploymentAllocation, size: 2
+                        )
+
+                        expected_message = <<~MSG
+                            deployed task 'task1' from deployment 'task1' defined in '' on 'stubs' is assigned to 2 tasks. Below is the list of the dependent non-deployed actions. Right after the list is a detailed explanation of why the first two tasks are not merged:
+                            Chain 1 cannot be merged in chain 2:
+                            Chain 1:
+                              T<id:X>
+                                no owners
+                                arguments:
+                                  orocos_name: "task1",
+                                  read_only: false,
+                                  conf: ["default"],
+                                  arg: 1
+                            Chain 2:
+                              T<id:X>
+                                no owners
+                                arguments:
+                                  orocos_name: "task1",
+                                  read_only: false,
+                                  conf: ["default"],
+                                  arg: 2
+                        MSG
+                        errors.zip(requirement_tasks).each do |error, task|
+                            assert_exception(error, task.planned_task, expected_message)
+                        end
+                    end
+
+                    def assert_exception(error, expected_task, expected_message)
+                        assert_equal expected_task, error.planned_task
+
+                        exception = error.original_exception
+                        formatted = PP.pp(exception, +"")
+                        assert_equal expected_message,
+                                     formatted.gsub(/<id:\d+>/, "<id:X>")
+                                              .gsub(/Class:0x[0-9a-f]+>:0x[0-9a-f]+>/,
+                                                    "Class:0xXXXXXX>:0xXXXXXX>")
+                                              .gsub(/Class:0x[0-9a-f]+/, "Class:0xXXXXXX")
+                    end
+
+                    def resolve_system_network(requirement_tasks, garbage_collect: true)
+                        instance_requirements = requirement_tasks.map(&:requirements)
+                        toplevel_tasks, errors = execute do
+                            toplevel_tasks = generator.instanciate_system_network(
+                                instance_requirements
+                            )
+                            generator.resolve_system_network(
+                                garbage_collect: garbage_collect
+                            )
+                            required_instances =
+                                Hash[requirement_tasks.zip(toplevel_tasks)]
+                            errors = error_handler.process_failures(
+                                required_instances, cleanup_failed_tasks: true
+                            )
+                            [toplevel_tasks, errors]
+                        end
+                    end
+
+                    def assert_relevant_errors(errors, error_type, size: 1)
+                        errors = errors.find_all do |e|
+                            e.original_exception.kind_of? error_type
+                        end
+                        assert_equal size, errors.size
+                        errors
+                    end
+
+                    def make_generator
+                        work_plan = Roby::Transaction.new(plan)
+                        @merge_solver = MergeSolver.new(work_plan)
+                        @error_handler =
+                            ResolutionErrorHandler.new(work_plan, @merge_solver)
+                        @generator = SystemNetworkGenerator.new(
+                            work_plan,
+                            error_handler: error_handler,
+                            merge_solver: @merge_solver,
+                            early_deploy: Syskit.conf.early_deploy?,
+                            default_deployment_group: default_deployment_group
+                        )
                     end
                 end
             end

--- a/test/network_generation/test_system_network_generator.rb
+++ b/test/network_generation/test_system_network_generator.rb
@@ -210,7 +210,7 @@ module Syskit
 
                         local_net_gen.merge_solver
                                      .merge_task_contexts_with_same_agent = true
-                        e = assert_raises(MissingDeployments) do
+                        e = assert_raises(MissingDeployment) do
                             local_net_gen.compute_system_network(
                                 [task_m.to_instance_requirements,
                                  task_m.to_instance_requirements
@@ -218,8 +218,8 @@ module Syskit
                                 validate_deployed_network: true
                             )
                         end
-
-                        assert_equal 1, e.tasks.size
+                    end
+                end
                     end
                 end
             end

--- a/test/runtime/test_apply_requirement_modifications.rb
+++ b/test/runtime/test_apply_requirement_modifications.rb
@@ -121,7 +121,8 @@ module Syskit
                 refute plan.syskit_current_resolution
             end
 
-            it "applies the computed network and emits the planning task's success event" do
+            it "applies the computed network and emits the planning task's resolution " \
+               "success event" do
                 cmp_m = Composition.new_submodel
                 plan.add_permanent_task(requirement_task = cmp_m.to_instance_requirements.as_plan)
                 requirement_task = requirement_task.planning_task
@@ -129,7 +130,7 @@ module Syskit
                 execute { Runtime.apply_requirement_modifications(plan) }
                 plan.syskit_current_resolution.future.value
                 execute { Runtime.apply_requirement_modifications(plan) }
-                assert requirement_task.success?
+                assert requirement_task.resolution_success?
             end
 
             it "applies the computed network and emits the planning task's failed " \
@@ -182,17 +183,17 @@ module Syskit
 
                     req_task1, req_task2 = requirement_tasks
 
-                    assert req_task2.success?
+                    assert req_task2.resolution_success?
 
                     assert req_task1.failed?
-                    exceptions = req_task1.failed_event.last.context.first
+                    exceptions = req_task1.failed_event.last.context
                     assert_equal 1, exceptions.size
                     assert_kind_of Syskit::MissingDeployment, exceptions.first
                     assert_exception_can_be_pretty_printed(exceptions.first)
                 end
 
-                it "applies the computed network and emits the planning task's success " \
-                   "event" do
+                it "applies the computed network and emits the planning task's " \
+                   "resolution success event" do
                     cmp_m = Composition.new_submodel
                     requirement_task = cmp_m.to_instance_requirements.as_plan
                     plan.add_permanent_task(requirement_task)
@@ -201,7 +202,7 @@ module Syskit
                     execute { Runtime.apply_requirement_modifications(plan) }
                     plan.syskit_current_resolution.future.value
                     execute { Runtime.apply_requirement_modifications(plan) }
-                    assert requirement_task.success?
+                    assert requirement_task.resolution_success?
                 end
             end
 

--- a/test/runtime/test_apply_requirement_modifications.rb
+++ b/test/runtime/test_apply_requirement_modifications.rb
@@ -5,6 +5,17 @@ require "syskit/test/self"
 module Syskit
     module Runtime
         describe ".apply_requirement_modifications" do
+            before do
+                @__capture_errors_feature_flag =
+                    Syskit.conf.capture_errors_during_network_resolution?
+                Syskit.conf.capture_errors_during_network_resolution = false
+            end
+
+            after do
+                Syskit.conf.capture_errors_during_network_resolution =
+                    @__capture_errors_feature_flag
+            end
+
             it "does nothing by default" do
                 Runtime.apply_requirement_modifications(plan)
                 refute plan.syskit_current_resolution
@@ -139,6 +150,59 @@ module Syskit
                     requirement_task.failed_event.last.context.first
                 )
             end
+
+            describe "capture_errors" do
+                before do
+                    @__capture_errors_feature_flag =
+                        Syskit.conf.capture_errors_during_network_resolution?
+                    Syskit.conf.capture_errors_during_network_resolution = true
+                end
+
+                after do
+                    Syskit.conf.capture_errors_during_network_resolution =
+                        @__capture_errors_feature_flag
+                end
+
+                it "applies the computed network for the well-defined instance tasks " \
+                   "and fails with an error for badly-defined instance tasks" do
+                    task_m = TaskContext.new_submodel
+                    cmp_m = Composition.new_submodel
+                    req_task1 =
+                        plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
+                    req_task2 =
+                        plan.add_permanent_task(cmp_m.to_instance_requirements.as_plan)
+                    requirement_tasks = [req_task1, req_task2].map(&:planning_task)
+                    execute do
+                        requirement_tasks.each(&:start!)
+                    end
+                    execute { Runtime.apply_requirement_modifications(plan) }
+                    plan.syskit_current_resolution.future.value
+                    expect_execution { Runtime.apply_requirement_modifications(plan) }
+                        .to { have_error_matching Roby::PlanningFailedError }
+
+                    req_task1, req_task2 = requirement_tasks
+
+                    assert req_task2.success?
+
+                    assert req_task1.failed?
+                    exceptions = req_task1.failed_event.last.context.first
+                    assert_equal 1, exceptions.size
+                    assert_kind_of Syskit::MissingDeployment, exceptions.first
+                    assert_exception_can_be_pretty_printed(exceptions.first)
+                end
+
+                it "applies the computed network and emits the planning task's success " \
+                   "event" do
+                    cmp_m = Composition.new_submodel
+                    requirement_task = cmp_m.to_instance_requirements.as_plan
+                    plan.add_permanent_task(requirement_task)
+                    requirement_task = requirement_task.planning_task
+                    execute { requirement_task.start! }
+                    execute { Runtime.apply_requirement_modifications(plan) }
+                    plan.syskit_current_resolution.future.value
+                    execute { Runtime.apply_requirement_modifications(plan) }
+                    assert requirement_task.success?
+                end
             end
 
             def assert_resolution_cancelled # rubocop:disable Metrics/AbcSize

--- a/test/runtime/test_apply_requirement_modifications.rb
+++ b/test/runtime/test_apply_requirement_modifications.rb
@@ -121,9 +121,11 @@ module Syskit
                 assert requirement_task.success?
             end
 
-            it "applies the computed network and emits the planning task's failed event if it raises" do
+            it "applies the computed network and emits the planning task's failed " \
+               "event if it raises" do
                 task_m = TaskContext.new_submodel
-                requirement_task = plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
+                requirement_task =
+                    plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
                 requirement_task = requirement_task.planning_task
                 execute { requirement_task.start! }
                 execute { Runtime.apply_requirement_modifications(plan) }
@@ -131,8 +133,12 @@ module Syskit
                 expect_execution { Runtime.apply_requirement_modifications(plan) }
                     .to { have_error_matching Roby::PlanningFailedError }
                 assert requirement_task.failed?
-                assert_kind_of Syskit::MissingDeployments, requirement_task.failed_event.last.context.first
-                assert_exception_can_be_pretty_printed(requirement_task.failed_event.last.context.first)
+                exception = requirement_task.failed_event.last.context.first
+                assert_kind_of Syskit::MissingDeployment, exception
+                assert_exception_can_be_pretty_printed(
+                    requirement_task.failed_event.last.context.first
+                )
+            end
             end
 
             def assert_resolution_cancelled # rubocop:disable Metrics/AbcSize

--- a/test/test/test_network_manipulation.rb
+++ b/test/test/test_network_manipulation.rb
@@ -387,7 +387,7 @@ module Syskit
                 end
 
                 it "fails if the plan can't be deployed" do
-                    plan.add_mission_task(@cmp_m.use("srv" => @task_m).as_plan)
+                    plan.add_mission_task(@cmp_m.as_plan)
                     assert_raises(Roby::Test::ExecutionExpectations::UnexpectedErrors) do
                         deploy_current_plan
                     end

--- a/test/test/test_network_manipulation.rb
+++ b/test/test/test_network_manipulation.rb
@@ -233,13 +233,23 @@ module Syskit
                     assert_equal "test_level", task.orocos_name
                 end
 
-                it "on error, it changes the planning failed and mission failed " \
+                it "on error, it filters out the planning failed and mission failed " \
                    "error caused by itself" do
                     task_m = Syskit::TaskContext.new_submodel
                     assert_raises(Syskit::MissingDeployment) do
                         syskit_deploy(task_m)
                     end
                 end
+
+                it "when capturing errors, it changes the planning failed error into a" \
+                   "PartialNetworkResolution" do
+                    before_flag = Syskit.conf.capture_errors_during_network_resolution?
+                    Syskit.conf.capture_errors_during_network_resolution = true
+                    task_m = Syskit::TaskContext.new_submodel
+                    assert_raises(Syskit::NetworkGeneration::PartialNetworkResolution) do
+                        syskit_deploy(task_m)
+                    end
+                    Syskit.conf.capture_errors_during_network_resolution = before_flag
                 end
             end
 
@@ -377,7 +387,7 @@ module Syskit
                 end
 
                 it "fails if the plan can't be deployed" do
-                    plan.add_mission_task(@cmp_m.as_plan)
+                    plan.add_mission_task(@cmp_m.use("srv" => @task_m).as_plan)
                     assert_raises(Roby::Test::ExecutionExpectations::UnexpectedErrors) do
                         deploy_current_plan
                     end

--- a/test/test/test_network_manipulation.rb
+++ b/test/test/test_network_manipulation.rb
@@ -233,12 +233,13 @@ module Syskit
                     assert_equal "test_level", task.orocos_name
                 end
 
-                it "on error, it filters out the planning failed and mission failed " \
+                it "on error, it changes the planning failed and mission failed " \
                    "error caused by itself" do
                     task_m = Syskit::TaskContext.new_submodel
-                    assert_raises(MissingDeployments) do
+                    assert_raises(Syskit::MissingDeployment) do
                         syskit_deploy(task_m)
                     end
+                end
                 end
             end
 

--- a/test/test/test_profile_assertions.rb
+++ b/test/test/test_profile_assertions.rb
@@ -524,7 +524,7 @@ module Syskit
                     end
 
                     assert_match(
-                        /cannot deploy the following tasks.*Task.*child test of Cmp/m,
+                        /cannot deploy the following task.*Task.*child test of Cmp/m,
                         PP.pp(e.each_original_exception.first, +"")
                     )
                 end
@@ -665,8 +665,8 @@ module Syskit
                     end
 
                     assert_match(
-                        /cannot deploy the following tasks.*Task.*child test of Cmp/m,
-                        PP.pp(e.each_original_exception.first, +"")
+                        /cannot deploy the following task.*Task.*child test of Cmp/m,
+                        PP.pp(e.original_exceptions.first, +"")
                     )
                 end
 

--- a/test/test_exceptions.rb
+++ b/test/test_exceptions.rb
@@ -71,9 +71,16 @@ module Syskit
                    .use("test" => robot.test_dev.with_arguments(arg: 2))
 
             self.syskit_run_planner_validate_network = true
-            e = assert_raises(ConflictingDeviceAllocation) do
-                run_planners([profile.test1_def, profile.test2_def])
-            end
+            e = if Syskit.conf.capture_errors_during_network_resolution?
+                    expect_execution do
+                        run_planners([profile.test1_def, profile.test2_def])
+                    end.to { have_error_matching Roby::PlanningFailedError.match }
+                        .exception.original_exceptions.first
+                else
+                    assert_raises(ConflictingDeviceAllocation) do
+                        run_planners([profile.test1_def, profile.test2_def])
+                    end
+                end
 
             formatted = PP.pp(e, +"")
             expected = <<~PP.chomp

--- a/test/test_instance_requirements_task.rb
+++ b/test/test_instance_requirements_task.rb
@@ -74,7 +74,7 @@ describe Syskit::InstanceRequirementsTask do
         assert !resolution.transaction_committed?
     end
 
-    it "finishes successfully if the network resolution succeeds" do
+    it "emits resolution success if the network resolution succeeds" do
         cmp_m = Syskit::Composition.new_submodel
         task = plan.add_permanent_task(cmp_m.as_plan)
         req_task = task.planning_task
@@ -82,10 +82,10 @@ describe Syskit::InstanceRequirementsTask do
         capture_syskit_current_resolution { |r| resolution = r }
 
         expect_execution { req_task.start! }
-            .to { emit req_task.success_event }
+            .to { emit req_task.resolution_success_event }
         assert resolution.transaction_finalized?
         assert resolution.transaction_committed?
-        assert req_task.success?
+        assert req_task.resolution_success?
     end
 
     describe ".subplan" do


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-gazebo/drivers-transformer/pull/13

We introduced a ResolutionError to mark errors during the new plan
network resolution shouldnt be raised, which causes the whole transation
to fail. Instead, we capture them and fail the deployment of the
specific tasks that caused them.

