### PR TITLE
feat: use rock_time_field when logging

### DIFF
--- a/lib/syskit/network_generation/logger.rb
+++ b/lib/syskit/network_generation/logger.rb
@@ -26,6 +26,20 @@ module Syskit
                 false
             end
 
+            def logical_time_field(type)
+                return unless type < Typelib::CompoundType
+
+                metadata = type.field_metadata
+                type.each_field do |field|
+                    next unless metadata[field].include?("role")
+
+                    role = metadata[field].get("role").first
+
+                    return field if role == "logical_time"
+                end
+                nil
+            end
+
             # Wrapper on top of the createLoggingPort operation
             #
             # @param [String] sink_port_name the desired port name on the logger
@@ -40,6 +54,13 @@ module Syskit
                     "rock_task_name" => logged_task.orocos_name,
                     "rock_task_object_name" => logged_port.name,
                     "rock_stream_type" => "port"]
+
+                type_logical_time_field = logical_time_field(
+                    Orocos.default_loader.intermediate_type_for(logged_port_type)
+                )
+                if type_logical_time_field
+                    metadata["rock_time_field"] = type_logical_time_field
+                end
                 metadata = metadata.map do |k, v|
                     Hash["key" => k, "value" => v]
                 end

--- a/lib/syskit/network_generation/logger.rb
+++ b/lib/syskit/network_generation/logger.rb
@@ -59,7 +59,7 @@ module Syskit
                     Orocos.default_loader.intermediate_type_for(logged_port_type)
                 )
                 if type_logical_time_field
-                    metadata["rock_time_field"] = type_logical_time_field
+                    metadata["rock_timestamp_field"] = type_logical_time_field
                 end
                 metadata = metadata.map do |k, v|
                     Hash["key" => k, "value" => v]

--- a/test/live/test_logger_logical_time.rb
+++ b/test/live/test_logger_logical_time.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+using_task_library "orogen_syskit_tests"
+
+module Syskit
+    # Provide an alias for the RockLogger is set to the logger model in orogen/logger.rb
+    # as OroGen.logger is taken (can't access through OroGen.logger.LoggerTask)
+    RockLogger = OroGen.syskit_model_by_orogen_name("logger::Logger")
+end
+
+Syskit.extend_model Syskit::RockLogger do
+    provides Syskit::LoggerService
+    include Syskit::NetworkGeneration::LoggerConfigurationSupport
+
+    def update_properties
+        super
+
+        properties.overwrite_existing_files = false
+        properties.auto_timestamp_files = false
+    end
+end
+
+module Syskit
+    class LogicalTimeLoggingTest < Syskit::Test::ComponentTest
+        run_live
+
+        attr_reader :task
+
+        before do
+            Syskit.conf.logs.enable_port_logging
+            @task = syskit_deploy(
+                OroGen.orogen_syskit_tests.LogicalTimeLoggingTest
+                    .deployed_as("logical_time_logging_test")
+            )
+
+            @timestamp = Time.at(1234)
+            @task.properties.test_type_timestamp = @timestamp
+        end
+
+        after do
+            Syskit.conf.logs.disable_port_logging
+        end
+
+        it "logs the correct logical time field value and metadata" do
+            syskit_configure_and_start(@task)
+            logger = plan.find_tasks(Syskit::RockLogger).first
+            logfile_path = File.join(Roby.app.log_dir, "logical_time_field.0.log")
+            logger.properties.file = logfile_path
+            syskit_configure_and_start(logger)
+
+            expect_execution.to do
+                have_one_new_sample(task.out_port)
+                    .matching { |s| s.timestamp == Time.at(1234) }
+            end
+
+            syskit_stop(@task)
+            syskit_stop(logger)
+
+            file = Pocolog::Logfiles.open(logfile_path)
+            file.stream("logical_time_logging_test.out").samples.each do |_, lg, _|
+                assert_equal @timestamp, lg
+            end
+        end
+    end
+end


### PR DESCRIPTION
Depends on:
 - [ ] https://github.com/rock-core/tools-orogen_syskit_tests/pull/7

Rock's logger already can use a field [to save in the logical time of the stream](https://github.com/rock-core/tools-logger/blob/master/tasks/Logger.cpp#L236). In this PR I modify syskit to pass the "right" field to the logger.