### PR TITLE
fix: log transfer/transfer_server CLI commands

### DIFF
--- a/lib/syskit/cli/log_runtime_archive_main.rb
+++ b/lib/syskit/cli/log_runtime_archive_main.rb
@@ -68,13 +68,13 @@ module Syskit
             option :max_size,
                    type: :numeric, default: 10_000, desc: "max log size in MB"
             option :max_upload_rate_mbps,
-                   type: :numeric, default: 10, desc: "max upload rate in Mbps"
+                   type: :numeric, default: 1_000, desc: "max upload rate in Mbps"
             def watch_transfer( # rubocop:disable Metrics/ParameterLists
-                source_dir, host, port, certfile_path, user, password, implicit_ftps
+                source_dir, host, port, certificate_path, user, password, implicit_ftps
             )
                 loop do
                     begin
-                        transfer(source_dir, host, port, certfile_path, user, password,
+                        transfer(source_dir, host, port, certificate_path, user, password,
                                  implicit_ftps)
                     rescue Errno::ENOSPC
                         next
@@ -89,15 +89,15 @@ module Syskit
             option :max_size,
                    type: :numeric, default: 10_000, desc: "max log size in MB"
             option :max_upload_rate_mbps,
-                   type: :numeric, default: 10, desc: "max upload rate in Mbps"
+                   type: :numeric, default: 1_000, desc: "max upload rate in Mbps"
             def transfer( # rubocop:disable Metrics/ParameterLists
-                source_dir, host, port, certfile_path, user, password, implicit_ftps
+                source_dir, host, port, certificate_path, user, password, implicit_ftps
             )
                 source_dir = validate_directory_exists(source_dir)
                 archiver = make_archiver(source_dir)
 
                 server_params = LogRuntimeArchive::FTPParameters.new(
-                    host: host, port: port, certificate: File.read(certfile_path),
+                    host: host, port: port, certificate: File.read(certificate_path),
                     user: user, password: password,
                     implicit_ftps: implicit_ftps,
                     max_upload_rate: rate_mbps_to_bps(options[:max_upload_rate_mbps])
@@ -118,7 +118,7 @@ module Syskit
             no_commands do # rubocop:disable Metrics/BlockLength
                 # Converts rate in Mbps to bps
                 def rate_mbps_to_bps(rate_mbps)
-                    rate_mbps / (10**6)
+                    rate_mbps * (10**6)
                 end
 
                 def validate_directory_exists(dir)

--- a/lib/syskit/cli/log_runtime_archive_main.rb
+++ b/lib/syskit/cli/log_runtime_archive_main.rb
@@ -70,11 +70,11 @@ module Syskit
             option :max_upload_rate_mbps,
                    type: :numeric, default: 10, desc: "max upload rate in Mbps"
             def watch_transfer( # rubocop:disable Metrics/ParameterLists
-                source_dir, host, port, certificate, user, password, implicit_ftps
+                source_dir, host, port, certfile_path, user, password, implicit_ftps
             )
                 loop do
                     begin
-                        transfer(source_dir, host, port, certificate, user, password,
+                        transfer(source_dir, host, port, certfile_path, user, password,
                                  implicit_ftps)
                     rescue Errno::ENOSPC
                         next
@@ -91,13 +91,13 @@ module Syskit
             option :max_upload_rate_mbps,
                    type: :numeric, default: 10, desc: "max upload rate in Mbps"
             def transfer( # rubocop:disable Metrics/ParameterLists
-                source_dir, host, port, certificate_path, user, password, implicit_ftps
+                source_dir, host, port, certfile_path, user, password, implicit_ftps
             )
                 source_dir = validate_directory_exists(source_dir)
                 archiver = make_archiver(source_dir)
 
                 server_params = LogRuntimeArchive::FTPParameters.new(
-                    host: host, port: port, certificate: File.read(certificate_path),
+                    host: host, port: port, certificate: File.read(certfile_path),
                     user: user, password: password,
                     implicit_ftps: implicit_ftps,
                     max_upload_rate: rate_mbps_to_bps(options[:max_upload_rate_mbps])
@@ -110,7 +110,8 @@ module Syskit
             def transfer_server( # rubocop:disable Metrics/ParameterLists
                 target_dir, host, port, certfile_path, user, password, implicit_ftps
             )
-                server = create_server(target_dir, host, port, certfile_path, user, password, implicit_ftps)
+                server = create_server(target_dir, host, port, certfile_path, user,
+                                       password, implicit_ftps)
                 server.run
             end
 

--- a/lib/syskit/cli/log_runtime_archive_main.rb
+++ b/lib/syskit/cli/log_runtime_archive_main.rb
@@ -91,27 +91,27 @@ module Syskit
             option :max_upload_rate_mbps,
                    type: :numeric, default: 10, desc: "max upload rate in Mbps"
             def transfer( # rubocop:disable Metrics/ParameterLists
-                source_dir, host, port, certificate, user, password, implicit_ftps
+                source_dir, host, port, certificate_path, user, password, implicit_ftps
             )
                 source_dir = validate_directory_exists(source_dir)
                 archiver = make_archiver(source_dir)
 
-                server_params = {
-                    host: host, port: port, certificate: certificate,
+                server_params = LogRuntimeArchive::FTPParameters.new(
+                    host: host, port: port, certificate: File.read(certificate_path),
                     user: user, password: password,
                     implicit_ftps: implicit_ftps,
                     max_upload_rate: rate_mbps_to_bps(options[:max_upload_rate_mbps])
-                }
+                )
                 archiver.process_root_folder_transfer(server_params)
             end
 
             desc "transfer_server", "creates the log transfer FTP server \
                                      that runs on the main computer"
             def transfer_server( # rubocop:disable Metrics/ParameterLists
-                target_dir, host, port, certificate, user, password, implicit_ftps
+                target_dir, host, port, certfile_path, user, password, implicit_ftps
             )
-                create_server(target_dir, host, port, certificate, user, password,
-                              implicit_ftps)
+                server = create_server(target_dir, host, port, certfile_path, user, password, implicit_ftps)
+                server.run
             end
 
             no_commands do # rubocop:disable Metrics/BlockLength

--- a/test/cli/test_log_runtime_archive_main.rb
+++ b/test/cli/test_log_runtime_archive_main.rb
@@ -225,21 +225,23 @@ module Syskit
                     dataset_tmp_path = make_tmppath
                     root_tmp_path = make_tmppath
 
-                    call_create_server(root_tmp_path, @server_params)
+                    server = call_create_server(root_tmp_path, @server_params)
 
                     make_dataset(dataset_tmp_path, "19981222-1301")
                     make_dataset(dataset_tmp_path, "19981222-1302")
 
-                    call_transfer(dataset_tmp_path)
+                    call_transfer(dataset_tmp_path, server_port: server.port)
                     assert(File.exist?(root_tmp_path / "19981222-1301" / "test.0.log"))
                 end
 
                 # Call 'transfer' function instead of 'watch' to call transfer once
-                def call_transfer(source_dir)
+                def call_transfer(source_dir, server_port: nil)
+                    updated_server_params = @server_params
+                    updated_server_params[:port] = server_port if server_port
                     args = [
                         "transfer",
                         source_dir,
-                        *@server_params.values
+                        *updated_server_params.values
                     ]
                     LogRuntimeArchiveMain.start(args)
                 end
@@ -275,7 +277,7 @@ module Syskit
                 interface = "127.0.0.1"
                 ca = RobyApp::TmpRootCA.new(interface)
 
-                { host: interface, port: 42_429,
+                { host: interface, port: 0,
                   certificate: ca.private_certificate_path,
                   user: "nilvo", password: "nilvo123",
                   implicit_ftps: true }

--- a/test/cli/test_log_runtime_archive_main.rb
+++ b/test/cli/test_log_runtime_archive_main.rb
@@ -157,6 +157,13 @@ module Syskit
                     @source_dir = make_tmppath
                     @server_params = server_params
                     @max_upload_rate = rate_mbps_to_bps(10)
+                    @ftp_params = LogRuntimeArchive::FTPParameters.new(
+                        host: @server_params[:host], port: @server_params[:port],
+                        certificate: File.read(@server_params[:certificate]),
+                        user:@server_params[:user], password: @server_params[:password],
+                        implicit_ftps: @server_params[:implicit_ftps],
+                        max_upload_rate: @max_upload_rate
+                    )
 
                     @server = call_create_server(make_tmppath, @server_params)
                 end
@@ -173,9 +180,7 @@ module Syskit
                         .new_instances
                         .should_receive(:process_root_folder_transfer)
                         .with(
-                            @server_params.merge(
-                                { max_upload_rate: @max_upload_rate }
-                            )
+                            @ftp_params
                         )
                         .pass_thru do
                             called += 1

--- a/test/cli/test_log_runtime_archive_main.rb
+++ b/test/cli/test_log_runtime_archive_main.rb
@@ -193,7 +193,8 @@ module Syskit
                             "watch_transfer",
                             @source_dir,
                             *@server_params.values,
-                            "--period", 0.5
+                            "--period", 0.5,
+                            "--max_upload_rate_mbps", 10
                         ]
                         LogRuntimeArchiveMain.start(args)
                     end
@@ -204,7 +205,7 @@ module Syskit
 
                 # Converts rate in Mbps to bps
                 def rate_mbps_to_bps(rate_mbps)
-                    rate_mbps / (10**6)
+                    rate_mbps * (10**6)
                 end
             end
 


### PR DESCRIPTION
The Transfer command was passing a hash instead of the FTPParameters, and passing the path instead of the certificate, and the server was not running, only being created.

Tested it by creating an RSA private key:
openssl genrsa -out rsa_private_key 2048

then a certificate:
openssl req -new -x509 -key rsa_private_key -out certificate.pem -subj "/CN=127.0.0.1"

then the required certfile:
cat rsa_private_key certificate.pem > certfile

Then ran the server:
syskit log_runtime_archive transfer_server /home/user/test/transfer_dir/ 127.0.0.1 2124 /home/user/test/certfile user pwd true

Then transfered files:
syskit log_runtime_archive transfer /home/user/test/log_dir/ 127.0.0.1 2124  /home/user/test/certificate.pem user pwd true

https://github.com/rock-core/tools-syskit/pull/453 was mistakenly closed when deleting the branch it was on top of...
