### PR TITLE
fix: pass max archive size as argument instead of class initialization param in logRuntimeArchive

### DIFF
--- a/lib/syskit/cli/log_runtime_archive.rb
+++ b/lib/syskit/cli/log_runtime_archive.rb
@@ -116,7 +116,7 @@ module Syskit
                 true
             end
 
-            def process_dataset(child, max_archive_size: DEFAULT_MAX_ARCHIVE_SIZE, full:)
+            def process_dataset(child, full:, max_archive_size: DEFAULT_MAX_ARCHIVE_SIZE)
                 use_existing = true
                 loop do
                     open_archive_for(

--- a/lib/syskit/cli/log_runtime_archive.rb
+++ b/lib/syskit/cli/log_runtime_archive.rb
@@ -29,17 +29,14 @@ module Syskit
             #   should be nil in transfer mode, as the logs will be transferred directly
             #   to the ftp server @see process_root_folder_transfer
             # @param [Logger] logger the log structure
-            # @param [Integer] max_archive_size the max size of the archive
             def initialize(
                 root_dir, target_dir: nil,
-                logger: LogRuntimeArchive.null_logger,
-                max_archive_size: DEFAULT_MAX_ARCHIVE_SIZE
+                logger: LogRuntimeArchive.null_logger
             )
                 @last_archive_index = {}
                 @logger = logger
                 @root_dir = root_dir
                 @target_dir = target_dir
-                @max_archive_size = max_archive_size
             end
 
             # Iterate over all datasets in a Roby log root folder and transfer them
@@ -65,11 +62,14 @@ module Syskit
             # @param [Pathname] root_dir the log root folder
             # @param [Pathname] target_dir the folder in which to save the
             #   archived datasets
-            def process_root_folder
+            # @param [Integer] max_archive_size the max size of the archive
+            def process_root_folder(max_archive_size: DEFAULT_MAX_ARCHIVE_SIZE)
                 candidates = self.class.find_all_dataset_folders(@root_dir)
                 running = candidates.last
                 candidates.each do |child|
-                    process_dataset(child, full: child != running)
+                    process_dataset(
+                        child, max_archive_size: max_archive_size, full: child != running
+                    )
                 end
             end
 
@@ -116,13 +116,13 @@ module Syskit
                 true
             end
 
-            def process_dataset(child, full:)
+            def process_dataset(child, max_archive_size: DEFAULT_MAX_ARCHIVE_SIZE, full:)
                 use_existing = true
                 loop do
                     open_archive_for(
                         child.basename.to_s, use_existing: use_existing
                     ) do |io|
-                        if io.tell > @max_archive_size
+                        if io.tell > max_archive_size
                             use_existing = false
                             break
                         end
@@ -130,7 +130,7 @@ module Syskit
                         dataset_complete = self.class.archive_dataset(
                             io, child,
                             logger: @logger, full: full,
-                            max_size: @max_archive_size
+                            max_size: max_archive_size
                         )
                         return if dataset_complete
                     end

--- a/lib/syskit/cli/log_runtime_archive_main.rb
+++ b/lib/syskit/cli/log_runtime_archive_main.rb
@@ -58,15 +58,15 @@ module Syskit
                     options[:free_space_low_limit] * 1_000_000,
                     options[:free_space_freed_limit] * 1_000_000
                 )
-                archiver.process_root_folder
+                archiver.process_root_folder(
+                    max_archive_size: options[:max_size] * (1024**2)
+                )
             end
 
             desc "watch_transfer", "watches a dataset root folder \
                                     and periodically performs transfer"
             option :period,
                    type: :numeric, default: 600, desc: "polling period in seconds"
-            option :max_size,
-                   type: :numeric, default: 10_000, desc: "max log size in MB"
             option :max_upload_rate_mbps,
                    type: :numeric, default: 10, desc: "max upload rate in Mbps"
             def watch_transfer( # rubocop:disable Metrics/ParameterLists
@@ -86,8 +86,6 @@ module Syskit
             end
 
             desc "transfer", "transfers the datasets"
-            option :max_size,
-                   type: :numeric, default: 10_000, desc: "max log size in MB"
             option :max_upload_rate_mbps,
                    type: :numeric, default: 10, desc: "max upload rate in Mbps"
             def transfer( # rubocop:disable Metrics/ParameterLists
@@ -117,8 +115,6 @@ module Syskit
             desc "watch_ensure_free_space", "watches the ensure free space process"
             option :period,
                    type: :numeric, default: 10, desc: "polling period in seconds"
-            option :max_size,
-                   type: :numeric, default: 10_000, desc: "max log size in MB"
             option :free_space_low_limit,
                    type: :numeric, default: 5_000, desc: "start deleting files if \
                     available space is below this threshold (threshold in MB)"
@@ -137,8 +133,6 @@ module Syskit
 
             desc "ensure_free_space", "ensures there is free space, if not, start \
                                        deleting files"
-            option :max_size,
-                   type: :numeric, default: 10_000, desc: "max log size in MB"
             option :free_space_low_limit,
                    type: :numeric, default: 5_000, desc: "start deleting files if \
                     available space is below this threshold (threshold in MB)"
@@ -180,8 +174,7 @@ module Syskit
 
                     Syskit::CLI::LogRuntimeArchive.new(
                         root_dir,
-                        target_dir: target_dir, logger: logger,
-                        max_archive_size: options[:max_size] * (1024**2)
+                        target_dir: target_dir, logger: logger
                     )
                 end
 

--- a/test/cli/test_log_runtime_archive.rb
+++ b/test/cli/test_log_runtime_archive.rb
@@ -392,9 +392,9 @@ module Syskit
                         .write(test1 = Base64.encode64(Random.bytes(1024)))
                     (dataset / "test.2.log").write(Base64.encode64(Random.bytes(1024)))
                     process = LogRuntimeArchive.new(
-                        @root, target_dir: @archive_dir, max_archive_size: 1024
+                        @root, target_dir: @archive_dir
                     )
-                    process.process_root_folder
+                    process.process_root_folder(max_archive_size: 1024)
 
                     entries = read_archive(path: @archive_dir / "20220434-2023.0.tar")
                     assert_equal 1, entries.size
@@ -420,12 +420,12 @@ module Syskit
                     (dataset / "test.2.log")
                         .write(test2 = Base64.encode64(Random.bytes(128)))
                     process = LogRuntimeArchive.new(
-                        @root, target_dir: @archive_dir, max_archive_size: 1024
+                        @root, target_dir: @archive_dir
                     )
-                    process.process_root_folder
+                    process.process_root_folder(max_archive_size: 1024)
 
                     (dataset / "test.3.log").write(Base64.encode64(Random.bytes(1024)))
-                    process.process_root_folder
+                    process.process_root_folder(max_archive_size: 1024)
 
                     entries = read_archive(path: @archive_dir / "20220434-2023.1.tar")
                     assert_equal 2, entries.size
@@ -446,12 +446,12 @@ module Syskit
                     test1 = make_random_file "test.1.log", root: dataset
                     test2 = make_random_file "test.2.log", root: dataset
                     process = LogRuntimeArchive.new(
-                        @root, target_dir: @archive_dir, max_archive_size: 1024
+                        @root, target_dir: @archive_dir
                     )
-                    process.process_root_folder
+                    process.process_root_folder(max_archive_size: 1024)
 
                     make_random_file "test.3.log", root: dataset
-                    process.process_root_folder
+                    process.process_root_folder(max_archive_size: 1024)
 
                     entries = read_archive(path: @archive_dir / "20220434-2023.1.tar")
                     assert_equal 1, entries.size


### PR DESCRIPTION
On top of #456 