### PR TITLE
feat: init policy defaults to true

### DIFF
--- a/lib/syskit/dynamic_port_binding.rb
+++ b/lib/syskit/dynamic_port_binding.rb
@@ -199,10 +199,7 @@ module Syskit
             # Method called by {Accessor} to create the accessor object from a
             # port
             def create_accessor(port)
-                if port.respond_to?(:init_policy) &&
-                   [true, false].include?(port.init_policy)
-                    policy.merge(init: port.init_policy)
-                end
+                policy.merge(init: policy.fetch(:init, port.model.init_policy))
                 port.reader(**policy)
             end
 

--- a/lib/syskit/dynamic_port_binding.rb
+++ b/lib/syskit/dynamic_port_binding.rb
@@ -199,6 +199,10 @@ module Syskit
             # Method called by {Accessor} to create the accessor object from a
             # port
             def create_accessor(port)
+                if port.respond_to?(:init_policy) &&
+                   [true, false].include?(port.init_policy)
+                    policy.merge(init: port.init_policy)
+                end
                 port.reader(**policy)
             end
 

--- a/lib/syskit/models/port.rb
+++ b/lib/syskit/models/port.rb
@@ -105,10 +105,6 @@ module Syskit
             # @raise [SelfConnection]
             def connect_to(in_port, policy = {})
                 out_port = to_component_port
-                if out_port.respond_to?(:init_policy) &&
-                    [true, false].include?(out_port.init_policy)
-                    policy = policy.merge(init: out_port.init_policy)
-                end
                 if out_port == self
                     if in_port.respond_to?(:to_component_port)
                         in_port = in_port.to_component_port

--- a/lib/syskit/models/port.rb
+++ b/lib/syskit/models/port.rb
@@ -111,16 +111,7 @@ module Syskit
                 if out_port == self
                     if in_port.respond_to?(:to_component_port)
                         in_port = in_port.to_component_port
-                        if !out_port.output?
-                            raise WrongPortConnectionDirection.new(self, in_port), "cannot connect #{out_port} to #{in_port}: #{out_port} is not an output port"
-                        elsif !in_port.input?
-                            raise WrongPortConnectionDirection.new(self, in_port), "cannot connect #{out_port} to #{in_port}: #{in_port} is not an input port"
-                        elsif out_port.component_model == in_port.component_model
-                            raise SelfConnection.new(out_port, in_port), "cannot connect #{out_port} to #{in_port}: they are both ports of the same component"
-                        elsif out_port.type != in_port.type
-                            raise WrongPortConnectionTypes.new(self, in_port), "cannot connect #{out_port} to #{in_port}: types mismatch"
-                        end
-
+                        validate_connection!(out_port, in_port)
                         component_model.connect_ports(in_port.component_model, [out_port.name, in_port.name] => policy)
                     else
                         Syskit.connect self, in_port, policy
@@ -128,6 +119,28 @@ module Syskit
 
                 else
                     out_port.connect_to(in_port, policy)
+                end
+            end
+
+            def validate_connection!(out_port, in_port)
+                unless out_port.output?
+                    raise WrongPortConnectionDirection.new(self, in_port),
+                          "cannot connect #{out_port} to #{in_port}: " \
+                          "#{out_port} is not an output port"
+                end
+                unless in_port.input?
+                    raise WrongPortConnectionDirection.new(self, in_port),
+                          "cannot connect #{out_port} to #{in_port}: " \
+                          "#{in_port} is not an input port"
+                end
+                if out_port.component_model == in_port.component_model
+                    raise SelfConnection.new(out_port, in_port),
+                          "cannot connect #{out_port} to #{in_port}: " \
+                          "they are both ports of the same component"
+                end
+                unless out_port.type == in_port.type
+                    raise WrongPortConnectionTypes.new(self, in_port),
+                          "cannot connect #{out_port} to #{in_port}: types mismatch"
                 end
             end
 

--- a/lib/syskit/models/port.rb
+++ b/lib/syskit/models/port.rb
@@ -105,13 +105,14 @@ module Syskit
             # @raise [SelfConnection]
             def connect_to(in_port, policy = {})
                 out_port = to_component_port
-                if out_port.respond_to?(:recommend_init)
-                    policy[:init] = out_port.recommend_init
+                if out_port.respond_to?(:init_policy) &&
+                    [true, false].include?(out_port.init_policy)
+                    policy = policy.merge(init: out_port.init_policy)
                 end
                 if out_port == self
                     if in_port.respond_to?(:to_component_port)
                         in_port = in_port.to_component_port
-                        validate_connection!(out_port, in_port)
+                        validate_connection(out_port, in_port)
                         component_model.connect_ports(in_port.component_model, [out_port.name, in_port.name] => policy)
                     else
                         Syskit.connect self, in_port, policy
@@ -122,7 +123,7 @@ module Syskit
                 end
             end
 
-            def validate_connection!(out_port, in_port)
+            def validate_connection(out_port, in_port)
                 unless out_port.output?
                     raise WrongPortConnectionDirection.new(self, in_port),
                           "cannot connect #{out_port} to #{in_port}: " \

--- a/lib/syskit/models/port.rb
+++ b/lib/syskit/models/port.rb
@@ -105,6 +105,9 @@ module Syskit
             # @raise [SelfConnection]
             def connect_to(in_port, policy = {})
                 out_port = to_component_port
+                if out_port.respond_to?(:recommend_init)
+                    policy[:init] = out_port.recommend_init
+                end
                 if out_port == self
                     if in_port.respond_to?(:to_component_port)
                         in_port = in_port.to_component_port

--- a/lib/syskit/network_generation/dataflow_dynamics.rb
+++ b/lib/syskit/network_generation/dataflow_dynamics.rb
@@ -601,30 +601,26 @@ module Syskit
                         "#{sink_task}:#{sink_port.name}"
                 end
 
-                source_port_m = source_port.model
-                if [true, false].include?(source_port_m.init_policy)
-                    policy = policy.merge(init: source_port_m.init_policy)
-                end
-
                 sink_port_m = sink_port.model
                 if sink_port_m.needs_reliable_connection?
-                    compute_reliable_connection_policy(
+                    policy = compute_reliable_connection_policy(
                         source_port, sink_port, fallback_policy
                     )
                 elsif sink_port_m.required_connection_type == :data
                     policy = Orocos::Port.prepare_policy(type: :data)
                     DataFlowDynamics.debug { "     result: #{policy}" }
-                    policy
                 elsif sink_port_m.required_connection_type == :buffer
                     policy = Orocos::Port.prepare_policy(type: :buffer, size: 1)
                     DataFlowDynamics.debug { "     result: #{policy}" }
-                    policy
                 else
                     raise UnsupportedConnectionType,
                           "unknown required connection type " \
                           "#{sink_port_m.required_connection_type} " \
                           "on #{sink_port}"
                 end
+
+                source_port_m = source_port.model
+                policy.merge(init: source_port_m.init_policy)
             end
 
             def compute_reliable_connection_policy(

--- a/lib/syskit/network_generation/dataflow_dynamics.rb
+++ b/lib/syskit/network_generation/dataflow_dynamics.rb
@@ -620,8 +620,8 @@ module Syskit
                 end
 
                 source_port_m = source_port.model
-                unless source_port_m.init_policy.nil?
-                    policy.merge(init: source_port_m.init_policy)
+                unless source_port_m.init_policy?
+                    policy = policy.merge(init: source_port_m.init_policy)
                 end
                 policy
             end

--- a/lib/syskit/network_generation/dataflow_dynamics.rb
+++ b/lib/syskit/network_generation/dataflow_dynamics.rb
@@ -620,7 +620,10 @@ module Syskit
                 end
 
                 source_port_m = source_port.model
-                policy.merge(init: source_port_m.init_policy)
+                unless source_port_m.init_policy.nil?
+                    policy.merge(init: source_port_m.init_policy)
+                end
+                policy
             end
 
             def compute_reliable_connection_policy(

--- a/lib/syskit/network_generation/dataflow_dynamics.rb
+++ b/lib/syskit/network_generation/dataflow_dynamics.rb
@@ -601,6 +601,11 @@ module Syskit
                         "#{sink_task}:#{sink_port.name}"
                 end
 
+                source_port_m = source_port.model
+                if [true, false].include?(source_port_m.init_policy)
+                    policy = policy.merge(init: source_port_m.init_policy)
+                end
+
                 sink_port_m = sink_port.model
                 if sink_port_m.needs_reliable_connection?
                     compute_reliable_connection_policy(

--- a/test/models/test_port.rb
+++ b/test/models/test_port.rb
@@ -72,22 +72,29 @@ describe Syskit::Models::Port do
                 out_task_m.out_port.connect_to in_task_m.in_port
             end
         end
-        it "adds 'init: true' as a default policy" do
+        it "makes sure init policy is not set without calling recommend_init" do
             policy = {}
             flexmock(out_task_m).should_receive(:connect_ports).explicitly.once
-                                .with(in_task_m, %w[out in] => policy.merge(init: true))
+                                .with(in_task_m, %w[out in] => policy)
             out_task_m.out_port.connect_to in_task_m.in_port, policy
-            assert policy[:init]
         end
-        it "adds 'init: false' if recommend_init flag is set to false" do
+        it "adds 'init: true' policy if recommend_init was called" do
             out_port_m = Syskit::Models::Port.new(out_task_m, out_task_m.orogen_model.find_port("out"))
-            out_port_m.orogen_model.recommend_init = false
-            refute out_port_m.recommend_init
+            out_port_m.orogen_model.recommend_init
+            assert out_port_m.init_policy
             policy = {}
             flexmock(out_task_m).should_receive(:connect_ports).explicitly
-                                .with(in_task_m, %w[out in] => policy.merge(init: false))
+                                .with(in_task_m, %w[out in] => { init: true })
             out_task_m.out_port.connect_to in_task_m.in_port, policy
-            refute policy[:init]
+        end
+        it "adds 'init: false' policy if recommend_init(init: false) was called" do
+            out_port_m = Syskit::Models::Port.new(out_task_m, out_task_m.orogen_model.find_port("out"))
+            out_port_m.orogen_model.recommend_init(init: false)
+            refute out_port_m.init_policy
+            policy = {}
+            flexmock(out_task_m).should_receive(:connect_ports).explicitly
+                                .with(in_task_m, %w[out in] => { init: false })
+            out_task_m.out_port.connect_to in_task_m.in_port, policy
         end
     end
 

--- a/test/models/test_port.rb
+++ b/test/models/test_port.rb
@@ -72,6 +72,23 @@ describe Syskit::Models::Port do
                 out_task_m.out_port.connect_to in_task_m.in_port
             end
         end
+        it "adds 'init: true' as a default policy" do
+            policy = {}
+            flexmock(out_task_m).should_receive(:connect_ports).explicitly.once
+                                .with(in_task_m, %w[out in] => policy.merge(init: true))
+            out_task_m.out_port.connect_to in_task_m.in_port, policy
+            assert policy[:init]
+        end
+        it "adds 'init: false' if recommend_init flag is set to false" do
+            out_port_m = Syskit::Models::Port.new(out_task_m, out_task_m.orogen_model.find_port("out"))
+            out_port_m.orogen_model.recommend_init = false
+            refute out_port_m.recommend_init
+            policy = {}
+            flexmock(out_task_m).should_receive(:connect_ports).explicitly
+                                .with(in_task_m, %w[out in] => policy.merge(init: false))
+            out_task_m.out_port.connect_to in_task_m.in_port, policy
+            refute policy[:init]
+        end
     end
 
     describe "#can_connect_to?" do

--- a/test/models/test_port.rb
+++ b/test/models/test_port.rb
@@ -72,30 +72,6 @@ describe Syskit::Models::Port do
                 out_task_m.out_port.connect_to in_task_m.in_port
             end
         end
-        it "makes sure init policy is not set without calling recommend_init" do
-            policy = {}
-            flexmock(out_task_m).should_receive(:connect_ports).explicitly.once
-                                .with(in_task_m, %w[out in] => policy)
-            out_task_m.out_port.connect_to in_task_m.in_port, policy
-        end
-        it "adds 'init: true' policy if recommend_init was called" do
-            out_port_m = Syskit::Models::Port.new(out_task_m, out_task_m.orogen_model.find_port("out"))
-            out_port_m.orogen_model.recommend_init
-            assert out_port_m.init_policy
-            policy = {}
-            flexmock(out_task_m).should_receive(:connect_ports).explicitly
-                                .with(in_task_m, %w[out in] => { init: true })
-            out_task_m.out_port.connect_to in_task_m.in_port, policy
-        end
-        it "adds 'init: false' policy if recommend_init(init: false) was called" do
-            out_port_m = Syskit::Models::Port.new(out_task_m, out_task_m.orogen_model.find_port("out"))
-            out_port_m.orogen_model.recommend_init(init: false)
-            refute out_port_m.init_policy
-            policy = {}
-            flexmock(out_task_m).should_receive(:connect_ports).explicitly
-                                .with(in_task_m, %w[out in] => { init: false })
-            out_task_m.out_port.connect_to in_task_m.in_port, policy
-        end
     end
 
     describe "#can_connect_to?" do

--- a/test/network_generation/test_dataflow_dynamics.rb
+++ b/test/network_generation/test_dataflow_dynamics.rb
@@ -420,14 +420,48 @@ module Syskit
                    "the sink port is marked as needs_reliable_connection" do
                     @sink_task_m.in_port.needs_reliable_connection
                     fallback_policy = flexmock
+                    expected_policy = flexmock
+
+                    expected_policy
+                        .should_receive(:merge)
+                        .and_return(expected_policy)
+
                     flexmock(@dynamics)
                         .should_receive(:compute_reliable_connection_policy)
                         .with(@source_t.out_port, @sink_t.in_port, fallback_policy)
-                        .once.and_return(expected_policy = flexmock)
+                        .once.and_return(expected_policy)
                     policy = @dynamics.policy_for(
                         @source_t, "out", "in", @sink_t, fallback_policy
                     )
                     assert_equal expected_policy, policy
+                end
+
+                it "merges init policy when sink requires reliable connection" do
+                    @sink_task_m.in_port.needs_reliable_connection
+                    @source_t.out_port.model.init_policy(true)
+
+                    fallback_policy = flexmock
+                    flexmock(@dynamics)
+                        .should_receive(:compute_reliable_connection_policy)
+                        .with(@source_t.out_port, @sink_t.in_port, fallback_policy)
+                        .once.and_return({ init: true })
+
+                    policy = @dynamics.policy_for(
+                        @source_t, "out", "in", @sink_t, fallback_policy
+                    )
+
+                    assert_equal true, policy[:init]
+                end
+
+                it "merges init policy when sink requires 'buffer' connection type" do
+                    @sink_task_m.in_port.needs_buffered_connection
+                    @source_t.out_port.model.init_policy(true)
+
+                    policy = @dynamics.policy_for(@source_t, "out", "in", @sink_t, nil)
+
+                    assert_equal true, policy[:init]
+                    assert_equal :buffer, policy[:type]
+                    assert_equal 1, policy[:size]
                 end
             end
 

--- a/test/network_generation/test_dataflow_dynamics.rb
+++ b/test/network_generation/test_dataflow_dynamics.rb
@@ -240,6 +240,46 @@ module Syskit
                                  policy_graph[[task0, task1]][%w[out in]])
                 end
 
+                it "adds init: true policy if available and saves it " \
+                   "in the graph's policy_graph" do
+                    plan.add(task0 = @task_m.new)
+                    plan.add(task1 = @task_m.new)
+
+                    add_agents(tasks = [task0, task1])
+                    flexmock(@dynamics).should_receive(:propagate).with(tasks)
+
+                    task0.out_port.model.recommend_init
+                    task0.out_port.connect_to(task1.in_port)
+
+                    @dynamics.should_receive(:policy_for)
+                             .with(task0, "out", "in", task1, nil)
+                             .and_return(type: :buffer, size: 42, init: true)
+                    policy_graph = @dynamics.compute_connection_policies
+
+                    assert_equal({ type: :buffer, size: 42, init: true },
+                                 policy_graph[[task0, task1]][%w[out in]])
+                end
+
+                it "adds init: false policy if available and saves it " \
+                   "in the graph's policy_graph" do
+                    plan.add(task0 = @task_m.new)
+                    plan.add(task1 = @task_m.new)
+
+                    add_agents(tasks = [task0, task1])
+                    flexmock(@dynamics).should_receive(:propagate).with(tasks)
+
+                    task0.out_port.model.recommend_init(init: false)
+                    task0.out_port.connect_to(task1.in_port)
+
+                    @dynamics.should_receive(:policy_for)
+                             .with(task0, "out", "in", task1, nil)
+                             .and_return(type: :buffer, size: 42, init: false)
+                    policy_graph = @dynamics.compute_connection_policies
+
+                    assert_equal({ type: :buffer, size: 42, init: false },
+                                 policy_graph[[task0, task1]][%w[out in]])
+                end
+
                 it "computes the policies on the concrete connections" do
                     plan.add(task = @task_m.new)
                     cmp = @cmp_m.instanciate(plan)

--- a/test/network_generation/test_dataflow_dynamics.rb
+++ b/test/network_generation/test_dataflow_dynamics.rb
@@ -248,7 +248,7 @@ module Syskit
                     add_agents(tasks = [task0, task1])
                     flexmock(@dynamics).should_receive(:propagate).with(tasks)
 
-                    task0.out_port.model.recommend_init
+                    task0.out_port.model.init_policy(true)
                     task0.out_port.connect_to(task1.in_port)
 
                     @dynamics.should_receive(:policy_for)
@@ -268,7 +268,7 @@ module Syskit
                     add_agents(tasks = [task0, task1])
                     flexmock(@dynamics).should_receive(:propagate).with(tasks)
 
-                    task0.out_port.model.recommend_init(init: false)
+                    task0.out_port.model.init_policy(false)
                     task0.out_port.connect_to(task1.in_port)
 
                     @dynamics.should_receive(:policy_for)

--- a/test/network_generation/test_dataflow_dynamics.rb
+++ b/test/network_generation/test_dataflow_dynamics.rb
@@ -455,6 +455,11 @@ module Syskit
 
                 it "merges init policy when sink requires 'buffer' connection type" do
                     @sink_task_m.in_port.needs_buffered_connection
+
+                    flexmock(@source_t.out_port.model)
+                        .should_receive(:init_policy).explicitly
+                        .and_return(true)
+
                     @source_t.out_port.model.init_policy(true)
 
                     policy = @dynamics.policy_for(@source_t, "out", "in", @sink_t, nil)

--- a/test/test_dynamic_port_binding.rb
+++ b/test/test_dynamic_port_binding.rb
@@ -394,7 +394,7 @@ module Syskit
                     .with(@task.out_port).and_return { @task.out_port.reader }
             end
 
-            it "expects no policy if recommend_init is not called" do
+            it "expects no policy if init_policy is not called" do
                 flexmock(@task.out_port)
                     .should_receive(:reader)
                     .and_return({})
@@ -402,8 +402,8 @@ module Syskit
                 @accessor.create_accessor(@task.out_port)
             end
 
-            it "expects init: true policy if recommend_init is called" do
-                @task.out_port.model.recommend_init
+            it "expects init: true policy if init_policy(true) is called" do
+                @task.out_port.model.init_policy(true)
                 flexmock(@task.out_port)
                     .should_receive(:reader)
                     .and_return({ init: true })
@@ -411,8 +411,8 @@ module Syskit
                 @accessor.create_accessor(@task.out_port)
             end
 
-            it "expects init: false policy if recommend_init(init: false) is called" do
-                @task.out_port.model.recommend_init(init: false)
+            it "expects init: false policy if init_policy(false) is called" do
+                @task.out_port.model.init_policy(false)
                 flexmock(@task.out_port)
                     .should_receive(:reader)
                     .and_return({ init: false })

--- a/test/test_dynamic_port_binding.rb
+++ b/test/test_dynamic_port_binding.rb
@@ -382,6 +382,45 @@ module Syskit
             @task = syskit_stub_deploy_configure_and_start(@task_m)
         end
 
+        describe "policy" do
+            attr_reader :task, :port_binding
+
+            before do
+                @port_binding = flexmock
+                @accessor = DynamicPortBinding::Accessor.new(@port_binding)
+                flexmock(@accessor)
+                    .should_receive(:create_accessor)
+                    .explicitly
+                    .with(@task.out_port).and_return { @task.out_port.reader }
+            end
+
+            it "expects no policy if recommend_init is not called" do
+                flexmock(@task.out_port)
+                    .should_receive(:reader)
+                    .and_return({})
+
+                @accessor.create_accessor(@task.out_port)
+            end
+
+            it "expects init: true policy if recommend_init is called" do
+                @task.out_port.model.recommend_init
+                flexmock(@task.out_port)
+                    .should_receive(:reader)
+                    .and_return({ init: true })
+
+                @accessor.create_accessor(@task.out_port)
+            end
+
+            it "expects init: false policy if recommend_init(init: false) is called" do
+                @task.out_port.model.recommend_init(init: false)
+                flexmock(@task.out_port)
+                    .should_receive(:reader)
+                    .and_return({ init: false })
+
+                @accessor.create_accessor(@task.out_port)
+            end
+        end
+
         describe "#update" do
             attr_reader :task, :port_binding
 


### PR DESCRIPTION
The `:init` policy flag requests that the connection sends the last value written to it.
This PR applies the `:init` policy using the `recommend_init` flag

Depends on:
- [ ] https://github.com/rock-core/tools-orogen/pull/23