### PR TITLE
fix: issues with killing Unmanaged::Process during its discovery phase

### DIFF
--- a/lib/syskit/process_managers/unmanaged/process.rb
+++ b/lib/syskit/process_managers/unmanaged/process.rb
@@ -121,8 +121,9 @@ module Syskit
 
                     result = {}
                     warning_time_deadline = Time.at(0)
+                    loop do
+                        return if quitting?
 
-                    until expected_names.empty?
                         expected_names.delete_if do |name|
                             result[name] = name_service.get(name)
                         rescue Orocos::NotFound
@@ -133,7 +134,9 @@ module Syskit
                             false
                         end
 
-                        sleep 0.1 if expected_names.any?
+                        break if expected_names.empty?
+
+                        sleep 0.1
                     end
                     result
                 end

--- a/lib/syskit/process_managers/unmanaged/process.rb
+++ b/lib/syskit/process_managers/unmanaged/process.rb
@@ -192,19 +192,6 @@ module Syskit
                     @ior_mappings
                 end
 
-                # @api private
-                #
-                # Helper method to kill a thread
-                def terminate_and_join_thread(thread)
-                    return unless thread.alive?
-
-                    thread.raise TerminateThread
-                    begin
-                        thread.join
-                    rescue TerminateThread # rubocop:disable Lint/SuppressedException
-                    end
-                end
-
                 # "Kill" this process
                 #
                 # It shuts down the tasks that are part of it

--- a/lib/syskit/process_managers/unmanaged/process.rb
+++ b/lib/syskit/process_managers/unmanaged/process.rb
@@ -239,8 +239,12 @@ module Syskit
                     if monitor_thread
                         !monitor_thread.alive?
                     else
-                        quitting?
+                        quitting? && !discovering?
                     end
+                end
+
+                def discovering?
+                    @iors_future && !@iors_future.fulfilled?
                 end
 
                 # Returns true if the tasks have been successfully discovered

--- a/test/process_managers/test_unmanaged.rb
+++ b/test/process_managers/test_unmanaged.rb
@@ -35,6 +35,17 @@ module Syskit
                     assert_equal @unmanaged_task_name, deployment_task.process_name
                 end
 
+                it "stops the discovery thread if killed during discovery" do
+                    expect_execution { deployment_task.start! }
+                        .join_all_waiting_work(false)
+                        .to { emit deployment_task.start_event }
+                    assert deployment_task.orocos_process.discovering?
+
+                    expect_execution { deployment_task.stop! }
+                        .to { emit deployment_task.stop_event }
+                    refute deployment_task.orocos_process.discovering?
+                end
+
                 it "readies the execution agent when the task becomes available" do
                     expect_execution { deployment_task.start! }
                         .join_all_waiting_work(false)

--- a/test/process_managers/test_unmanaged.rb
+++ b/test/process_managers/test_unmanaged.rb
@@ -173,8 +173,8 @@ module Syskit
                 # This is really a heisentest .... previous versions of
                 # UnmanagedProcess would fail when this happened but the current
                 # implementation should be completely imprevious
-                it "handles concurrently having the monitor fail and #kill being called" \
-                do
+                it "handles concurrently having the monitor fail " \
+                   "and #kill being called" do
                     make_deployment_ready
                     expect_execution do
                         delete_unmanaged_task

--- a/test/process_managers/test_unmanaged.rb
+++ b/test/process_managers/test_unmanaged.rb
@@ -35,6 +35,28 @@ module Syskit
                     assert_equal @unmanaged_task_name, deployment_task.process_name
                 end
 
+                it "declares the process dead during discovery only when the discovery " \
+                   "thread has returned" do
+                    expect_execution { deployment_task.start! }
+                        .join_all_waiting_work(false)
+                        .to { emit deployment_task.start_event }
+
+                    flexmock(deployment_task.orocos_process)
+                        .should_receive(:discovering?)
+                        .and_return(true, false)
+
+                    deployment_task.orocos_process.kill
+                    refute deployment_task.orocos_process.dead?
+                    deployment_task.orocos_process.wait_running
+                    assert deployment_task.orocos_process.dead?
+
+                    plan.unmark_permanent_task(deployment_task)
+                    expect_execution.to do
+                        emit deployment_task.stop_event
+                        have_error_matching Roby::EmissionFailed.match
+                    end
+                end
+
                 it "stops the discovery thread if killed during discovery" do
                     expect_execution { deployment_task.start! }
                         .join_all_waiting_work(false)


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-roby/pull/321

The main issue is that the discovery loop was not stopped. This is the first commit. The rest are cleanup concerns (e.g. declaring that the process is dead only when the thread has quit)

This was detected through (many) spurious warnings - after the addition of the warning by @kapeps. I believe it might be the source of a segmentation fault in test suites (the name_service being disposed on the one hand but used by the thread in the other)