### PR TITLE
chore: revive `syskit browse`

### DIFF
--- a/lib/syskit/graphviz.rb
+++ b/lib/syskit/graphviz.rb
@@ -371,19 +371,18 @@ module Syskit
             policy_graph = dataflow_graph.policy_graph
             policy_annotations = {}
             plan.find_local_tasks(TaskContext).each do |source_task|
-                source_task.each_output_connection do |source_port, sink_port, sink_task, policy|
-                    key = [source_task, source_port, sink_task, sink_port]
-                    policy_annotations[key] = policy_to_string(policy)
-                end
-
                 source_task.each_concrete_output_connection do |source_port, sink_port, sink_task, _|
                     key = [source_task, source_port, sink_task, sink_port]
-                    next if policy_annotations[key]
-
                     if (task_policies = policy_graph[[source_task, sink_task]])
                         policy = task_policies[[source_port, sink_port]]
                     end
-                    policy_annotations[key] = policy_to_string(policy || {})
+                    policy_annotations[key] = policy_to_string(
+                        policy || policy_annotations[key] || {}
+                    )
+                end
+                source_task.each_output_connection do |source_port, sink_port, sink_task, policy|
+                    key = [source_task, source_port, sink_task, sink_port]
+                    policy_annotations[key] ||= policy_to_string(policy)
                 end
             end
 

--- a/lib/syskit/gui/browse.rb
+++ b/lib/syskit/gui/browse.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "syskit/gui/model_browser"
+require "syskit/gui/instanciate"
 module Syskit
     module GUI
         # Main widget for model browsing
@@ -22,13 +23,14 @@ module Syskit
 
             def initialize(parent = nil)
                 super
-                @main_layout = Qt::VBoxLayout.new(self)
 
-                @model_browser = ModelBrowser.new(self)
+                @main_layout = Qt::VBoxLayout.new(self)
+                @tabs = Qt::TabWidget.new(self)
+
                 @btn_reload_models = Qt::PushButton.new("Reload Models", self)
 
                 main_layout.add_widget btn_reload_models
-                main_layout.add_widget model_browser
+                main_layout.add_widget @tabs
 
                 btn_reload_models.connect(SIGNAL("clicked()")) do
                     model_browser.registered_exceptions.clear
@@ -37,6 +39,19 @@ module Syskit
                     model_browser.update_exceptions
                     model_browser.reload
                 end
+
+                add_model_browser
+                add_instanciation
+            end
+
+            def add_model_browser
+                @model_browser = ModelBrowser.new(self)
+                @tabs.add_tab @model_browser, "Browse"
+            end
+
+            def add_instanciation
+                @instanciate_gui = Instanciate.new(self)
+                @tabs.add_tab @instanciate_gui, "Instanciate"
             end
 
             # Select the current model using its module

--- a/lib/syskit/gui/instanciate.rb
+++ b/lib/syskit/gui/instanciate.rb
@@ -9,7 +9,7 @@ require "metaruby/gui/exception_view"
 module Syskit
     module GUI
         class Instanciate < Qt::Widget
-            attr_reader :apply_btn, :instance_txt, :display, :page, :rendering, :exception_view, :permanent
+            attr_reader :update_btn, :instance_txt, :display, :page, :rendering, :exception_view, :permanent
 
             def plan
                 rendering.plan
@@ -41,9 +41,7 @@ module Syskit
                 splitter.add_widget exception_view
                 splitter.set_stretch_factor 1, 1
 
-                @apply_btn.connect(SIGNAL("clicked()")) do
-                    Roby.app.clear_exceptions
-                    Roby.app.reload_models
+                @update_btn.connect(SIGNAL("clicked()")) do
                     compute
                 end
 
@@ -53,9 +51,9 @@ module Syskit
 
             def create_toolbar
                 toolbar_layout = Qt::HBoxLayout.new
-                @apply_btn = Qt::PushButton.new("Reload && Apply", self)
+                @update_btn = Qt::PushButton.new("Update", self)
                 @instance_txt = Qt::LineEdit.new(self)
-                toolbar_layout.add_widget(@apply_btn)
+                toolbar_layout.add_widget(@update_btn)
                 toolbar_layout.add_widget(@instance_txt)
                 toolbar_layout
             end

--- a/lib/syskit/gui/instanciate.rb
+++ b/lib/syskit/gui/instanciate.rb
@@ -105,7 +105,11 @@ module Syskit
                         begin
                             _, act = ::Robot.action_from_name(action_name)
                         rescue ArgumentError
-                            act = eval(action_name).to_action # rubocop:disable Security/Eval
+                            act = eval(action_name) # rubocop:disable Security/Eval
+                            if act.respond_to?(:to_instance_requirements)
+                                act = act.to_instance_requirements
+                            end
+                            act = act.to_action
                         end
 
                         # Instanciate the action, and find out if it is actually

--- a/lib/syskit/scripts/browse.rb
+++ b/lib/syskit/scripts/browse.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "roby/standalone"
 require "syskit/scripts/common"
 require "Qt"
 require "syskit/gui/browse"
@@ -13,11 +12,8 @@ parser = OptionParser.new do |opt|
         Usage: browse [file] [options]
         Loads the models from this bundle and allows to browse them. If a file is given, only this file is loaded.
     BANNER_TEXT
-
-    opt.on "--all", "-a", "Load all models from all active bundles instead of only the ones from the current" do
-        load_all = true
-    end
 end
+Roby.app.require_app_dir
 Scripts.common_options(parser, true)
 remaining = parser.parse(ARGV)
 
@@ -26,13 +22,15 @@ Roby.app.using "syskit"
 Syskit.conf.only_load_models = true
 Syskit.conf.disables_local_process_server = true
 Roby.app.ignore_all_load_errors = true
+Roby.app.development_mode = false
 
 direct_files, model_names = remaining.partition do |arg|
     File.file?(arg)
 end
+
 # Load all task libraries if we don't get a file to require
 Roby.app.auto_load_all = load_all
-Roby.app.auto_load_models = direct_files.empty?
+Roby.app.auto_load_models = false
 Roby.app.additional_model_files.concat(direct_files)
 
 app = Qt::Application.new(ARGV)


### PR DESCRIPTION
`syskit browse` is the forgotten little brother (browser ... ahahaha :cry:) of `syskit ide`. It is an interface that allows to instanciate and display the result of arbitrary *lists* of requirements.

In our system, it for instance allows to display the result of a complete network, by instanciating the network *and* the safety compositions:

`Seabots::Compositions::AggregatedTelemetryLinks.for(primary:true,channel_id:0,peer_id:"",port_base:0,encryption_key:"",safety_status_timeout:0).use("actual_safety_status"=>Wetpaint::Actions::Main.safety_status_monitor_def)  safe_rudders_def constant_rudder_angle_def`

The syntax is very rough. It splits the line at spaces (so, remove spaces in arguments) and then interprets each part of the line as a separate requirement.