### PR TITLE
fix: telemetry UI behaviour on real world tests

### DIFF
--- a/lib/syskit/telemetry/async/listener.rb
+++ b/lib/syskit/telemetry/async/listener.rb
@@ -22,6 +22,10 @@ module Syskit
                     @disposable = @register_with.call
                 end
 
+                def listening?
+                    @disposable
+                end
+
                 # De-registers the callback
                 #
                 # Does nothing if the listener is already started

--- a/lib/syskit/telemetry/async/name_service.rb
+++ b/lib/syskit/telemetry/async/name_service.rb
@@ -129,7 +129,9 @@ module Syskit
                 def async_discover_task(task)
                     future = Concurrent::Promises.future_on(@discovery_executor) do
                         ior = @iors.get[task.name]
-                        discover_task(task.name, ior, task.orogen_model_name)
+                        # ior will be nil if the task has been removed from the task
+                        # set while the future was pending
+                        discover_task(task.name, ior, task.orogen_model_name) if ior
                     end
                     @discovery[task.name] = AsyncDiscovery.new(task: task, future: future)
                 end
@@ -202,6 +204,8 @@ module Syskit
                 #
                 # @param [AsyncDiscovery] async_discovery
                 def finished_discovery_validate_ior(async_discovery)
+                    return unless async_discovery.task
+
                     current_ior = @iors.get[async_discovery.task.name]
                     return unless current_ior
 
@@ -239,6 +243,9 @@ module Syskit
                     [ior, async_task]
                 rescue StandardError => e
                     warn "Failed discovery of task #{name}: #{e.message}"
+                    e.backtrace.each do |line|
+                        warn "  #{line}"
+                    end
                     [ior, nil]
                 end
 

--- a/lib/syskit/telemetry/async/port_read_manager.rb
+++ b/lib/syskit/telemetry/async/port_read_manager.rb
@@ -13,7 +13,7 @@ module Syskit
                     read_executor: self.class.default_read_executor
                 )
                     @callbacks = {}
-                    @pollers = {}
+                    @pollers = Concurrent::AtomicReference.new({})
 
                     @connection_executor = connection_executor
                     @disconnection_executor = disconnection_executor
@@ -188,26 +188,30 @@ module Syskit
                     end
 
                     update_poller_period(poller)
-                    @pollers[port] = poller
+                    @pollers.update { |h| h.merge(port => poller) }
                 end
 
                 # @api private
                 #
                 # Remove the poller for a given port
                 def remove_poller(port)
-                    return unless (poller = @pollers.delete(port))
+                    poller = nil
+                    @pollers.update do |h|
+                        result = h.dup
+                        poller = result.delete(port)
+                        result
+                    end
 
-                    poller.dispose
+                    poller&.dispose
                 end
 
                 def dispose
-                    @pollers.each_value(&:dispose)
-                    @pollers = {}
+                    @pollers.get_and_set({}).each_value(&:dispose)
                 end
 
                 # Whether we are currently polling the given port
                 def polling?(port)
-                    @pollers.key?(port)
+                    @pollers.get.key?(port)
                 end
 
                 # Update a poller's period to match the callbacks currently listening
@@ -220,13 +224,13 @@ module Syskit
                 #
                 # @return [Reader,nil]
                 def find_poller_for_port(port)
-                    @pollers[port]
+                    @pollers.get[port]
                 end
 
                 # Method called regularly to update the asynchronous class state
                 def poll
                     now = monotonic_time
-                    @pollers.each_value do |p|
+                    @pollers.get.each_value do |p|
                         p.poll
 
                         process_poller_state(p, now)

--- a/lib/syskit/telemetry/async/readable_interface_object.rb
+++ b/lib/syskit/telemetry/async/readable_interface_object.rb
@@ -25,6 +25,10 @@ module Syskit
                         @disposable = @object.send(@event, &@block)
                     end
 
+                    def listening?
+                        @disposable
+                    end
+
                     def stop
                         @disposable&.dispose
                         @disposable = nil

--- a/lib/syskit/telemetry/ui/runtime_state.rb
+++ b/lib/syskit/telemetry/ui/runtime_state.rb
@@ -145,6 +145,7 @@ module Syskit
 
                     @current_job = nil
                     @current_job_tasks = []
+                    @current_job_task_names = []
                     @current_tasks = []
 
                     syskit.on_ui_event do |event_name, *args|
@@ -571,6 +572,7 @@ module Syskit
 
                 def reset_current_job
                     @current_job = nil
+                    @current_job_tasks = []
                     @current_job_task_names = []
 
                     update_task_inspector(@name_service.tasks)
@@ -610,13 +612,14 @@ module Syskit
 
                 def update_current_job_task_names
                     polling_call [], "tasks_of_job", @current_job.job_id do |tasks|
-                        # TODO: handle asynchronicity, the tasks may not be already
-                        # discovered and/or the
-                        @current_job_tasks =
+                        @current_job_task_names =
                             tasks
                             .map { _1.arguments[:orocos_name] }
                             .compact
+                        @current_job_tasks =
+                            @current_job_task_names
                             .map { @name_service.find(_1) }
+                            .compact
                     end
                 end
 
@@ -669,13 +672,24 @@ module Syskit
                 end
 
                 def update_name_service(deployments)
-                    all_deployed_tasks = deployments.flat_map do |d|
+                    deployed_tasks = deployments.flat_map do |d|
                         d.deployed_tasks.find_all do |deployed_task|
                             model_name = deployed_task.orogen_model_name
                             !hide_loggers? || !OROGEN_LOGGER_NAMES.include?(model_name)
                         end
                     end
-                    @name_service.async_update_tasks(all_deployed_tasks)
+
+                    if @current_job
+                        # If we are focussing, keep the tasks that have already been
+                        # discovered, but resolve the ones that interest the user first
+                        focussed_names =
+                            (@name_service.names + @current_job_task_names).to_set
+                        deployed_tasks.delete_if do |t|
+                            !focussed_names.include?(t.name)
+                        end
+                    end
+
+                    @name_service.async_update_tasks(deployed_tasks)
                 end
 
                 OROGEN_LOGGER_NAMES = %w[logger::Logger OroGen.logger.Logger].freeze


### PR DESCRIPTION
Fix behaviour of the `telemetry ui` (in its current state).
- fix crash when selecting jobs
- fix discovery behaviour (now prefers resolving tasks of the selected job)
- fix thread safety

This PR does not fix a problem with the display of the task states (it may stay on INITIALIZING while ports can be read already)