### PR TITLE
fix: use implicit ftps as a boolean option instead of receiving it as a string

### DIFF
--- a/lib/syskit/cli/log_runtime_archive_main.rb
+++ b/lib/syskit/cli/log_runtime_archive_main.rb
@@ -72,7 +72,7 @@ module Syskit
             option :max_upload_rate_mbps,
                    type: :numeric, default: 1_000, desc: "max upload rate in Mbps"
             option :implicit_ftps,
-                   type: :boolean, default: true,
+                   type: :boolean, default: false,
                    desc: "use implicit connection method for ftps " \
                          "(disable for 2.5 clients on 2.7 servers)"
             def watch_transfer( # rubocop:disable Metrics/ParameterLists
@@ -95,7 +95,7 @@ module Syskit
             option :max_upload_rate_mbps,
                    type: :numeric, default: 1_000, desc: "max upload rate in Mbps"
             option :implicit_ftps,
-                   type: :boolean, default: true,
+                   type: :boolean, default: false,
                    desc: "use implicit connection method for ftps " \
                          "(disable for 2.5 clients on 2.7 servers)"
             def transfer( # rubocop:disable Metrics/ParameterLists
@@ -116,7 +116,7 @@ module Syskit
             desc "transfer_server TARGET_DIR HOST PORT CERTFILE_PATH USER PASSWORD",
                  "creates the log transfer FTP server that runs on the main computer"
             option :implicit_ftps,
-                   type: :boolean, default: true,
+                   type: :boolean, default: false,
                    desc: "use implicit connection method for ftps " \
                          "(disable for 2.5 clients on 2.7 servers)"
             def transfer_server( # rubocop:disable Metrics/ParameterLists

--- a/lib/syskit/cli/log_runtime_archive_main.rb
+++ b/lib/syskit/cli/log_runtime_archive_main.rb
@@ -16,7 +16,8 @@ module Syskit
                 true
             end
 
-            desc "watch", "watch a dataset root folder and call archiver"
+            desc "watch ROOT_DIR TARGET_DIR",
+                 "watch a dataset root folder and call archiver"
             option :period,
                    type: :numeric, default: 600, desc: "polling period in seconds"
             option :max_size,
@@ -40,7 +41,8 @@ module Syskit
                 end
             end
 
-            desc "archive", "archive the datasets and manages disk space"
+            desc "archive ROOT_DIR TARGET_DIR",
+                 "archive the datasets and manages disk space"
             option :max_size,
                    type: :numeric, default: 10_000, desc: "max log size in MB"
             option :free_space_low_limit,
@@ -63,8 +65,8 @@ module Syskit
                 )
             end
 
-            desc "watch_transfer", "watches a dataset root folder \
-                                    and periodically performs transfer"
+            desc "watch_transfer SOURCE_DIR HOST PORT CERTIFICATE_PATH USER PASSWORD",
+                 "watches a dataset root folder and periodically performs transfer"
             option :period,
                    type: :numeric, default: 600, desc: "polling period in seconds"
             option :max_upload_rate_mbps,
@@ -88,7 +90,8 @@ module Syskit
                 end
             end
 
-            desc "transfer", "transfers the datasets"
+            desc "transfer SOURCE_DIR HOST PORT CERTIFICATE_PATH USER PASSWORD",
+                 "transfers the datasets"
             option :max_upload_rate_mbps,
                    type: :numeric, default: 1_000, desc: "max upload rate in Mbps"
             option :implicit_ftps,
@@ -110,7 +113,7 @@ module Syskit
                 archiver.process_root_folder_transfer(server_params)
             end
 
-            desc "transfer_server TARGET_DIR HOST CERFILE_PATH PASSWORD",
+            desc "transfer_server TARGET_DIR HOST PORT CERTFILE_PATH USER PASSWORD",
                  "creates the log transfer FTP server that runs on the main computer"
             option :implicit_ftps,
                    type: :boolean, default: true,
@@ -124,7 +127,8 @@ module Syskit
                 server.run
             end
 
-            desc "watch_ensure_free_space", "watches the ensure free space process"
+            desc "watch_ensure_free_space SOURCE_DIR",
+                 "watches the ensure free space process"
             option :period,
                    type: :numeric, default: 10, desc: "polling period in seconds"
             option :free_space_low_limit,
@@ -143,8 +147,8 @@ module Syskit
                 end
             end
 
-            desc "ensure_free_space", "ensures there is free space, if not, start \
-                                       deleting files"
+            desc "ensure_free_space SOURCE_DIR",
+                 "ensures there is free space, if not, start deleting files"
             option :free_space_low_limit,
                    type: :numeric, default: 5_000, desc: "start deleting files if \
                     available space is below this threshold (threshold in MB)"

--- a/lib/syskit/cli/log_runtime_archive_main.rb
+++ b/lib/syskit/cli/log_runtime_archive_main.rb
@@ -69,13 +69,16 @@ module Syskit
                    type: :numeric, default: 600, desc: "polling period in seconds"
             option :max_upload_rate_mbps,
                    type: :numeric, default: 1_000, desc: "max upload rate in Mbps"
+            option :implicit_ftps,
+                   type: :boolean, default: true,
+                   desc: "use implicit connection method for ftps " \
+                         "(disable for 2.5 clients on 2.7 servers)"
             def watch_transfer( # rubocop:disable Metrics/ParameterLists
-                source_dir, host, port, certificate_path, user, password, implicit_ftps
+                source_dir, host, port, certificate_path, user, password
             )
                 loop do
                     begin
-                        transfer(source_dir, host, port, certificate_path, user, password,
-                                 implicit_ftps)
+                        transfer(source_dir, host, port, certificate_path, user, password)
                     rescue Errno::ENOSPC
                         next
                     end
@@ -88,8 +91,12 @@ module Syskit
             desc "transfer", "transfers the datasets"
             option :max_upload_rate_mbps,
                    type: :numeric, default: 1_000, desc: "max upload rate in Mbps"
+            option :implicit_ftps,
+                   type: :boolean, default: true,
+                   desc: "use implicit connection method for ftps " \
+                         "(disable for 2.5 clients on 2.7 servers)"
             def transfer( # rubocop:disable Metrics/ParameterLists
-                source_dir, host, port, certificate_path, user, password, implicit_ftps
+                source_dir, host, port, certificate_path, user, password
             )
                 source_dir = validate_directory_exists(source_dir)
                 archiver = make_archiver(source_dir)
@@ -97,19 +104,23 @@ module Syskit
                 server_params = LogRuntimeArchive::FTPParameters.new(
                     host: host, port: port, certificate: File.read(certificate_path),
                     user: user, password: password,
-                    implicit_ftps: implicit_ftps,
+                    implicit_ftps: options[:implicit_ftps],
                     max_upload_rate: rate_mbps_to_bps(options[:max_upload_rate_mbps])
                 )
                 archiver.process_root_folder_transfer(server_params)
             end
 
-            desc "transfer_server", "creates the log transfer FTP server \
-                                     that runs on the main computer"
+            desc "transfer_server TARGET_DIR HOST CERFILE_PATH PASSWORD",
+                 "creates the log transfer FTP server that runs on the main computer"
+            option :implicit_ftps,
+                   type: :boolean, default: true,
+                   desc: "use implicit connection method for ftps " \
+                         "(disable for 2.5 clients on 2.7 servers)"
             def transfer_server( # rubocop:disable Metrics/ParameterLists
-                target_dir, host, port, certfile_path, user, password, implicit_ftps
+                target_dir, host, port, certfile_path, user, password
             )
                 server = create_server(target_dir, host, port, certfile_path, user,
-                                       password, implicit_ftps == "true")
+                                       password, options[:implicit_ftps])
                 server.run
             end
 

--- a/test/cli/test_log_runtime_archive_main.rb
+++ b/test/cli/test_log_runtime_archive_main.rb
@@ -189,12 +189,16 @@ module Syskit
 
                     tic = Time.now
                     assert_raises(quit) do
+                        updated_server_params = @server_params
+                        implicit_ftps = updated_server_params[:implicit_ftps]
+                        updated_server_params.delete(:implicit_ftps)
                         args = [
                             "watch_transfer",
                             @source_dir,
-                            *@server_params.values,
+                            *updated_server_params.values,
                             "--period", 0.5,
-                            "--max_upload_rate_mbps", 10
+                            "--max_upload_rate_mbps", 10,
+                            "--implicit_ftps", implicit_ftps
                         ]
                         LogRuntimeArchiveMain.start(args)
                     end
@@ -238,11 +242,14 @@ module Syskit
                 # Call 'transfer' function instead of 'watch' to call transfer once
                 def call_transfer(source_dir, server_port: nil)
                     updated_server_params = @server_params
+                    implicit_ftps = updated_server_params[:implicit_ftps]
+                    updated_server_params.delete(:implicit_ftps)
                     updated_server_params[:port] = server_port if server_port
                     args = [
                         "transfer",
                         source_dir,
-                        *updated_server_params.values
+                        *updated_server_params.values,
+                        "--implicit_ftps", implicit_ftps
                     ]
                     LogRuntimeArchiveMain.start(args)
                 end

--- a/test/cli/test_log_runtime_archive_main.rb
+++ b/test/cli/test_log_runtime_archive_main.rb
@@ -190,7 +190,12 @@ module Syskit
                     tic = Time.now
                     assert_raises(quit) do
                         updated_server_params = @server_params
-                        implicit_ftps = updated_server_params[:implicit_ftps]
+                        implicit_ftps_arg =
+                            if updated_server_params[:implicit_ftps]
+                                "--implicit_ftps"
+                            else
+                                "--no-implicit_ftps"
+                            end
                         updated_server_params.delete(:implicit_ftps)
                         args = [
                             "watch_transfer",
@@ -198,7 +203,7 @@ module Syskit
                             *updated_server_params.values,
                             "--period", 0.5,
                             "--max_upload_rate_mbps", 10,
-                            "--implicit_ftps", implicit_ftps
+                            implicit_ftps_arg
                         ]
                         LogRuntimeArchiveMain.start(args)
                     end
@@ -242,14 +247,19 @@ module Syskit
                 # Call 'transfer' function instead of 'watch' to call transfer once
                 def call_transfer(source_dir, server_port: nil)
                     updated_server_params = @server_params
-                    implicit_ftps = updated_server_params[:implicit_ftps]
+                    implicit_ftps_arg =
+                        if updated_server_params[:implicit_ftps]
+                            "--implicit_ftps"
+                        else
+                            "--no-implicit_ftps"
+                        end
                     updated_server_params.delete(:implicit_ftps)
                     updated_server_params[:port] = server_port if server_port
                     args = [
                         "transfer",
                         source_dir,
                         *updated_server_params.values,
-                        "--implicit_ftps", implicit_ftps
+                        implicit_ftps_arg
                     ]
                     LogRuntimeArchiveMain.start(args)
                 end


### PR DESCRIPTION
1. It was supposed to receive a bool, not a string of true or false.

Tested with real logs:
![image](https://github.com/user-attachments/assets/befd50ce-d7b8-4cdc-97e6-16b2a9bc1d54)

2. There was missing documentation for the cli commands.
![image](https://github.com/user-attachments/assets/fb41767b-1b44-4daf-ae3f-2525d18bd6ea)

