### PR TITLE
fix: provide proper quarantine reasons

### DIFF
--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -661,7 +661,14 @@ module Syskit
         # RTT state, we make sure that the component is actually stopped *and* that
         # catch other state transitions, such as FATAL_ERROR
         def update_orogen_state_in_exception(state)
-            quarantined! if Time.now > @exception_transition_deadline
+            if Time.now > @exception_transition_deadline
+                quarantined!(
+                    reason: "time out reached while waiting for the task to stop " \
+                            "after it indicated a transition to an exception state. " \
+                            "Received state updates: " \
+                            "#{@pending_exception_states.map(&:to_s).join(', ')}"
+                )
+            end
 
             push_pending_exception_state(state) if state
             @exception_confirmation_received ||= has_exception_confirmation?
@@ -1046,7 +1053,8 @@ module Syskit
         def setup_failed!(exception)
             unless exception.kind_of?(Orocos::StateTransitionFailed)
                 fatal "Unexpected error '#{exception}' received while configuring"
-                fatal "Component #{self} is put in quarantine and cannot be reused"
+                fatal "Component #{self} is put in quarantine and cannot be reused " \
+                      "until its deployment has been restarted"
                 execution_agent.register_task_context_in_fatal(orocos_name)
             end
 
@@ -1099,8 +1107,8 @@ module Syskit
                 unless exception.kind_of?(Orocos::StateTransitionFailed)
                     fatal "#{exception} received while starting " \
                           "#{orocos_name}, expected a StateTransitionFailed " \
-                          "error. The component is put in quarantine and " \
-                          "cannot be reused"
+                          "error. The component cannot be reused until its deployment " \
+                          "has been restarted"
                     execution_agent.register_task_context_in_fatal(orocos_name)
                 end
 
@@ -1211,7 +1219,7 @@ module Syskit
                     end
                 promise.on_error(description: "#{self}#interrupt#error") do |error|
                     if execution_agent && !error.kind_of?(Orocos::StateTransitionFailed)
-                        quarantined!
+                        quarantined!(reason: "task's stop call raised: #{error}")
                     end
                 end
 

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -607,7 +607,8 @@ module Syskit
             quarantined!
 
             # Have we already degraded to using RemoteStateGetter ?
-            # Do NOT use quarantined?. It can mean other things.
+            # Do NOT use quarantined?. quarantined! could have been called by something
+            # else than validate_state_reader_connected
             if @state_reader == @remote_state_getter
                 # We already had degraded to the remote state getter ... there's
                 # nothing more we can do

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -604,7 +604,6 @@ module Syskit
             return true if state_reader.connected?
 
             queue_last_chance_to_stop if running? && !stop_event.pending?
-            quarantined!
 
             # Have we already degraded to using RemoteStateGetter ?
             # Do NOT use quarantined?. quarantined! could have been called by something
@@ -626,18 +625,23 @@ module Syskit
 
                 false
             else
+                quarantined!(reason: "the task's state reader got disconnected")
+
                 # Switch to the remote state getter to at least figure out
                 # in which toplevel state we are. The component is unusable
                 # as is, but we can finish whatever transition it is doing
                 # (and stop it cleanly)
-                fatal "putting #{self} in quarantine, its state reader " \
-                      "#{state_reader} got disconnected"
-
                 @state_reader = @remote_state_getter
                 @remote_state_getter.resume_or_start
 
                 true
             end
+        end
+
+        # Whether self is waiting for the component to stop after it entered
+        # an exception state
+        def waiting_for_stop_after_exception?
+            @exception_transition_deadline
         end
 
         # @api private
@@ -666,9 +670,10 @@ module Syskit
                 @last_orogen_state = @orogen_state
                 @orogen_state = @pending_exception_states.shift
             elsif !@remote_state_getter.connected?
-                fatal "putting #{self} in quarantine, its remote state reader " \
-                      "#{@remote_state_getter} failed during exception handling"
-                quarantined!
+                quarantined!(
+                    reason: "the task's remote state getter got disconnected " \
+                            "during exception handling"
+                )
                 # Don't stop like in #handle_state_reader_disconnection, the component
                 # is currently transitioning to exception, a.k.a. already stopping
             end

--- a/test/live/test_blocking_hooks.rb
+++ b/test/live/test_blocking_hooks.rb
@@ -157,10 +157,12 @@ module Syskit
 
                     synchronize_on_sleep(task) { task.start! }
 
-                    expect_execution { task.stop! }.timeout(5).to do
-                        quarantine task
-                    end
+                    expect_execution { task.stop! }
+                        .timeout(5)
+                        .to_quarantine(task)
                     refute @deployment.task_context_in_fatal?(@task.orocos_name)
+                    assert_equal "task's stop call raised: Timeout",
+                                 @task.quarantine_reason
                 end
 
                 it "stops the task if the stop eventually works" do
@@ -172,7 +174,7 @@ module Syskit
 
                     expect_execution { task.stop! }
                         .timeout(1.5).join_all_waiting_work(false)
-                        .to { quarantine task }
+                        .to_quarantine(task)
                     expect_execution.to { emit task.stop_event }
                     refute @deployment.task_context_in_fatal?(@task.orocos_name)
                 end
@@ -197,6 +199,11 @@ module Syskit
                         emit task.aborted_event
                         emit deployment.kill_event
                     end
+
+                    assert_match(
+                        /task's stop call raised: Communication failed with corba/,
+                        @task.quarantine_reason
+                    )
                 end
             end
 
@@ -224,9 +231,11 @@ module Syskit
                     Orocos::CORBA.call_timeout = 1_000
                     syskit_configure_and_start(@task)
 
-                    expect_execution { task.stop! }.timeout(5).to do
-                        quarantine task
-                    end
+                    expect_execution { task.stop! }
+                        .timeout(5)
+                        .to_quarantine(task)
+                    assert_equal "task's stop call raised: Timeout",
+                                 @task.quarantine_reason
                     refute @deployment.task_context_in_fatal?(@task.orocos_name)
                 end
 
@@ -237,8 +246,10 @@ module Syskit
 
                     expect_execution { task.stop! }
                         .timeout(1.5).join_all_waiting_work(false)
-                        .to { quarantine task }
+                        .to_quarantine(task)
                     expect_execution.to { emit task.stop_event }
+                    assert_equal "task's stop call raised: Timeout",
+                                 @task.quarantine_reason
                     refute @deployment.task_context_in_fatal?(@task.orocos_name)
                 end
 
@@ -248,7 +259,7 @@ module Syskit
                     syskit_configure_and_start(task)
 
                     start = Time.now
-                    expect_execution { task.stop! }.join_all_waiting_work(false).to do
+                    expect_execution { task.stop! }.to do
                         poll do
                             kill_agent_once_in_poll(task) if (Time.now - start) > 1
                         end
@@ -260,6 +271,10 @@ module Syskit
                         emit task.aborted_event
                         emit deployment.kill_event
                     end
+                    assert_match(
+                        /task's stop call raised: Communication failed with corba/,
+                        @task.quarantine_reason
+                    )
                 end
             end
 
@@ -285,9 +300,13 @@ module Syskit
                     Syskit.conf.exception_transition_timeout = 1
                     syskit_configure_and_start(@task)
 
-                    expect_execution.timeout(5).to do
-                        quarantine task
-                    end
+                    expect_execution.timeout(5).to_quarantine(task)
+                    assert_equal(
+                        "time out reached while waiting for the task to stop " \
+                        "after it indicated a transition to an exception state. " \
+                        "Received state updates: EXCEPTION",
+                        task.quarantine_reason
+                    )
                     refute @deployment.task_context_in_fatal?(@task.orocos_name)
                 end
 
@@ -305,18 +324,24 @@ module Syskit
 
                 it "handles the task being killed in the middle of a long transition" do
                     @task.properties.time = 10
-                    Syskit.conf.exception_transition_timeout = 2
+                    Syskit.conf.exception_transition_timeout = 1
                     syskit_configure_and_start(task)
 
                     start = Time.now
                     expect_execution.join_all_waiting_work(false).to do
                         poll do
-                            kill_agent_once_in_poll(task) if (Time.now - start) > 1
+                            kill_agent_once_in_poll(task) if (Time.now - start) > 2
                         end
                         ignore_errors_from quarantine(task)
                         emit task.aborted_event
                         emit deployment.kill_event
                     end
+
+                    assert_equal(
+                        "time out reached while waiting for the task to stop " \
+                        "after it indicated a transition to an exception state. " \
+                        "Received state updates: EXCEPTION", task.quarantine_reason
+                    )
                 end
             end
 

--- a/test/live/test_blocking_hooks.rb
+++ b/test/live/test_blocking_hooks.rb
@@ -79,7 +79,7 @@ module Syskit
                     Orocos::CORBA.call_timeout = 2_000
                     start = Time.now
 
-                    expect_execution.scheduler(true).join_all_waiting_work(false).to do
+                    expect_execution.scheduler(true).to do
                         poll do
                             if task.setting_up? && (Time.now - start) > 1
                                 kill_agent_once_in_poll(task)
@@ -119,7 +119,7 @@ module Syskit
                     Orocos::CORBA.call_timeout = 2_000
                     start = Time.now
 
-                    expect_execution.scheduler(true).join_all_waiting_work(false).to do
+                    expect_execution.scheduler(true).to do
                         poll do
                             if task.start_event.pending? && (Time.now - start) > 1
                                 kill_agent_once_in_poll(task)
@@ -187,7 +187,7 @@ module Syskit
                     synchronize_on_sleep(task) { task.start! }
 
                     start = Time.now
-                    expect_execution { task.stop! }.join_all_waiting_work(false).to do
+                    expect_execution { task.stop! }.to do
                         poll do
                             kill_agent_once_in_poll(task) if (Time.now - start) > 1
                         end
@@ -200,10 +200,17 @@ module Syskit
                         emit deployment.kill_event
                     end
 
-                    assert_match(
-                        /task's stop call raised: Communication failed with corba/,
-                        @task.quarantine_reason
-                    )
+                    # NOTE: the quarantine/have_error_matching may or may not happen
+                    # It is a race between the kill (abort_event) and processing the
+                    # report of CORBA reporting the connection error. This race is
+                    # inherent to the test
+
+                    if @task.quarantined?
+                        assert_match(
+                            /task's stop call raised: Communication failed with corba/,
+                            @task.quarantine_reason
+                        )
+                    end
                 end
             end
 
@@ -271,10 +278,18 @@ module Syskit
                         emit task.aborted_event
                         emit deployment.kill_event
                     end
-                    assert_match(
-                        /task's stop call raised: Communication failed with corba/,
-                        @task.quarantine_reason
-                    )
+
+                    # NOTE: the quarantine/have_error_matching may or may not happen
+                    # It is a race between the kill (abort_event) and processing the
+                    # report of CORBA reporting the connection error. This race is
+                    # inherent to the test
+
+                    if @task.quarantined?
+                        assert_match(
+                            /task's stop call raised: Communication failed with corba/,
+                            @task.quarantine_reason
+                        )
+                    end
                 end
             end
 

--- a/test/live/test_state_reader_disconnection.rb
+++ b/test/live/test_state_reader_disconnection.rb
@@ -47,9 +47,11 @@ module Syskit
                     have_one_new_sample task.sleep_start_port
                 end
                 expect_execution { task.state_reader.disconnect }
-                    .to { quarantine(task) }
+                    .to_quarantine(task)
 
                 assert task.setup?
+                assert_equal "the task's state reader got disconnected",
+                             task.quarantine_reason
             end
         end
 
@@ -67,6 +69,8 @@ module Syskit
                         emit task.start_event
                     end
 
+                assert_equal "the task's state reader got disconnected",
+                             task.quarantine_reason
                 syskit_stop(task)
             end
 
@@ -79,6 +83,8 @@ module Syskit
                         fail_to_start task
                     end
 
+                assert_equal "the task's state reader got disconnected",
+                             task.quarantine_reason
                 deployment_kill
             end
         end
@@ -101,6 +107,8 @@ module Syskit
                         quarantine(task)
                         emit task.stop_event
                     end
+                assert_equal "the task's state reader got disconnected",
+                             task.quarantine_reason
             end
 
             it "does nothing more if the remote getter is lost as well" do
@@ -109,10 +117,12 @@ module Syskit
                 flexmock(task).should_receive(:queue_last_chance_to_stop)
                 expect_execution { task.state_reader.disconnect }
                     .join_all_waiting_work(false)
-                    .to { quarantine task }
+                    .to_quarantine(task)
 
+                assert_equal "the task's state reader got disconnected",
+                             task.quarantine_reason
                 sleep 2.5
-                expect_execution.to { not_emit task.stop_event }
+                expect_execution.to_not_emit(task.stop_event)
 
                 deployment_kill
             end
@@ -131,16 +141,21 @@ module Syskit
                         quarantine(task)
                         emit task.stop_event
                     end
+                assert_equal "the task's state reader got disconnected",
+                             task.quarantine_reason
             end
 
             it "does nothing more if the remote getter is lost as well" do
                 mock_disconnected_remote_state_getter
                 expect_execution { task.state_reader.disconnect }
                     .join_all_waiting_work(false)
-                    .to { quarantine task }
+                    .to_quarantine(task)
+
+                assert_equal "the task's state reader got disconnected",
+                             task.quarantine_reason
 
                 sleep 2.5
-                expect_execution.to { not_emit task.stop_event }
+                expect_execution.to_not_emit(task.stop_event)
 
                 deployment_kill
             end
@@ -151,26 +166,49 @@ module Syskit
                 @task.properties.hook = "exception"
                 syskit_configure(@task)
                 synchronize_on_sleep(task, execute: -> { task.start! })
+                wait_for_exception
             end
 
-            it "goes into quarantine and falls back to the remote state getter" do
+            it "goes into quarantine and manages to stop anyway" do
                 expect_execution { task.state_reader.disconnect }
                     .to do
                         quarantine(task)
                         emit task.exception_event
                     end
+
+                assert_equal "the task's state reader got disconnected",
+                             task.quarantine_reason
             end
 
-            it "does nothing more if the remote getter is lost as well" do
+            it "enters quarantine and stop updating if the remote state getter fails" do
                 mock_disconnected_remote_state_getter
-                expect_execution { task.state_reader.disconnect }
+                expect_execution
                     .join_all_waiting_work(false)
-                    .to { quarantine task }
+                    .to_quarantine(task)
 
-                sleep 2.5
-                expect_execution.to { not_emit task.stop_event }
+                assert_equal "the task's remote state getter got disconnected " \
+                             "during exception handling",
+                             task.quarantine_reason
+
+                expect_execution.to_not_emit(task.stop_event, within: 2.5)
 
                 deployment_kill
+            end
+
+            it "opportunistically reads the remote state getter's pending state " \
+               "updates even if disconnected" do
+                mock_disconnected_remote_state_getter(
+                    return_read: %I[RUNNING EXCEPTION]
+                )
+                expect_execution
+                    .join_all_waiting_work(false)
+                    .to_quarantine(task)
+
+                assert_equal "the task's remote state getter got disconnected " \
+                             "during exception handling",
+                             task.quarantine_reason
+
+                expect_execution.to_emit(task.stop_event)
             end
         end
 
@@ -180,19 +218,26 @@ module Syskit
                 @task.properties.hook = "exception"
                 syskit_configure(@task)
                 synchronize_on_sleep(task, execute: -> { task.start! })
+                wait_for_exception
             end
 
             it "goes into quarantine and processes the exception normally" do
                 mock_disconnected_remote_state_getter
-                expect_execution.join_all_waiting_work(false).to { quarantine(task) }
+                expect_execution.join_all_waiting_work(false).to_quarantine(task)
+
+                assert_equal "the task's remote state getter got disconnected " \
+                             "during exception handling",
+                             task.quarantine_reason
 
                 sleep 2.5
-                expect_execution.to { emit task.stop_event }
+                expect_execution.to_emit(task.stop_event)
             end
         end
 
-        def mock_disconnected_remote_state_getter
+        def mock_disconnected_remote_state_getter(return_read: [nil])
             task_info = task.execution_agent.remote_task_handles[task.orocos_name]
+            flexmock(task_info.state_getter)
+                .should_receive(:read).and_return(*return_read)
             flexmock(task_info.state_getter)
                 .should_receive(:connected?).and_return(false)
         end
@@ -225,6 +270,10 @@ module Syskit
                     emit task.aborted_event if task.running?
                     ignore_errors_from quarantine(task)
                 end
+        end
+
+        def wait_for_exception
+            expect_execution.to_achieve { task.waiting_for_stop_after_exception? }
         end
     end
 end

--- a/test/live/test_state_reader_disconnection.rb
+++ b/test/live/test_state_reader_disconnection.rb
@@ -212,28 +212,6 @@ module Syskit
             end
         end
 
-        describe "when only losing the remote state reader " \
-                 "while processing an exception" do
-            before do
-                @task.properties.hook = "exception"
-                syskit_configure(@task)
-                synchronize_on_sleep(task, execute: -> { task.start! })
-                wait_for_exception
-            end
-
-            it "goes into quarantine and processes the exception normally" do
-                mock_disconnected_remote_state_getter
-                expect_execution.join_all_waiting_work(false).to_quarantine(task)
-
-                assert_equal "the task's remote state getter got disconnected " \
-                             "during exception handling",
-                             task.quarantine_reason
-
-                sleep 2.5
-                expect_execution.to_emit(task.stop_event)
-            end
-        end
-
         def mock_disconnected_remote_state_getter(return_read: [nil])
             task_info = task.execution_agent.remote_task_handles[task.orocos_name]
             flexmock(task_info.state_getter)


### PR DESCRIPTION
On top of #488 

Depends on:
- [ ] https://github.com/rock-core/tools-roby/pull/327
- [ ] https://github.com/rock-core/tools-roby/pull/328

We recently did hit a bug during exception handling of a component, which triggered the exception timeout sanity check mechanism. This mechanism would not give us proper information about what was happening (only that the component was put in quarantine)

This PR adds the proper reasons, adding in particular the list of exceptions that trigger the sanity check - informing why the component transitioned to exception in a first place.