### PR TITLE
fix: validate resolution error processing and garbage collect after cleanup

### DIFF
--- a/lib/syskit/exceptions.rb
+++ b/lib/syskit/exceptions.rb
@@ -444,6 +444,8 @@ module Syskit
         def initialize(device, task0, task1, toplevel_tasks_to_requirements = {})
             @device = device
             @tasks = [task0, task1]
+            merge_solver = NetworkGeneration::MergeSolver.new(task0.plan)
+            @merge_result = merge_solver.resolve_merge(task0, task1, {})
 
             @involved_definitions = @tasks.map do |t|
                 find_all_related_syskit_actions(t, toplevel_tasks_to_requirements)
@@ -453,7 +455,8 @@ module Syskit
         def pretty_print(pp)
             pp.text "device '#{device.name}' of type #{device.model} is assigned "
             pp.text "to two tasks that cannot be merged"
-            print_failed_merge_chain(pp, *@tasks)
+            pp.breakable
+            @merge_result.pretty_print_failure(pp)
             @tasks.zip(@involved_definitions).each do |t, defs|
                 print_dependent_definitions(pp, t, defs)
             end
@@ -470,6 +473,8 @@ module Syskit
             @tasks = tasks
             @toplevel_tasks_to_requirements = toplevel_tasks_to_requirements
             @agent = tasks.first.execution_agent
+            merge_solver = NetworkGeneration::MergeSolver.new(tasks[0].plan)
+            @merge_result = merge_solver.resolve_merge(tasks[0], tasks[1], {})
         end
 
         def pretty_print(pp)
@@ -488,7 +493,8 @@ module Syskit
                 )
                 print_dependent_definitions(pp, t, defs)
             end
-            print_failed_merge_chain(pp, @tasks[0], @tasks[1])
+            pp.breakable
+            @merge_result.pretty_print_failure(pp)
         end
     end
 

--- a/lib/syskit/exceptions.rb
+++ b/lib/syskit/exceptions.rb
@@ -444,8 +444,9 @@ module Syskit
         def initialize(device, task0, task1, toplevel_tasks_to_requirements = {})
             @device = device
             @tasks = [task0, task1]
-            merge_solver = NetworkGeneration::MergeSolver.new(task0.plan)
-            @merge_result = merge_solver.resolve_merge(task0, task1, {})
+            @merge_result = NetworkGeneration::MergeSolver.resolve_merge(
+                tasks[0].plan, tasks[0], tasks[1], {}
+            )
 
             @involved_definitions = @tasks.map do |t|
                 find_all_related_syskit_actions(t, toplevel_tasks_to_requirements)
@@ -473,8 +474,9 @@ module Syskit
             @tasks = tasks
             @toplevel_tasks_to_requirements = toplevel_tasks_to_requirements
             @agent = tasks.first.execution_agent
-            merge_solver = NetworkGeneration::MergeSolver.new(tasks[0].plan)
-            @merge_result = merge_solver.resolve_merge(tasks[0], tasks[1], {})
+            @merge_result = NetworkGeneration::MergeSolver.resolve_merge(
+                tasks[0].plan, tasks[0], tasks[1], {}
+            )
         end
 
         def pretty_print(pp)

--- a/lib/syskit/gui/component_network_base_view.rb
+++ b/lib/syskit/gui/component_network_base_view.rb
@@ -149,7 +149,7 @@ module Syskit
                 main_plan.add(original_task = model.as_plan)
                 base_task = original_task.as_service
                 engine = Syskit::NetworkGeneration::Engine.new(main_plan)
-                _, resolution_errors =
+                _, resolution_errors, =
                     engine.compute_system_network([base_task.task.planning_task])
                 [base_task.task, resolution_errors]
             ensure

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -112,9 +112,6 @@ module Syskit
                     deployer.deploy(
                         error_handler: error_handler, validate: validate_deployed_network
                     )
-                    required_instances = required_instances.transform_values do |task|
-                        merge_solver.replacement_for(task)
-                    end
                     resolution_errors = error_handler.process_failures(
                         required_instances, cleanup_failed_tasks: true
                     )
@@ -141,7 +138,7 @@ module Syskit
                 @deployment_tasks = work_plan.find_local_tasks(Deployment).to_set
                 @deployed_tasks = work_plan.find_local_tasks(Component).to_set
 
-                [required_instances, resolution_errors]
+                resolution_errors
             end
 
             # Apply the deployed network created with
@@ -761,7 +758,8 @@ module Syskit
                     system_network_generator.toplevel_tasks_to_requirements
 
                 resolution_errors = error_handler.process_failures(
-                    required_instances, cleanup_failed_tasks: cleanup_resolution_errors
+                    required_instances,
+                    cleanup_failed_tasks: cleanup_resolution_errors
                 )
                 if cleanup_resolution_errors
                     # Sanity check that the plan was properly cleaned up
@@ -834,7 +832,7 @@ module Syskit
 
                 if compute_deployments
                     log_timepoint_group "compute_deployed_network" do
-                        required_instances, deployment_resolution_errors =
+                        deployment_resolution_errors =
                             compute_deployed_network(
                                 toplevel_tasks_to_requirements,
                                 error_handler: error_handler,

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -93,6 +93,7 @@ module Syskit
             #
             # This does not access {#real_plan}
             def compute_deployed_network(
+                toplevel_tasks_to_requirements,
                 error_handler: RaiseErrorHandler.new,
                 required_instances: [],
                 default_deployment_group: Syskit.conf.deployment_group,
@@ -111,8 +112,18 @@ module Syskit
                     deployer.deploy(
                         error_handler: error_handler, validate: validate_deployed_network
                     )
+                    required_instances = required_instances.transform_values do |task|
+                        merge_solver.replacement_for(task)
+                    end
                     resolution_errors = error_handler.process_failures(
                         required_instances, cleanup_failed_tasks: true
+                    )
+                    # Sanity check that the plan was properly cleaned up
+                    SystemNetworkDeployer.verify_all_tasks_deployed(
+                        work_plan, default_deployment_group
+                    )
+                    SystemNetworkGenerator.verify_all_deployments_are_unique(
+                        work_plan, toplevel_tasks_to_requirements.dup
                     )
                 end
 
@@ -130,7 +141,7 @@ module Syskit
                 @deployment_tasks = work_plan.find_local_tasks(Deployment).to_set
                 @deployed_tasks = work_plan.find_local_tasks(Component).to_set
 
-                resolution_errors
+                [required_instances, resolution_errors]
             end
 
             # Apply the deployed network created with
@@ -741,14 +752,27 @@ module Syskit
                     garbage_collect: garbage_collect,
                     validate_abstract_network: validate_abstract_network,
                     validate_generated_network: validate_generated_network,
-                    validate_deployed_network: validate_deployed_network
+                    validate_deployed_network:
+                        early_deploy && validate_deployed_network
                 )
                 required_instances = Hash[requirement_tasks.zip(toplevel_tasks)]
 
                 resolution_errors = error_handler.process_failures(
                     required_instances, cleanup_failed_tasks: cleanup_resolution_errors
                 )
-                [required_instances, resolution_errors]
+                if cleanup_resolution_errors
+                    # Sanity check that the plan was properly cleaned up
+                    system_network_generator.validate_network(
+                        error_handler: RaiseErrorHandler.new,
+                        validate_abstract_network: validate_abstract_network,
+                        validate_generated_network: validate_generated_network,
+                        validate_deployed_network:
+                            early_deploy && validate_deployed_network
+                    )
+                end
+                toplevel_tasks_to_requirements =
+                    system_network_generator.toplevel_tasks_to_requirements.dup
+                [required_instances, resolution_errors, toplevel_tasks_to_requirements]
             end
 
             # Computes the system network, that is the network that fullfills
@@ -793,22 +817,25 @@ module Syskit
                                 else
                                     RaiseErrorHandler.new
                                 end
-                required_instances, resolution_errors = compute_system_network(
-                    requirement_tasks,
-                    error_handler: error_handler,
-                    garbage_collect: garbage_collect,
-                    validate_abstract_network: validate_abstract_network,
-                    validate_generated_network: validate_generated_network,
-                    default_deployment_group: (default_deployment_group if early_deploy),
-                    validate_deployed_network: validate_deployed_network,
-                    early_deploy: early_deploy && compute_deployments,
-                    cleanup_resolution_errors: cleanup_resolution_errors
-                )
+                required_instances, resolution_errors, toplevel_tasks_to_requirements =
+                    compute_system_network(
+                        requirement_tasks,
+                        error_handler: error_handler,
+                        garbage_collect: garbage_collect,
+                        validate_abstract_network: validate_abstract_network,
+                        validate_generated_network: validate_generated_network,
+                        default_deployment_group:
+                            (default_deployment_group if early_deploy),
+                        validate_deployed_network: validate_deployed_network,
+                        early_deploy: early_deploy && compute_deployments,
+                        cleanup_resolution_errors: cleanup_resolution_errors
+                    )
 
                 if compute_deployments
                     log_timepoint_group "compute_deployed_network" do
-                        deployment_resolution_errors =
+                        required_instances, deployment_resolution_errors =
                             compute_deployed_network(
+                                toplevel_tasks_to_requirements,
                                 error_handler: error_handler,
                                 required_instances: required_instances,
                                 default_deployment_group: default_deployment_group,

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -756,6 +756,9 @@ module Syskit
                         early_deploy && validate_deployed_network
                 )
                 required_instances = Hash[requirement_tasks.zip(toplevel_tasks)]
+                # Take toplevel tasks to requirements before cleanup
+                toplevel_tasks_to_requirements =
+                    system_network_generator.toplevel_tasks_to_requirements
 
                 resolution_errors = error_handler.process_failures(
                     required_instances, cleanup_failed_tasks: cleanup_resolution_errors
@@ -770,8 +773,6 @@ module Syskit
                             early_deploy && validate_deployed_network
                     )
                 end
-                toplevel_tasks_to_requirements =
-                    system_network_generator.toplevel_tasks_to_requirements.dup
                 [required_instances, resolution_errors, toplevel_tasks_to_requirements]
             end
 

--- a/lib/syskit/network_generation/merge_solver.rb
+++ b/lib/syskit/network_generation/merge_solver.rb
@@ -481,6 +481,11 @@ module Syskit
                 end
             end
 
+            def self.resolve_merge(plan, merged_task, task, mappings)
+                solver = MergeSolver.new(plan)
+                solver.resolve_merge(merged_task, task, mappings)
+            end
+
             # Resolve merge between N tasks with the given tasks as seeds
             #
             # The method will cycle through the task's mismatching inputs (if

--- a/lib/syskit/network_generation/resolution_error_handler.rb
+++ b/lib/syskit/network_generation/resolution_error_handler.rb
@@ -202,6 +202,15 @@ module Syskit
                     work_plan.remove_task(toplevel_task)
                     cleaned_up[requirement_task] = toplevel_task
                 end
+
+                NetworkGeneration.debug "cleanup up after error resolution"
+                protected_tasks = required_instances.values
+                work_plan
+                    .static_garbage_collect(protected_roots: protected_tasks) do |obj|
+                        NetworkGeneration.debug { "  removing #{obj}" }
+                        # Remove tasks that are not useful anymore
+                        @plan.remove_task(obj)
+                    end
             end
         end
 

--- a/lib/syskit/network_generation/resolution_error_handler.rb
+++ b/lib/syskit/network_generation/resolution_error_handler.rb
@@ -211,6 +211,7 @@ module Syskit
                         # Remove tasks that are not useful anymore
                         @plan.remove_task(obj)
                     end
+                @resolution_failures.clear
             end
         end
 

--- a/lib/syskit/network_generation/resolution_error_handler.rb
+++ b/lib/syskit/network_generation/resolution_error_handler.rb
@@ -184,27 +184,16 @@ module Syskit
             def cleanup_resolution_errors(
                 resolution_errors, required_instances, work_plan
             )
-                cleaned_up = {}
                 resolution_errors.each do |error|
                     requirement_task = error.planning_task
-                    toplevel_task = required_instances[requirement_task]
-                    if cleaned_up[requirement_task]
-                        # Even if a task have multiple resolution errors, enforce that it
-                        # is only cleaned up once.
-                        next
-                    elsif !toplevel_task
-                        raise "trying to cleanup a requirement task that doesnt have" \
-                              "a top level task assigned to it. Maybe it was already " \
-                              "cleaned up?!"
-                    end
-
                     required_instances.delete requirement_task
-                    work_plan.remove_task(toplevel_task)
-                    cleaned_up[requirement_task] = toplevel_task
                 end
+                return if resolution_errors.empty?
 
                 NetworkGeneration.debug "cleanup up after error resolution"
-                protected_tasks = required_instances.values
+                protected_tasks = required_instances.values.map do |v|
+                    @merge_solver.replacement_for(v)
+                end
                 work_plan
                     .static_garbage_collect(protected_roots: protected_tasks) do |obj|
                         NetworkGeneration.debug { "  removing #{obj}" }

--- a/test/features/capture_errors.rb
+++ b/test/features/capture_errors.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
+require "syskit"
+
 Syskit.conf.capture_errors_during_network_resolution = true

--- a/test/features/early_deploy.rb
+++ b/test/features/early_deploy.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
+require "syskit"
+
 Syskit.conf.early_deploy = true

--- a/test/network_generation/test_engine.rb
+++ b/test/network_generation/test_engine.rb
@@ -94,29 +94,6 @@ module Syskit
                 end
             end
 
-            describe "#compute_system_network" do
-                attr_reader :original_task
-                attr_reader :planning_task
-                attr_reader :requirements
-
-                before do
-                    plan.add_mission_task(@original_task = simple_component_model.as_plan)
-                    @planning_task = original_task.planning_task
-                    @requirements = planning_task.requirements
-                end
-
-                it "saves the mapping from requirement task in real_plan to instanciated task in work_plan" do
-                    flexmock(requirements).should_receive(:instanciate)
-                                          .and_return(instanciated_task = simple_component_model.new)
-                    syskit_stub_configured_deployment(simple_component_model)
-                    mapping, = syskit_engine.compute_system_network(
-                        [planning_task],
-                        default_deployment_group: default_deployment_group
-                    )
-                    assert_equal instanciated_task, mapping[planning_task]
-                end
-            end
-
             describe "#fix_toplevel_tasks" do
                 attr_reader :original_task
                 attr_reader :planning_task

--- a/test/runtime/test_apply_requirement_modifications.rb
+++ b/test/runtime/test_apply_requirement_modifications.rb
@@ -228,6 +228,27 @@ module Syskit
                     execute { Runtime.apply_requirement_modifications(plan) }
                     assert requirement_task.resolution_success?
                 end
+
+                it "clears leftover failed tasks from the plan" do
+                    srv_m = Syskit::DataService.new_submodel
+                    task_m = Syskit::TaskContext.new_submodel
+                    task_m.provides srv_m, as: "srv"
+                    cmp_m = Composition.new_submodel do
+                        add srv_m, as: "test"
+                    end
+
+                    t1 = cmp_m.as_plan
+                    requirement_task = t1.as_plan
+                    plan.add_permanent_task(requirement_task)
+                    requirement_task = requirement_task.planning_task
+                    execute { requirement_task.start! }
+                    execute { Runtime.apply_requirement_modifications(plan) }
+                    plan.syskit_current_resolution.future.value
+                    expect_execution { Runtime.apply_requirement_modifications(plan) }
+                        .to { have_error_matching Roby::PlanningFailedError }
+                    assert requirement_task.failed?
+                    refute plan.find_tasks(srv_m).first
+                end
             end
 
             def assert_resolution_cancelled # rubocop:disable Metrics/AbcSize


### PR DESCRIPTION
Not validating the resulting plan after cleanup was an obvious issue, it made bugs in the plan afterwards very hard to find. 

One of these bugs was the lack of garbage collection of unneeded tasks after we cleaned up the resolution errors. That meant that we had useless tasks THAT STILL CONTAINED ERRORS in the plan, which would constantly trigger the errors in future deployments. 

Another bug is that there was no update to the required instances between the #compute_deployed_network and #apply_deployed_network_to_plan calls, meaning that wrong required instances would be used to process the network failures (especially when the early_deploy was false)