### PR TITLE
fix: variable reference

### DIFF
--- a/lib/syskit/process_managers/remote/process.rb
+++ b/lib/syskit/process_managers/remote/process.rb
@@ -73,7 +73,9 @@ module Syskit
                         mapped_name = mapped_name_of(deployed_task.name)
                         unless (ior = @ior_mappings[mapped_name])
                             raise IORNotRegisteredError,
-                                  "no IOR is registered for #{task_name}"
+                                  "no IOR is registered for #{deployed_task.name}. The "\
+                                  "deployment model used by the process server may "\
+                                  "differ from the one used by the syskit main instance."
                         end
 
                         map[mapped_name] =


### PR DESCRIPTION
### fix: variable reference
task_name dont exist in this context, the correct variable reference is deployed_task.name. This commit also brings more information to the error message