### PR TITLE
chore: report old instance requirements only

### DIFF
--- a/lib/syskit/runtime/apply_requirement_modifications.rb
+++ b/lib/syskit/runtime/apply_requirement_modifications.rb
@@ -118,14 +118,11 @@ module Syskit
                 end
                 resolution_apply_result
             rescue ::Exception => e # rubocop:disable Lint/RescueException
-                new_requirement_tasks =
-                    running_requirement_tasks.reject(&:resolution_success?)
-                new_requirement_tasks.each do |t|
-                    t.failed_event.emit(e)
-                end
+                old_requirement_tasks, new_requirement_tasks =
+                    running_requirement_tasks.partition(&:resolution_success?)
+                new_requirement_tasks.each { |t| t.failed_event.emit(e) }
                 NetworkGeneration::SystemNetworkPlanApplyResult.new(
-                    errors: [e],
-                    instance_requirement_tasks: running_requirement_tasks
+                    errors: [e], instance_requirement_tasks: old_requirement_tasks
                 )
             end
         end


### PR DESCRIPTION
This is mostly to align the result instance requirements with the tasks that emitted failed.
We only use the result in unit tests and the instance requirement tasks
arent relevant in that scenario, but it was reporting the wrong
information nonetheless