### PR TITLE
fix: cancel async resolution at tests teardown

### DIFF
--- a/lib/syskit/test/spec.rb
+++ b/lib/syskit/test/spec.rb
@@ -41,9 +41,17 @@ module Syskit
                     )
                 end
 
+                kill_running_async_resolution
                 super
             ensure
                 Syskit.conf.remove_process_server("stubs")
+            end
+
+            def kill_running_async_resolution
+                return unless plan.syskit_has_async_resolution?
+
+                plan.syskit_cancel_async_resolution
+                plan.syskit_join_current_resolution
             end
 
             def teardown_registered_plans


### PR DESCRIPTION
this ensures to cancel network resolution in progress at the end
of each test to avoid deployment errors at the following tests