### PR TITLE
fix: enable the syskit plugin when invoking Roby CLI scripts via the `syskit` command

### DIFF
--- a/bin/syskit
+++ b/bin/syskit
@@ -69,6 +69,8 @@ else
     if SYSKIT_MODES.include?(mode)
         require "syskit/scripts/#{mode}"
     elsif ROBY_MODES.include?(mode)
+        require "roby"
+        Roby.app.using "syskit"
         require "roby/app/scripts/#{mode}"
     end
 


### PR DESCRIPTION
This fixes missing constants when connecting using `syskit shell` via the v2 interface