### PR TITLE
feat: add `update_and_restore_attr` helper

### DIFF
--- a/lib/syskit/test/base.rb
+++ b/lib/syskit/test/base.rb
@@ -16,21 +16,18 @@ module Syskit
             def setup
                 @task_stubs = []
                 @old_loglevel = Orocos.logger.level
+                @__syskit_test_updated_attrs = {}
 
                 super
             end
 
             def teardown
                 # Disable log output to avoid spurious "stopped / interrupting"
-                registered_plans.each do |p|
-                    if p.executable?
-                        p.find_tasks(Syskit::TaskContext).each do |t|
-                            flexmock(t).should_receive(:info)
-                        end
-                    end
-                end
+                __syskit_test_disable_taskcontext_info_messages
 
                 plug_connection_management
+                __syskit_test_restore_updated_attributes
+
                 begin
                     super
                 rescue ::Exception => e
@@ -42,6 +39,22 @@ module Syskit
                 Orocos.logger.level = @old_loglevel if @old_loglevel
                 if teardown_failure
                     raise teardown_failure
+                end
+            end
+
+            def __syskit_test_disable_taskcontext_info_messages
+                registered_plans.each do |p|
+                    next unless p.executable?
+
+                    p.find_tasks(Syskit::TaskContext).each do |t|
+                        flexmock(t).should_receive(:info)
+                    end
+                end
+            end
+
+            def __syskit_test_restore_updated_attributes
+                @__syskit_test_updated_attrs.each do |(obj, setter), value|
+                    obj.send(setter, value)
                 end
             end
 
@@ -59,6 +72,25 @@ module Syskit
 
             def unplug_connection_management
                 RobyApp::Plugin.unplug_handler_from_roby(execution_engine, :connection_management)
+            end
+
+            # Update an object's attribute, restoring its original value on teardown
+            #
+            # @param [Object] object
+            # @param [String,Symbol] name the attribute name. Predicate attributes are
+            #   handled by removing the trailing question mark before adding the `=`
+            # @param [Object] value the new value
+            def update_and_restore_attr(object, name, value)
+                name = name.to_s
+                setter =
+                    if name.end_with?("?")
+                        "#{name[0..-2]}="
+                    else
+                        "#{name}="
+                    end
+
+                @__syskit_test_updated_attrs[[object, setter]] = object.send(name)
+                object.send(setter, value)
             end
 
             # @deprecated use the expectations on {ExecutionExpectations} instead

--- a/test/test/test_base.rb
+++ b/test/test/test_base.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "syskit/test/self"
+
+module Syskit
+    module Test
+        class << self
+            attr_accessor :update_and_restore_attr_target_attribute
+
+            attr_writer :update_and_restore_attr_target_predicate
+
+            def update_and_restore_attr_target_predicate?
+                @update_and_restore_attr_target_predicate
+            end
+        end
+        @update_and_restore_attr_target_attribute = 0
+        @update_and_restore_attr_target_predicate = false
+
+        describe Base do
+            include Base
+
+            describe "update_and_restore_attr" do
+                describe "the update part" do
+                    before do
+                        update_and_restore_attr(
+                            Syskit::Test, :update_and_restore_attr_target_attribute, 42
+                        )
+                        update_and_restore_attr(
+                            Syskit::Test, :update_and_restore_attr_target_predicate?, true
+                        )
+                    end
+
+                    it "updates a plain attribute" do
+                        assert_equal(
+                            42, Syskit::Test.update_and_restore_attr_target_attribute
+                        )
+                    end
+
+                    it "updates a predicate attribute" do
+                        assert Syskit::Test.update_and_restore_attr_target_predicate?
+                    end
+                end
+
+                it "restores the attribute after the test finishes " do
+                    assert_equal 0, Syskit::Test.update_and_restore_attr_target_attribute
+                end
+
+                it "restores the attribute after it has been " do
+                    refute Syskit::Test.update_and_restore_attr_target_predicate?
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
The helper ensures that a modified attribute is properly restored to its old value, e.g. for global state (Conf, State or Syskit configuration parameters)