### PR TITLE
chore: cache result of dynamic port bindings based on matchers

### DIFF
--- a/lib/syskit/dynamic_port_binding.rb
+++ b/lib/syskit/dynamic_port_binding.rb
@@ -31,6 +31,7 @@ module Syskit
         def initialize(model)
             @model = model
             @port_resolver = nil
+            @raw_resolved_port = nil
             @resolved_port = nil
             @accessor = nil
         end
@@ -93,19 +94,39 @@ module Syskit
             self
         end
 
+        def update_raw_port
+            return unless @port_resolver
+
+            if @raw_resolved_port &&
+               @port_resolver&.current_selection_valid?(@raw_resolved_port)
+                return @raw_resolved_port
+            end
+
+            @port_resolver.update
+        end
+
         # Update the resolved port
         #
         # @return [(Boolean,(Port,nil))] tuple whose first element is true if
         #   the port was updated, and false otherwise. The tuple's second element
         #   is the new resolved port which may be nil if no ports can be found
         def update
-            if @resolved_port && @port_resolver&.current_selection_valid?(@resolved_port)
-                return false, @resolved_port
+            raw_port = update_raw_port
+            port = begin
+                raw_port&.to_actual_port
+                # Whenever a replacement happens, or before we have deployed a
+                # task, the ports won't be resolvable because children are not
+                # there yet
+                #
+                # Ignore the port when it happens. This is consistent with the
+                # data reader's purpose
+            rescue Roby::NoSuchChild
+                raw_port = nil
             end
 
-            port = @port_resolver&.update
             return false, @resolved_port if @resolved_port == port
 
+            @raw_resolved_port = raw_port
             @resolved_port = port
             [true, port]
         end
@@ -115,6 +136,7 @@ module Syskit
         # Note that calling {#update} after calling {#reset} might re-resolve
         # the same port (in which case {#update} will return true)
         def reset
+            @raw_resolved_port = nil
             @resolved_port = nil
         end
 
@@ -304,15 +326,7 @@ module Syskit
             end
 
             def update
-                port = @matcher.each_in_plan(@plan).first
-                port&.to_actual_port
-                # Whenever a replacement happens, or before we have deployed a
-                # task, the ports won't be resolvable because children are not
-                # there yet
-                #
-                # Ignore the port when it happens. This is consistent with the
-                # data reader's purpose
-            rescue Roby::NoSuchChild # rubocop:disable Lint/SuppressedException
+                @matcher.each_in_plan(@plan).first
             end
 
             def self.instanciate(task, model)

--- a/test/test_dynamic_port_binding.rb
+++ b/test/test_dynamic_port_binding.rb
@@ -219,7 +219,7 @@ module Syskit
             end
         end
 
-        describe "#update from a port matcher" do
+        describe "#update from a port matching a task" do
             attr_reader :task, :port_binding
 
             before do
@@ -251,6 +251,88 @@ module Syskit
                 @port_binding.update
                 assert_equal [false, @task.out_port], @port_binding.update
                 assert @port_binding.valid?
+            end
+
+            it "returns [true, nil] if the current match is valid " \
+               "but the port is finalized" do
+                port_binding_m =
+                    Models::DynamicPortBinding
+                    .create_from_matcher(@task_m.match.out_port)
+                port_binding = port_binding_m.instanciate.attach_to_task(@task)
+
+                syskit_configure_and_start(@task)
+                port_binding.update
+                expect_execution { plan.unmark_mission_task(@task) }
+                    .garbage_collect(true)
+                    .to_finalize(@task)
+
+                assert_equal [true, nil], port_binding.update
+                refute port_binding.valid?
+            end
+
+            it "returns [true, nil] if the current match is not valid anymore" do
+                syskit_configure_and_start(@task)
+                @port_binding.update
+                syskit_stop task
+
+                assert_equal [true, nil], @port_binding.update
+                refute @port_binding.valid?
+            end
+        end
+
+        describe "#update from a port matching a data service" do
+            attr_reader :task, :port_binding
+
+            before do
+                @srv_m = Syskit::DataService.new_submodel do
+                    output_port "srv_out", "/double"
+                end
+                @task_m.provides @srv_m, as: "srv"
+                @port_binding_m =
+                    Models::DynamicPortBinding
+                    .create_from_matcher(@srv_m.match.running.srv_out_port)
+                @task = syskit_stub_and_deploy(@task_m, remote_task: false)
+                @port_binding = @port_binding_m.instanciate.attach_to_task(@task)
+            end
+
+            it "returns [false, nil] in #update if the binding is not attached" do
+                port_binding = @port_binding_m.instanciate
+                assert_equal [false, nil], port_binding.update
+            end
+
+            it "returns [false, nil] if there are no matches in the plan" do
+                assert_equal [false, nil], @port_binding.update
+            end
+
+            it "returns [true, port] if there is a new match in the plan" do
+                syskit_configure_and_start(@task)
+
+                assert_equal [true, @task.out_port], @port_binding.update
+                assert @port_binding.valid?
+            end
+
+            it "returns [false, port] if the current match is still valid" do
+                syskit_configure_and_start(@task)
+                @port_binding.update
+                assert_equal [false, @task.out_port], @port_binding.update
+                assert @port_binding.valid?
+            end
+
+            it "returns [true, nil] if the current match is valid " \
+               "but the port is finalized" do
+                port_binding_m =
+                    Models::DynamicPortBinding
+                    .create_from_matcher(@srv_m.match.running.srv_out_port)
+                port_binding = port_binding_m.instanciate.attach_to_task(@task)
+
+                syskit_configure_and_start(@task)
+                port_binding.update
+                expect_execution { plan.unmark_mission_task(@task) }
+                    .garbage_collect(true)
+                    .to_finalize(@task)
+
+                assert_equal [true, nil], port_binding.update
+                refute port_binding.valid?
             end
 
             it "returns [true, nil] if the current match is not valid anymore" do

--- a/test/test_dynamic_port_binding.rb
+++ b/test/test_dynamic_port_binding.rb
@@ -341,8 +341,8 @@ module Syskit
                "is not finalized" do
                 updated, port = @port_binding.update
                 assert updated
-                assert_equal "srv_out", port.name
-                assert_equal @cmp.test_child.out_port, port.to_component_port
+                assert_equal "out", port.name
+                assert_equal @cmp.test_child.out_port, port
             end
 
             it "returns [false, port] the second time if the underlying component " \
@@ -350,8 +350,8 @@ module Syskit
                 @port_binding.update
                 updated, port = @port_binding.update
                 refute updated
-                assert_equal "srv_out", port.name
-                assert_equal @cmp.test_child.out_port, port.to_component_port
+                assert_equal "out", port.name
+                assert_equal @cmp.test_child.out_port, port
             end
 
             it "returns [false, ni] the first time if the underlying component " \


### PR DESCRIPTION
This was identified as a hotspot in syskit CPU usage on our systems.

We introduced a mechanism to avoid re-resolving queries for readers that have a
working reader already. This mechanism was actually not being triggered for the
very common case of matching a dataservice. This was because a data service's
actual port (the one that is used to create e.g. a reader) is not equal to the
one that is being matched. The matcher's current_selection_valid? method would
then not recognize its argument as valid.

Fix this by returning the "raw" port and letting DynamicPortBinding#update
resolving the actual port.