### PR TITLE
fix: warnings about deployment model being modified

### DIFF
--- a/lib/syskit/models/deployment.rb
+++ b/lib/syskit/models/deployment.rb
@@ -107,6 +107,17 @@ module Syskit
                 klass
             end
 
+            # Define a new deployed task in this deployment model
+            #
+            # Mostly used in unit tests
+            #
+            # @return [OroGen::Spec::TaskDeployment]
+            def define_deployed_task(name, model)
+                deployed_task = @orogen_model.task(name, model.orogen_model)
+                @task_name_to_syskit_model[name] = model
+                deployed_task
+            end
+
             # Creates a subclass of Deployment that represents the given
             # deployment
             #
@@ -141,6 +152,23 @@ module Syskit
                 orogen_model.task_activities.each do |task|
                     yield(task.name)
                 end
+            end
+
+            # @api private
+            #
+            # Return the syskit task model from the deployed task name
+            #
+            # @return [Syskit::Models::TaskContext,nil] the task model, or nil
+            #   if it is not registered
+            def find_syskit_model_for_deployed_task(deployed_task)
+                task_name =
+                    if deployed_task.respond_to?(:to_str)
+                        deployed_task
+                    else
+                        deployed_task_name
+                    end
+
+                @task_name_to_syskit_model[task_name]
             end
 
             # @api private

--- a/test/models/test_deployment.rb
+++ b/test/models/test_deployment.rb
@@ -136,6 +136,23 @@ module Syskit
             end
         end
 
+        describe "#define_deployed_task" do
+            it "defines the task and registers the orogen-to-syskit mapping" do
+                model = Deployment.new_submodel
+                task_m = TaskContext.new_submodel
+                model.define_deployed_task("task", task_m)
+                assert_same task_m, model.find_syskit_model_for_deployed_task("task")
+            end
+
+            it "returns the deployed task" do
+                model = Deployment.new_submodel
+                task_m = TaskContext.new_submodel
+                ret = model.define_deployed_task("task", task_m)
+                assert_kind_of OroGen::Spec::TaskDeployment, ret
+                assert_equal "task", ret.name
+            end
+        end
+
         def test_clear_submodels_removes_registered_submodels
             m1 = Deployment.new_submodel
             m2 = Deployment.new_submodel

--- a/test/network_generation/test_system_network_deployer.rb
+++ b/test/network_generation/test_system_network_deployer.rb
@@ -513,6 +513,7 @@ module Syskit
 
                         plan.add(parent = task_m.new)
                         parent.depends_on(task_m.new, role: "test")
+
                         deployer.validate_deployed_network(error_handler: error_handler)
                         assert error_handler.resolution_failures.any? do |f|
                             f.original_exception.kind_of? MissingDeployment
@@ -523,7 +524,7 @@ module Syskit
                 describe "validation that all configurations are defined" do
                     it "raises if some configurations are not defined" do
                         task_m = Syskit::TaskContext.new_submodel
-                        deployment_m.orogen_model.task "task", task_m.orogen_model
+                        deployment_m.define_deployed_task("task", task_m)
                         plan.add(
                             deployment = deployment_m.new(
                                 name_mappings: { "task" => "task" }
@@ -542,7 +543,7 @@ module Syskit
 
                     it "properly formats the MissingConfigurationSection error" do
                         task_m = Syskit::TaskContext.new_submodel
-                        deployment_m.orogen_model.task "task", task_m.orogen_model
+                        deployment_m.define_deployed_task("task", task_m)
                         plan.add(
                             deployment = deployment_m.new(
                                 name_mappings: { "task" => "task" }
@@ -566,7 +567,7 @@ module Syskit
                             deployer.plan, deployer.merge_solver
                         )
                         task_m = Syskit::TaskContext.new_submodel
-                        deployment_m.orogen_model.task "task", task_m.orogen_model
+                        deployment_m.define_deployed_task("task", task_m)
                         plan.add(
                             deployment = deployment_m.new(
                                 name_mappings: { "task" => "task" }


### PR DESCRIPTION
"Funnily" enough, the warning mentions the defined_deployed_task method which actually does not exist. Define it.