### PR TITLE
feat: support unavailable process managers

### DIFF
--- a/lib/syskit/exceptions.rb
+++ b/lib/syskit/exceptions.rb
@@ -1104,4 +1104,25 @@ module Syskit
             @deployment.pretty_print(pp)
         end
     end
+
+    # Exception raised whenever a task is deployed on a disabled process manager
+    class DeployedOnDisabledProcessManager < SpecError
+        # The task itself
+        attr_reader :task
+
+        # The deployment task
+        attr_reader :deployment_task
+
+        def initialize(task, deployment_task)
+            @task = task
+            @deployment_task = deployment_task
+        end
+
+        def pretty_print(pp)
+            pp.text "the following task was deployed on "
+            pp.text "#{@deployment_task.arguments[:on]}, which is currently disabled"
+            pp.breakable
+            task.pretty_print(pp)
+        end
+    end
 end

--- a/lib/syskit/network_generation/system_network_deployer.rb
+++ b/lib/syskit/network_generation/system_network_deployer.rb
@@ -209,14 +209,15 @@ module Syskit
             def validate_deployed_network(error_handler: RaiseErrorHandler.new)
                 verify_all_tasks_deployed(error_handler: error_handler)
                 verify_all_configurations_exist(error_handler: error_handler)
+                verify_all_process_managers_enabled(error_handler: error_handler)
             end
 
             # Verifies that all tasks in the plan are deployed
             #
             # @param [ResolutionErrorHandler | RaiseErrorHandler] error_handler
-            def verify_all_tasks_deployed(error_handler)
+            def verify_all_tasks_deployed(error_handler: RaiseErrorHandler.new)
                 self.class.verify_all_tasks_deployed(
-                    plan, default_deployment_group, error_handler
+                    plan, default_deployment_group, error_handler: error_handler
                 )
             end
 
@@ -253,6 +254,36 @@ module Syskit
                 tasks_with_candidates.each do |task, candidates|
                     e = MissingDeployment.new(task, candidates)
                     error_handler.register_resolution_failures_from_exception(e.task, e)
+                end
+            end
+
+            # Generate errors for all tasks that are using a deployment from a disabled
+            # process server
+            #
+            # @param [#register_resolution_failures_from_exception] error_handler
+            def verify_all_process_managers_enabled(error_handler: RaiseErrorHandler.new)
+                self.class.verify_all_process_managers_enabled(
+                    plan, error_handler: error_handler
+                )
+            end
+
+            # Generate errors for all tasks that are using a deployment from a disabled
+            # process server
+            #
+            # @param [Roby::Plan] plan
+            # @param [#register_resolution_failures_from_exception] error_handler
+            def self.verify_all_process_managers_enabled(
+                plan, error_handler: RaiseErrorHandler.new
+            )
+                failed =
+                    plan.find_local_tasks(Deployment)
+                        .find_all { |d| !d.process_server_config.available? }
+
+                failed.each do |deployment_task|
+                    deployment_task.each_executed_task do |t|
+                        e = DeployedOnDisabledProcessManager.new(t, deployment_task)
+                        error_handler.register_resolution_failures_from_exception(t, e)
+                    end
                 end
             end
 

--- a/lib/syskit/process_managers/remote/manager.rb
+++ b/lib/syskit/process_managers/remote/manager.rb
@@ -65,6 +65,7 @@ module Syskit
 
                 STATE_CONNECTED = "connected"
                 STATE_DISCONNECTED = "disconnected"
+                STATE_CLOSED = "closed"
 
                 def available?
                     @state == STATE_CONNECTED
@@ -135,9 +136,20 @@ module Syskit
 
                 def poll
                     case @state
+                    when STATE_CLOSED
+                        poll_in_closed_state
                     when STATE_DISCONNECTED
                         poll_in_disconnected_state
                     end
+                end
+
+                def poll_in_closed_state
+                    # Read the output of the future if there is one, and close
+                    # the possibly existing socket
+                    return unless (result = @connect_future&.result(0))
+
+                    result[1]&.close
+                    @connect_future = nil
                 end
 
                 def poll_in_disconnected_state
@@ -187,7 +199,7 @@ module Syskit
                         "call failed: #{e.message}"
                     )
 
-                    close
+                    close(state: STATE_DISCONNECTED)
                     schedule_connection_attempt
                 end
 
@@ -398,9 +410,9 @@ module Syskit
                     close
                 end
 
-                def close
-                    @state = STATE_DISCONNECTED
-                    @socket.close
+                def close(state: STATE_CLOSED)
+                    @state = state
+                    @socket&.close
                 end
 
                 def write_command(cmd, args = nil)

--- a/lib/syskit/process_managers/remote/manager.rb
+++ b/lib/syskit/process_managers/remote/manager.rb
@@ -86,12 +86,14 @@ module Syskit
                         Syskit.conf.remote_process_managers_response_timeout,
                     root_loader: Orocos.default_loader,
                     register_on_name_server: true,
-                    connect_executor: :io
+                    connect_executor: :io,
+                    create_log_dir: true
                 )
                     @host = host
                     @port = port
                     @state = STATE_DISCONNECTED
                     @response_timeout = response_timeout
+                    @create_log_dir = create_log_dir
 
                     @processes = {}
                     @death_queue = []
@@ -187,9 +189,11 @@ module Syskit
                     @server_pid = pid
                     @loader = Loader.new(self, @root_loader)
 
-                    create_log_dir(
-                        Roby.app.time_tag, { "parent" => Roby.app.app_metadata }
-                    )
+                    if @create_log_dir
+                        create_log_dir(
+                            Roby.app.time_tag, { "parent" => Roby.app.app_metadata }
+                        )
+                    end
                     kill_all if Syskit.conf.kill_all_on_process_server_connection?
 
                     ProcessManagers.info "connected to remote process manager #{self}"

--- a/lib/syskit/process_managers/remote/manager.rb
+++ b/lib/syskit/process_managers/remote/manager.rb
@@ -174,6 +174,12 @@ module Syskit
 
                     @server_pid = pid
                     @loader = Loader.new(self, @root_loader)
+
+                    create_log_dir(
+                        Roby.app.time_tag, { "parent" => Roby.app.app_metadata }
+                    )
+                    kill_all if Syskit.conf.kill_all_on_process_server_connection?
+
                     ProcessManagers.info "connected to remote process manager #{self}"
                 rescue StandardError => e
                     ProcessManagers.warn(

--- a/lib/syskit/process_managers/remote/server/process.rb
+++ b/lib/syskit/process_managers/remote/server/process.rb
@@ -360,7 +360,7 @@ module Syskit
                         ENV["ORO_LOGFILE"] = resolve_orocos_logger_output(pid)
 
                         ::Process.setpgrp
-                        debug "command line: #{@command} #{arguments.join(' ')}"
+                        info "starting: #{@command} #{arguments.join(' ')}"
                         exec(@command, *arguments,
                              control_read_fd => control_read_fd,
                              ior_write_fd => ior_write_fd,

--- a/lib/syskit/process_managers/remote/server/process.rb
+++ b/lib/syskit/process_managers/remote/server/process.rb
@@ -423,7 +423,6 @@ module Syskit
                             rescue Errno::ESRCH # rubocop:disable Lint/SuppressedException
                             end
                         else
-                            puts "control FD"
                             @control_write_fd.write("Q")
                         end
                     end

--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -775,10 +775,17 @@ module Syskit
 
             ProcessServerConfig =
                 Struct.new :name, :client, :log_dir, :host_id, :supports_log_transfer,
-                           :logging_enabled, :register_on_name_server,
+                           :logging_enabled, :register_on_name_server, :disabled,
                            keyword_init: true do
                     def manager
                         client
+                    end
+
+                    def available?
+                        return false if disabled
+                        return client.available? if client.respond_to?(:available?)
+
+                        true
                     end
 
                     def on_localhost?

--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -759,10 +759,6 @@ module Syskit
                 client = ProcessManagers::Remote::Manager.new(
                     host, port, root_loader: app.default_loader
                 )
-                client.create_log_dir(
-                    Roby.app.time_tag, { "parent" => Roby.app.app_metadata }
-                )
-                client.kill_all if kill_all_on_process_server_connection?
                 config = register_process_server(
                     name, client,
                     host_id: host_id || name,

--- a/lib/syskit/roby_app/plugin.rb
+++ b/lib/syskit/roby_app/plugin.rb
@@ -718,28 +718,9 @@ module Syskit
                           "no process server is being started"
                 end
 
-                # Wait for the server to be ready
-                client = nil
-                until client
-                    client =
-                        begin ProcessManagers::Remote::Manager.new("localhost", @server_port)
-                        rescue Errno::ECONNREFUSED
-                            sleep 0.1
-                            is_running =
-                                begin
-                                    !::Process.waitpid(@server_pid, ::Process::WNOHANG)
-                                rescue Errno::ESRCH
-                                    false
-                                end
-
-                            unless is_running
-                                raise ProcessManagers::Remote::Manager::StartupFailed,
-                                      "the local process server failed to start"
-                            end
-
-                            nil
-                        end
-                end
+                client = ProcessManagers::Remote::Manager.new(
+                    "localhost", @server_port, create_log_dir: false
+                )
 
                 # Verify that the server is actually ours (i.e. check that there
                 # was not one that was still running)

--- a/lib/syskit/runtime/update_deployment_states.rb
+++ b/lib/syskit/runtime/update_deployment_states.rb
@@ -10,14 +10,24 @@ module Syskit
             # #cleanup_dead_connections, thus avoiding to disconnect connections
             # between already-dead processes
 
+            poll_managers
             handle_dead_deployments(plan)
             trigger_ready_deployments(plan)
+        end
+
+        def self.poll_managers
+            server_config = Syskit.conf.each_process_server_config.to_a
+            server_config.each do |config|
+                config.client.poll if config.client.respond_to?(:poll)
+            end
         end
 
         def self.handle_dead_deployments(plan)
             all_dead_deployments = Set.new
             server_config = Syskit.conf.each_process_server_config.to_a
             server_config.each do |config|
+                next unless config.available?
+
                 begin
                     dead_deployments = config.client.wait_termination
                 rescue ::Exception => e
@@ -42,6 +52,8 @@ module Syskit
             not_ready_deployments = find_all_not_ready_deployments(plan)
             not_ready_deployments.each do |process_server_name, deployments|
                 server_config = Syskit.conf.process_server_config_for(process_server_name)
+                next unless server_config.available?
+
                 wait_result = server_config.client.wait_running(
                     *deployments.map { |d| d.arguments[:process_name] }
                 )

--- a/lib/syskit/scripts/process_server.rb
+++ b/lib/syskit/scripts/process_server.rb
@@ -5,6 +5,8 @@ require "syskit/process_managers/remote/server"
 
 require "optparse"
 
+server_port = Syskit::ProcessManagers::Remote::DEFAULT_PORT
+
 options = Hash[host: "localhost"]
 parser = OptionParser.new do |opt|
     opt.on "--fd=FD", Integer, "the socket that should be used as TCP server" do |fd|
@@ -13,12 +15,14 @@ parser = OptionParser.new do |opt|
     opt.on "--log-dir=DIR", String, "the directory that should be used for logs" do |dir|
         Roby.app.log_dir = dir
     end
+    opt.on "--port=PORT", Integer, "the port to listen on" do |port|
+        server_port = port
+    end
     opt.on("--debug", "turn on debug mode") do
         Syskit::ProcessManagers::Remote::Server.logger.level = Logger::DEBUG
     end
 end
 
-server_port = Syskit::ProcessManagers::Remote::DEFAULT_PORT
 Roby::Application.host_options(parser, options)
 parser.parse(ARGV)
 

--- a/lib/syskit/test/network_manipulation.rb
+++ b/lib/syskit/test/network_manipulation.rb
@@ -351,14 +351,14 @@ module Syskit
             # @param [Boolean] register the configured deployment in the test group
             #   This makes it available to further deployments
             # @return [Syskit::Models::ConfiguredDeployment]
-            def syskit_stub_configured_deployment(
+            def syskit_stub_configured_deployment( # rubocop:disable Metrics/ParameterLists
                 task_model = nil, task_name = syskit_default_stub_name(task_model),
                 remote_task: syskit_stub_resolves_remote_tasks?,
-                register: true, read_only: [], &block
+                on: "stubs", register: true, read_only: [], &block
             )
                 configured_deployment = @__stubs.stub_configured_deployment(
                     task_model, task_name,
-                    read_only: read_only, remote_task: remote_task, &block
+                    on: on, read_only: read_only, remote_task: remote_task, &block
                 )
                 if register
                     @__test_deployment_group

--- a/lib/syskit/test/stubs.rb
+++ b/lib/syskit/test/stubs.rb
@@ -285,13 +285,14 @@ module Syskit
             # @api private
             #
             # Computes a configured deployment suitable to deploy the given task model
-            def stub_configured_deployment(
+            def stub_configured_deployment( # rubocop:disable Metrics/ParameterLists
                 task_model = nil, task_name = default_stub_name,
-                remote_task: false, read_only: [], logger_name: nil, &block
+                remote_task: false, read_only: [], logger_name: nil,
+                on: "stubs", &block
             )
                 deployment_model = stub_deployment_model(task_model, task_name, &block)
 
-                process_server = Syskit.conf.process_server_for("stubs")
+                process_server = Syskit.conf.process_server_for(on)
                 task_context_class =
                     if remote_task
                         Orocos::RubyTasks::RemoteTaskContext
@@ -300,7 +301,7 @@ module Syskit
                     end
 
                 Models::ConfiguredDeployment.new(
-                    "stubs", deployment_model, { task_name => task_name }, task_name,
+                    on, deployment_model, { task_name => task_name }, task_name,
                     Hash[task_context_class: task_context_class],
                     read_only: read_only, logger_name: logger_name
                 )

--- a/test/network_generation/test_system_network_deployer.rb
+++ b/test/network_generation/test_system_network_deployer.rb
@@ -569,7 +569,7 @@ module Syskit
                         deployment_m.orogen_model.task "task", task_m.orogen_model
                         plan.add(
                             deployment = deployment_m.new(
-                                name_mappings: { "task" => "task" }
+                                on: "localhost", name_mappings: { "task" => "task" }
                             )
                         )
                         plan.add(task = deployment.task("task"))
@@ -578,6 +578,36 @@ module Syskit
                         assert error_handler.resolution_failures.any? do |f|
                             f.original_exception.kind_of? MissingConfigurationSection
                         end
+                    end
+                end
+
+                describe "validation that all process managers are enabled" do
+                    it "rejects tasks that are using a deployment " \
+                       "from a disabled manager" do
+                        mng = register_ruby_tasks_manager("disabled_manager")
+                        mng.disabled = true
+
+                        task_m = Syskit::TaskContext.new_submodel
+                        deployment = syskit_stub_configured_deployment(
+                            task_m, on: "disabled_manager"
+                        )
+                        ir = task_m.to_instance_requirements
+                        ir.use_configured_deployment(deployment)
+                        task = ir.instanciate(plan)
+
+                        error_handler = ResolutionErrorHandler.new(
+                            deployer.plan, deployer.merge_solver
+                        )
+                        execute do
+                            deployer.deploy(error_handler: error_handler)
+                        end
+
+                        assert_equal 1, error_handler.resolution_failures.size
+                        e = error_handler.resolution_failures.first
+                        assert_kind_of DeployedOnDisabledProcessManager,
+                                       e.original_exception
+                        assert_equal deployer.merge_solver.replacement_for(task),
+                                     e.original_exception.task
                     end
                 end
             end

--- a/test/process_managers/test_remote.rb
+++ b/test/process_managers/test_remote.rb
@@ -95,6 +95,25 @@ describe Syskit::ProcessManagers::Remote do
             )
         end
 
+        it "can be closed/disconnected in DISCONNECTED state, " \
+           "and then stops attempting to connect" do
+            @server = Syskit::ProcessManagers::Remote::Server::Server.new(
+                @app, port: 0, name_service_ip: "127.0.0.1"
+            )
+            @server.open
+
+            client = Syskit::ProcessManagers::Remote::Manager.new(
+                "localhost", server.port,
+                root_loader: root_loader,
+                connection_timeout: 1, response_timeout: 1,
+                initial_connection_timeout: 1
+            )
+            client.close
+
+            @server_thread = Thread.new { server.listen }
+            refute_client_is_eventually_available(client)
+        end
+
         it "handles a server that allows connection but does not reply" do
             @server = Syskit::ProcessManagers::Remote::Server::Server.new(
                 @app, port: 0, name_service_ip: "127.0.0.1"
@@ -721,6 +740,21 @@ describe Syskit::ProcessManagers::Remote do
         end
 
         flunk("#{block} did not return true in #{timeout} seconds")
+    end
+
+    def refute_client_is_eventually_available(client, timeout: 1)
+        now = Roby.monotonic_time
+        deadline = now + timeout
+        while deadline > now
+            if client.available?
+                flunk("client did become available in #{timeout} seconds")
+            end
+
+            client.poll
+            sleep 0.01
+
+            now = Roby.monotonic_time
+        end
     end
 
     def assert_client_is_eventually_available(client, timeout: 5)

--- a/test/process_managers/test_remote.rb
+++ b/test/process_managers/test_remote.rb
@@ -643,12 +643,9 @@ describe Syskit::ProcessManagers::Remote do
     end
 
     def connect_to_server
-        client = Syskit::ProcessManagers::Remote::Manager.new(
+        Syskit::ProcessManagers::Remote::Manager.new(
             "localhost", server.port, root_loader: root_loader
         )
-
-        client.create_log_dir(Roby.app.time_tag)
-        client
     end
 
     def start_and_connect_to_server

--- a/test/runtime/fixtures/missing_process_manager_on_start.rb
+++ b/test/runtime/fixtures/missing_process_manager_on_start.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+$stdout.sync = true
+require "roby/schedulers/temporal"
+Roby.scheduler = Roby::Schedulers::Temporal.new
+
+TOKEN = ENV.fetch("SYSKIT_TEST_MISSING_PROCESS_SERVER_TOKEN", nil)
+PROCESS_SERVER_PORT = Integer(ENV.fetch("SYSKIT_TEST_MISSING_PROCESS_SERVER_PORT", nil))
+
+Syskit.conf.remote_process_managers_initial_connection_timeout = 1
+Syskit.conf.remote_process_managers_connection_timeout = 1
+Syskit.conf.remote_process_managers_response_timeout = 1
+Syskit.conf.remote_process_managers_accept_failed_connections = true
+Syskit.conf.register_remote_manager(
+    "test", "localhost", port: PROCESS_SERVER_PORT
+)
+test_remote_manager = Syskit.conf.process_server_config_for("test")
+if test_remote_manager.available?
+    puts "#{TOKEN} - failed - process manager available on start"
+    Roby.app.quit
+end
+
+using_task_library "orogen_syskit_tests"
+
+deadline = nil
+spawned = false
+Robot.controller do
+    Roby.execution_engine.each_cycle do
+        if test_remote_manager.available? && !spawned
+            spawned = true
+            task_m =
+                OroGen.orogen_syskit_tests.Empty
+                      .deployed_as("#{Process.pid}_missing_empty", on: "test")
+            task = Roby.plan.add_mission_task(task_m)
+            task.start_event.on do |_event|
+                puts "#{TOKEN} - success"
+                Roby.app.quit
+            end
+        end
+    end
+
+    deadline ||= Time.now + 10
+    if Time.now > deadline
+        puts "#{TOKEN} - failed"
+        Roby.app.quit
+    end
+end

--- a/test/runtime/test_update_deployment_state.rb
+++ b/test/runtime/test_update_deployment_state.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "syskit/test/self"
+require "syskit/test/roby_app_helpers"
+require "syskit/process_managers/remote/server"
 
 module Syskit
     module Runtime
@@ -38,11 +40,50 @@ module Syskit
         end
 
         describe ".update_deployment_states" do
+            describe "system behaviour with remote manager availability" do
+                include Syskit::Test::RobyAppHelpers
+
+                after do
+                    if @remote_process_server_pid
+                        remote_process_server_quit(@remote_process_server_pid)
+                    end
+                end
+
+                def roby_app_fixture_path
+                    File.expand_path("fixtures", __dir__)
+                end
+
+                it "gracefully handles a process manager that appears after start" do
+                    dir = roby_app_setup_single_script(
+                        "missing_process_manager_on_start.rb"
+                    )
+                    port = roby_app_allocate_port
+                    token = SecureRandom.hex(10)
+                    env = {
+                        "SYSKIT_TEST_MISSING_PROCESS_SERVER_PORT" => port.to_s,
+                        "SYSKIT_TEST_MISSING_PROCESS_SERVER_TOKEN" => token
+                    }
+
+                    pid, = roby_app_start(
+                        "run", "-c", "scripts/missing_process_manager_on_start.rb",
+                        capture_output: true, chdir: dir, env: env
+                    )
+                    sleep 5
+
+                    @remote_process_server_pid = remote_process_server_spawn(port)
+                    assert_roby_app_exits(pid)
+                    output = roby_app_captured_output(pid)
+                    refute_match(/#{token} - failed/, output[:out])
+                    assert_match(/#{token} - success/, output[:out])
+                end
+            end
+
             describe "#handle_dead_deployments" do
                 it "calls #dead! on the dead deployments" do
                     client = flexmock
-                    flexmock(Syskit.conf).should_receive(:each_process_server_config)
-                                         .and_return([flexmock(client: client)])
+                    flexmock(Syskit.conf)
+                        .should_receive(:each_process_server_config)
+                        .and_return([flexmock(client: client, available?: true)])
                     client.should_receive(:wait_termination)
                           .and_return([[p = flexmock, s = flexmock]])
                     flexmock(Deployment).should_receive(:deployment_by_process).with(p)
@@ -184,6 +225,22 @@ module Syskit
                     end
                     mock
                 end
+            end
+
+            def remote_process_server_spawn(port)
+                log_dir = make_tmpdir
+                pid = spawn(
+                    "syskit", "process_server",
+                    "--log-dir=#{log_dir}", "--port=#{port}",
+                    chdir: log_dir, out: "/dev/null", err: "/dev/null"
+                )
+                register_pid(pid)
+                pid
+            end
+
+            def remote_process_server_quit(pid)
+                Process.kill "INT", pid
+                assert_process_exits(pid)
             end
         end
     end

--- a/test/test_exceptions.rb
+++ b/test/test_exceptions.rb
@@ -254,4 +254,19 @@ module Syskit
             assert_equal expected, formatted.gsub(/<id:\d+>/, "<id:ID>").chomp
         end
     end
+
+    describe DeployedOnDisabledProcessManager do
+        it "pretty-prints itself" do
+            task0 = flexmock
+            task0.should_receive(:pretty_print).and_return { |pp| pp.text "task0" }
+            deployment_task = flexmock(arguments: { on: "manager" })
+            error = DeployedOnDisabledProcessManager.new(task0, deployment_task)
+            formatted = PP.pp(error, +"", 5)
+            expected = <<~PP
+                the following task was deployed on manager, which is currently disabled
+                task0
+            PP
+            assert_equal expected, formatted
+        end
+    end
 end


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-roby/pull/334

This pull request adds the ability for a Syskit app to start with missing process managers. The direct effect is that any part of the system that depend on these process managers will not be deployed. How to ensure the system is still functional must be done by higher level logic. 