### PR TITLE
perf: use 'orocos_name' to filter candidate lists when merging task contexts

### DIFF
--- a/lib/syskit/network_generation/merge_solver.rb
+++ b/lib/syskit/network_generation/merge_solver.rb
@@ -262,6 +262,13 @@ module Syskit
                     break
                 end
 
+                if (orocos_name = task.arguments[:orocos_name])
+                    candidates = candidates.find_all do |t|
+                        !t.arguments.set?(:orocos_name) ||
+                            t.arguments[:orocos_name] == orocos_name
+                    end
+                end
+
                 candidates.each do |merged_task|
                     next if task == merged_task
 


### PR DESCRIPTION
My take on Syskit's current slowness on our systems is that we have a LOT of GPIO-driving tasks. The merge solver was designed on the basis that filtering on type would be enough to avoid hitting large task groups. This is not the case anymore here.

It is doing N^2 steps on more and more tasks, and that takes forever.

When early_deploy is set, however, orocos_name will be set *and* we can only merge two tasks if they have the same deployment (the same orocos_name). Use this to filter out merge candidates.

It reduced the complete system generation + apply loop from ~1.5s to 0.5s.