### PR TITLE
fix: optionally replace the executable? hack from Composition by schedule_as relations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,18 +44,13 @@ def core_task(name, files_setup)
     end
 end
 
-def core(early_deploy: false, capture_errors_during_network_resolution: false,
-    all_features: false)
-    s = ":no-features"
-    if capture_errors_during_network_resolution
-        s = ":capture-errors"
-        files_setup = ["test/features/capture_errors.rb"]
-    elsif early_deploy
-        s = ":early-deploy"
-        files_setup = ["test/features/early_deploy.rb"]
-    elsif all_features
+def core(all_features: false)
+    if all_features
         s = ":all-features"
         files_setup = ["test/features/all_features.rb"]
+    else
+        s = ":no-features"
+        files_setup = []
     end
 
     core_task(s, files_setup)
@@ -88,13 +83,10 @@ Rake::TestTask.new("test:gui") do |t|
     t.warning = false
 end
 
-core early_deploy: true
-core capture_errors_during_network_resolution: true
 core all_features: true
 core
 desc "Run core library tests, excluding GUI and live tests"
-task "test:core" => %w[test:core:no-features test:core:early-deploy
-                       test:core:capture-errors test:core:all-features]
+task "test:core" => %w[test:core:no-features test:core:all-features]
 
 desc "Run all tests"
 task "test" => ["test:gui", "test:core", "test:live", "test:telemetry"]

--- a/lib/syskit/composition.rb
+++ b/lib/syskit/composition.rb
@@ -192,6 +192,8 @@ module Syskit
         #
         # will return false if any of the children is not executable.
         def executable? # :nodoc:
+            return super if Syskit.conf.compositions_use_schedule_as?
+
             return false unless super
             return true if @executable
 

--- a/lib/syskit/models/composition.rb
+++ b/lib/syskit/models/composition.rb
@@ -1076,6 +1076,10 @@ module Syskit
                         end
 
                         self_task.depends_on(child_task, dependency_options)
+                        if Syskit.conf.compositions_use_schedule_as?
+                            self_task.schedule_as(child_task)
+                        end
+
                         self_task.child_selection[child_name] = selected_child
                         if (main = main_task) && (main.child_name == child_name)
                             child_task.each_event do |ev|

--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -193,6 +193,22 @@ module Syskit
             # spaced by {#remote_process_managers_connection_retry_period}
             attr_accessor :remote_process_managers_initial_connection_timeout
 
+            # Change the mechanism through which Syskit synchronizes
+            # a composition and its children
+            #
+            # @see #compositions_use_schedule_as?
+            attr_writer :compositions_use_schedule_as
+
+            # Which mechanism Syskit uses to synchronize a composition and its children
+            #
+            # The default of false uses the old way. Change to true to test the new
+            # way. The old way could lead to deadlocks (subsystems not being started)
+            # when the child of a composition was swapped for another (unstarted) one
+            # dynamically
+            def compositions_use_schedule_as?
+                @compositions_use_schedule_as
+            end
+
             # Controls whether the orogen types should be exported as Ruby
             # constants
             #
@@ -234,6 +250,8 @@ module Syskit
                 @remote_process_managers_connection_timeout = 10
                 @remote_process_managers_response_timeout = 10
                 @remote_process_managers_initial_connection_timeout = 60
+
+                @compositions_use_schedule_as = false
 
                 @log_rotation_period = nil
                 @log_transfer = LogTransferManager::Configuration.new(

--- a/test/features/all_features.rb
+++ b/test/features/all_features.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
-require "test/features/early_deploy"
-require "test/features/capture_errors"
+Syskit.conf.early_deploy = true
+Syskit.conf.capture_errors_during_network_resolution = true
+Syskit.conf.compositions_use_schedule_as = true

--- a/test/features/capture_errors.rb
+++ b/test/features/capture_errors.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-require "syskit"
-
-Syskit.conf.capture_errors_during_network_resolution = true

--- a/test/features/early_deploy.rb
+++ b/test/features/early_deploy.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-require "syskit"
-
-Syskit.conf.early_deploy = true


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-roby/pull/337

Syskit has for a long time made sure that compositions would wait for their children to be "ready to run" (that is, have their children's execution agents ready and their networks connected) to start. This was done by redefining `#executable?`.

The temporal scheduler, not knowing about it (executable? is opaque to it) would not be able to properly deal with a child being abstract (that is, not executable) with its planning task being scheduled_as itself, that is:

```
composition.depends_on(child)
child.planned_by instance_requirements_task
```

Which is valid, and happens when some plan modifications are done at runtime.

This commit adds a flag that allows to use the temporal scheduler's updated schedule_as support (from Roby) to get the same behaviour, but this time in a more robust way.