### PR TITLE
fix: corner case injecting a composition child

### DIFF
--- a/lib/syskit/instance_requirements.rb
+++ b/lib/syskit/instance_requirements.rb
@@ -546,8 +546,10 @@ module Syskit
         #
         # See also Composition#instanciate
         def use(*mappings)
-            unless model <= Syskit::Composition
-                raise ArgumentError, "#use is available only for compositions, got #{base_model.short_name}"
+            unless model.to_component_model <= Syskit::Composition
+                raise ArgumentError,
+                      "#use is available only for compositions, " \
+                      "got #{base_model.short_name}"
             end
 
             invalidate_dependency_injection
@@ -580,6 +582,8 @@ module Syskit
                 break
             end
 
+            composition_model = to_component_model
+
             # Validate the new mappings first
             new_mappings = selections.dup
             # !!! #add_explicit does not do any normalization. User-provided
@@ -589,7 +593,7 @@ module Syskit
                 req = new_mappings.explicit[child_name]
                 next unless req.respond_to?(:fullfills?)
 
-                if child = model.find_child(child_name)
+                if child = composition_model.find_child(child_name)
                     _, selected_m, = new_mappings.selection_for(child_name, child)
                     unless selected_m.fullfills?(child)
                         raise InvalidSelection.new(child_name, req, child), "#{req} is not a valid selection for #{child_name}. Was expecting something that provides #{child}"
@@ -600,7 +604,7 @@ module Syskit
             # See comment about #add_explicit vs. #add above
             selections.add(explicit)
             selections.add(*defaults)
-            composition_model = narrow_model || composition_model
+            composition_model = narrow_model.to_component_model
 
             selections.each_selection_key do |obj|
                 if obj.respond_to?(:to_str)

--- a/lib/syskit/instance_requirements.rb
+++ b/lib/syskit/instance_requirements.rb
@@ -956,7 +956,7 @@ module Syskit
                         specialization_hints: specialization_hints
                     )
                 ensure
-                    context.restore unless from_cache
+                    context.restore
                 end
             end
 

--- a/lib/syskit/instance_requirements.rb
+++ b/lib/syskit/instance_requirements.rb
@@ -372,12 +372,14 @@ module Syskit
             end
         end
 
+        # (see Models::BoundDataService#as_real_model)
         def as_real_model
             result = dup
             result.as_real_model!
             result
         end
 
+        # (see Models::BoundDataService#as_real_model)
         def as_real_model!
             @base_model = base_model.as_real_model
             @model = model.as_real_model

--- a/lib/syskit/instance_selection.rb
+++ b/lib/syskit/instance_selection.rb
@@ -79,7 +79,7 @@ module Syskit
 
         # Returns the selected component model
         def component_model
-            selected.base_model
+            selected.component_model
         end
 
         # Computes the service selection that will allow to replace a

--- a/lib/syskit/models/composition.rb
+++ b/lib/syskit/models/composition.rb
@@ -1036,7 +1036,7 @@ module Syskit
                         selected_child = selected_child.dup
 
                         resolved_selected_child = selected_child
-                        if selected_child.selected.fullfills?(Syskit::Composition)
+                        if selected_child.component_model.fullfills?(Syskit::Composition)
                             resolved_selected_child = selected_child.dup
 
                             has_unresolved_reference_to_sibling =

--- a/test/models/test_composition.rb
+++ b/test/models/test_composition.rb
@@ -484,6 +484,41 @@ describe Syskit::Models::Composition do
             assert_equal cmp.first_child, root.child_selection["second"].selected.resolved_dependency_injection.explicit[srv]
         end
 
+        it "allows using children as use flags for other children" do
+            srv = Syskit::DataService.new_submodel(name: "Srv")
+            task = Syskit::TaskContext.new_submodel(name: "Task") { provides srv, as: "srv" }
+            second = Syskit::Composition.new_submodel(name: "SecondCmp") { add srv, as: "second_test" }
+            cmp = Syskit::Composition.new_submodel(name: "RootCmp") do
+                add task, as: "first"
+                add(second, as: "second")
+                    .use(srv => first_child)
+            end
+            root = cmp.instanciate(plan, Syskit::DependencyInjectionContext.new("first.first_test" => task))
+            assert_same root.first_child, root.second_child.second_test_child
+        end
+
+        it "allows using service-mapped children as use flags for other children" do
+            srv0_m = Syskit::DataService.new_submodel(name: "Srv0")
+            srv1_m = Syskit::DataService.new_submodel(name: "Srv1")
+            task_m = Syskit::TaskContext.new_submodel(name: "Task") do
+                provides srv0_m, as: "srv"
+            end
+            cmp_m = Syskit::Composition.new_submodel(name: "Cmp") do
+                add srv0_m, as: "task"
+                provides srv1_m, as: "srv"
+            end
+            root_m = Syskit::Composition.new_submodel(name: "Root") do
+                add srv0_m, as: "task"
+                add srv1_m, as: "cmp"
+            end
+            injection = Syskit::DependencyInjectionContext.new(
+                "task" => task_m,
+                "cmp" => cmp_m.use("task" => root_m.task_child)
+            )
+            root = root_m.instanciate(plan, injection)
+            assert_same root.task_child, root.cmp_child.task_child
+        end
+
         it "allows to use grandchildren as use flags for other children" do
             srv = Syskit::DataService.new_submodel(name: "Srv")
             task = Syskit::TaskContext.new_submodel(name: "Task") { provides srv, as: "srv" }

--- a/test/test_instance_requirements.rb
+++ b/test/test_instance_requirements.rb
@@ -290,24 +290,59 @@ describe Syskit::InstanceRequirements do
             @task_m = Syskit::TaskContext.new_submodel
             task_m.provides srv_m, as: "test"
         end
-        it "should not try to verify a name to value mapping for a known child if the value is a string" do
+
+        it "raises if the model is not a composition" do
+            e = assert_raises(ArgumentError) do
+                @task_m.to_instance_requirements.use("some" => "thing")
+            end
+            assert_match(/available.only.for.compositions/, e.message)
+        end
+
+        describe "when the model is a bound service on a composition" do
+            it "refines it" do
+                @cmp_m.provides @srv_m, as: "srv"
+                cmp = @cmp_m
+                      .srv_srv.to_instance_requirements.use("test" => @task_m)
+                      .instanciate(Roby::Plan.new)
+                assert_kind_of @task_m, cmp.component.test_child
+            end
+
+            it "rejects invalid children names" do
+                @cmp_m.provides @srv_m, as: "srv"
+                assert_raises(ArgumentError) do
+                    @cmp_m.srv_srv.to_instance_requirements
+                          .use("does_not_exist" => @task_m)
+                end
+            end
+
+            it "rejects invalid selected models" do
+                @cmp_m.provides @srv_m, as: "srv"
+                task_m = Syskit::TaskContext.new_submodel
+                assert_raises(Syskit::InvalidSelection) do
+                    @cmp_m.srv_srv.to_instance_requirements
+                          .use("test" => task_m)
+                end
+            end
+        end
+
+        it "does not verify a name to value mapping for a known child if the value is a string" do
             simple_composition_model.overload("srv", simple_component_model)
             simple_composition_model.use("srv" => "device")
         end
-        it "should raise if a name to value mapping is invalid for a known child" do
+        it "raises if a name to value mapping is invalid for a known child" do
             simple_composition_model.overload("srv", simple_component_model)
             assert_raises(Syskit::InvalidSelection) do
                 simple_composition_model.use("srv" => Syskit::TaskContext.new_submodel)
             end
         end
-        it "should raise if a name to value mapping is invalid for a known child, even though the model does not respond to #fullfills?" do
+        it "raises if a name to value mapping is invalid for a known child, even though the model does not respond to #fullfills?" do
             simple_composition_model.overload("srv", simple_component_model)
             req = flexmock(to_instance_requirements: Syskit::TaskContext.new_submodel.to_instance_requirements)
             assert_raises(Syskit::InvalidSelection) do
                 simple_composition_model.use("srv" => req)
             end
         end
-        it "should allow providing a service submodel as a selection for a composition child" do
+        it "allows providing a service submodel as a selection for a composition child" do
             srv_m = Syskit::DataService.new_submodel
             subsrv_m = srv_m.new_submodel
             cmp_m = Syskit::Composition.new_submodel do
@@ -317,11 +352,11 @@ describe Syskit::InstanceRequirements do
             ir.use("test" => subsrv_m)
         end
 
-        it "should raise if a child selection is ambiguous" do
+        it "raises if a child selection is ambiguous" do
             task_m.provides srv_m, as: "ambiguous"
             cmp_m.use("test" => task_m)
         end
-        it "should allow selecting a service explicitly" do
+        it "allows selecting a service explicitly" do
             task_m.provides srv_m, as: "ambiguous"
             req = cmp_m.use("test" => task_m.test_srv)
             assert_equal task_m.test_srv, req.resolved_dependency_injection.explicit["test"]

--- a/test/test_instance_selection.rb
+++ b/test/test_instance_selection.rb
@@ -94,6 +94,22 @@ describe Syskit::InstanceSelection do
         end
     end
 
+    describe "#component_model" do
+        it "returns the selected model with its bound service removed" do
+            srv_m = Syskit::DataService.new_submodel
+            component_m = Syskit::Component.new_submodel do
+                provides srv_m, as: "test"
+            end
+            sel = Syskit::InstanceSelection.new(
+                nil,
+                component_m.to_instance_requirements,
+                srv_m.to_instance_requirements
+            )
+            assert_equal component_m.test_srv.to_instance_requirements, sel.selected
+            assert_equal component_m, sel.component_model
+        end
+    end
+
     describe "#port_mappings" do
         it "merges the port mappings from all selected services" do
             stub_t = self.stub_t


### PR DESCRIPTION
The situation this PR fixes is:

   cmp:
      child0: service1
      child1: service2

Where child1 gets a child of cmp in its `use()` injections.

In this case, during selection, child1 is narrowed to the bound data
service that matches 'service2' and the code was failing because of that
(looking for a plain composition)