### PR TITLE
fix: support multiple exceptions on ProfileAssertionFailed

### DIFF
--- a/lib/syskit/test/profile_assertions.rb
+++ b/lib/syskit/test/profile_assertions.rb
@@ -15,10 +15,13 @@ module Syskit
             class ProfileAssertionFailed < Roby::ExceptionBase
                 attr_reader :actions
 
-                def initialize(assertion_name, actions, original_error)
+                def initialize(assertion_name, actions, original_errors)
                     @assertion_name = assertion_name
                     @actions = Array(actions)
-                    super([original_error])
+                    # When capture errors is active, its possible to receive an array of
+                    # exceptions instead of a single one.
+                    original_errors = Array(original_errors)
+                    super(original_errors)
                 end
 
                 def pretty_print(pp)

--- a/test/test/test_profile_assertions.rb
+++ b/test/test/test_profile_assertions.rb
@@ -572,6 +572,24 @@ module Syskit
                     )
                 end
 
+                it "accepts failing with more than a single exception and can display " \
+                   "the exception" do
+                    skip unless Syskit.conf.capture_errors_during_network_resolution?
+
+                    @test_profile.define "test", @cmp_m
+
+                    e = assert_raises(ProfileAssertions::ProfileAssertionFailed) do
+                        assert_can_deploy(@test_profile)
+                    end
+                    assert_operator e.original_exceptions.size, :>, 1
+                    # We had a bug where #display_exceptions was failing due to
+                    # #e.original_exceptions being an array of arrays, this guarantees
+                    # that original_exceptions are properly formatted.
+                    #
+                    # Also, use StringIO to avoid cluttering the test results
+                    Roby.display_exception(StringIO.new, e)
+                end
+
                 it "handles plain instance requirements" do
                     assert_can_deploy(
                         @cmp_m


### PR DESCRIPTION
When the capture_errors_during_network_resolution flag is on, the ProfileAssertionFailed will receive an array of exceptions (even if its a single exception). At first glance it wasnt an issue, but Roby.display_exception expects that the array is flattened, so it would raise whenever trying to display exceptions with a ProfileAssertionFailed. 

I prefer to solve this than flattening the exceptions on Roby#display_exceptions (as in https://github.com/rock-core/tools-roby/pull/342), which would hide unintended behaviors.