### PR TITLE
fix: dont fail tasks not in the resolution

### DIFF
--- a/lib/syskit/network_generation/async.rb
+++ b/lib/syskit/network_generation/async.rb
@@ -79,6 +79,10 @@ module Syskit
                 @future = resolver
             end
 
+            def resolution_requirement_tasks
+                @future&.requirement_tasks
+            end
+
             def default_requirement_tasks
                 Engine.discover_requirement_tasks_from_plan(plan)
             end

--- a/lib/syskit/runtime/apply_requirement_modifications.rb
+++ b/lib/syskit/runtime/apply_requirement_modifications.rb
@@ -98,8 +98,8 @@ module Syskit
                     raise "the current network resolution is not yet finished"
                 end
 
-                running_requirement_tasks =
-                    find_tasks(Syskit::InstanceRequirementsTask).running
+                requirement_tasks = syskit_current_resolution.resolution_requirement_tasks
+                running_requirement_tasks = requirement_tasks.find_all(&:running?)
 
                 begin
                     resolution_apply_result = syskit_current_resolution.apply

--- a/test/runtime/test_apply_requirement_modifications.rb
+++ b/test/runtime/test_apply_requirement_modifications.rb
@@ -79,6 +79,59 @@ module Syskit
             end
         end
 
+        describe ".syskit_apply_async_resolution_results" do
+            it "ignores instance requirement tasks added to the plan after the " \
+               "resolution was started and would succeded without errors" do
+                cmp_m = Composition.new_submodel
+                cmp = plan.add_permanent_task(cmp_m.to_instance_requirements.as_plan)
+                requirement_task = cmp.planning_task
+
+                execute { requirement_task.start! }
+                execute { Runtime.apply_requirement_modifications(plan) }
+                plan.syskit_current_resolution.future.value
+
+                # This task should fail if listed for deployment as it has no defined
+                # deployment
+                other_m = TaskContext.new_submodel
+                other_t =
+                    plan.add_permanent_task(other_m.to_instance_requirements.as_plan)
+                other_t_requirement = other_t.planning_task
+                execute { other_t_requirement.start! }
+
+                execute { plan.syskit_apply_async_resolution_results }
+                assert requirement_task.resolution_success_event.emitted?
+                # Ensures that other_t was never considered during the resolution as it
+                # was added after the resolution started
+                refute other_t_requirement.failed_event.emitted?
+            end
+
+            it "ignores instance requirement tasks added to the plan after the " \
+               "resolution was started and would raise an exception" do
+                skip if Syskit.conf.capture_errors_during_network_resolution?
+
+                task_m = TaskContext.new_submodel
+                task_t = plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
+                requirement_task = task_t.planning_task
+                execute { requirement_task.start! }
+                execute { Runtime.apply_requirement_modifications(plan) }
+                plan.syskit_current_resolution.future.value
+
+                other_m = TaskContext.new_submodel
+                other_t =
+                    plan.add_permanent_task(other_m.to_instance_requirements.as_plan)
+                other_t_requirement = other_t.planning_task
+                execute { other_t_requirement.start! }
+
+                expect_execution do
+                    plan.syskit_apply_async_resolution_results
+                end.to { have_error_matching Roby::PlanningFailedError.match }
+                assert requirement_task.failed_event.emitted?
+                # Ensures that other_t was never considered during the resolution as it
+                # was added after the resolution started
+                refute other_t_requirement.failed_event.emitted?
+            end
+        end
+
         describe ".apply_requirement_modifications" do
             before do
                 @__capture_errors_feature_flag =


### PR DESCRIPTION
This only happened on the non-error capture code path, but still shouldnt. The requirement tasks should always be the tasks included in the resolution