### PR TITLE
feat: override model instead of klass

### DIFF
--- a/lib/syskit/models/component.rb
+++ b/lib/syskit/models/component.rb
@@ -1343,7 +1343,10 @@ module Syskit
             #
             # @return [DynamicPortBinding::BoundOutputReader]
             def data_reader(
-                port, as:, klass: Syskit::DynamicPortBinding::BoundOutputReader, **policy
+                port, as:,
+                klass: nil,
+                model: DynamicPortBinding::BoundOutputReader,
+                **policy
             )
                 port = DynamicPortBinding.create(port)
                 unless port.output?
@@ -1351,9 +1354,16 @@ module Syskit
                           "expected an output port, but #{port} seems to be an input"
                 end
 
-                data_readers[as] = DynamicPortBinding::BoundOutputReader.new(
-                    as, self, port, klass: klass, **policy
-                )
+                data_readers[as] =
+                    if klass
+                        Roby.warn_deprecated(
+                            "the klass argument of data_reader is deprecated, " \
+                            "use the model argument instead"
+                        )
+                        model.new(as, self, port, klass: klass, **policy)
+                    else
+                        model.new(as, self, port, **policy)
+                    end
             end
 
             # The data writers defined on this task, as a mapping from the writer's

--- a/lib/syskit/models/dynamic_port_binding.rb
+++ b/lib/syskit/models/dynamic_port_binding.rb
@@ -204,9 +204,10 @@ module Syskit
                     @klass = klass
                 end
 
-                def instanciate(component, value_resolver: IdentityValueResolver.new)
+                def instanciate(component, klass: @klass,
+                    value_resolver: IdentityValueResolver.new)
                     port_binding = @port_binding.instanciate
-                    @klass.new(
+                    klass.new(
                         name, component, port_binding,
                         value_resolver: value_resolver, **policy
                     )

--- a/test/test_component.rb
+++ b/test/test_component.rb
@@ -691,6 +691,22 @@ describe Syskit::Component do
             expect_execution.to { achieve { reader.connected? } }
             assert_equal task.out_port, reader.resolved_accessor.port
         end
+
+        it "overrides BoundOutputReader with another model" do
+            injected = Class.new Syskit::Models::DynamicPortBinding::BoundOutputReader do
+                def type
+                    String
+                end
+            end
+
+            @support_task_m.data_reader(
+                @task_m.match.running.out_port, as: "test", model: injected
+            )
+            reader = @support_task_m.test_reader
+
+            assert reader.kind_of? injected
+            assert_equal String, reader.type
+        end
     end
 
     describe Syskit::Component::DataAccessorInterface do


### PR DESCRIPTION
The model is more informative than the instance, and in hindsight is the better choice to be overriden. For example, by overriding the model we can change the type of the reader. Keep in mind whoever overrides the model probably still wants to implement a new instanciated version of it.  Do so by overriding the `#instanciate` method