### PR TITLE
fix: update fatal error tests after the change of behaviour in RTT

### DIFF
--- a/test/live/test_fatal_error.rb
+++ b/test/live/test_fatal_error.rb
@@ -263,7 +263,6 @@ module Syskit
         def trigger_fatal_error(task, &block)
             expect_execution { task.stop! }.to do
                 emit task.fatal_error_event
-                emit task.exception_event
                 instance_eval(&block) if block
             end
         end


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/rtt/pull/19

uncaught exceptions from stopHook are now directly transitioning to fatal.
