### PR TITLE
fix: rescue SyntaxError in BatchManager

### DIFF
--- a/lib/syskit/gui/batch_manager.rb
+++ b/lib/syskit/gui/batch_manager.rb
@@ -190,7 +190,7 @@ module Syskit
                             @error_message.hide
                             @result = Parser.parse(self.text)
                             accept
-                        rescue StandardError => e
+                        rescue SyntaxError, StandardError => e
                             @error_message.text = e.message
                             @error_message.show
                         end


### PR DESCRIPTION
The user is writing code in there ... of course SyntaxError has to be handled