### PR TITLE
fix: put a task in quarantine if it times out on stop

### DIFF
--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -44,7 +44,16 @@ module Syskit
             # The default is false for historical reasons. We strongly recommend turning
             # this on globally
             attr_predicate :auto_restart_deployments_with_quarantines?, true
+
+            # How long Syskit will allow a component to take to transition to STOPPED
+            # after an interruption
+            #
+            # This includes the time needed to stop. The default is 20s
+            attr_accessor :stop_transition_timeout
+
             # How long Syskit will allow a component to take to transition to EXCEPTION
+            # after it received the first state update that indicates such a transition
+            # happens
             #
             # This usually includes the time needed to stop and cleanup. The default
             # is 20s
@@ -262,6 +271,7 @@ module Syskit
                 @buffer_size_margin = 0.1
                 @opportunistic_recovery_from_quarantine = true
                 @auto_restart_deployments_with_quarantines = false
+                @stop_transition_timeout = 20.0
                 @exception_transition_timeout = 20.0
                 @kill_all_on_process_server_connection = false
                 @register_self_on_name_server = (ENV["SYSKIT_REGISTER_SELF_ON_NAME_SERVER"] != "0")

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -578,10 +578,10 @@ module Syskit
                     state_reader.read(@state_sample)
                 end
 
-            if @stop_transition_deadline
-                evaluate_stop_transition_deadline
-            elsif @exception_transition_deadline
+            if @exception_transition_deadline
                 return update_orogen_state_in_exception(state)
+            elsif @stop_transition_deadline
+                evaluate_stop_transition_deadline
             end
 
             return unless state

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -578,7 +578,9 @@ module Syskit
                     state_reader.read(@state_sample)
                 end
 
-            if @exception_transition_deadline
+            if @stop_transition_deadline
+                evaluate_stop_transition_deadline
+            elsif @exception_transition_deadline
                 return update_orogen_state_in_exception(state)
             end
 
@@ -595,6 +597,17 @@ module Syskit
                 @last_orogen_state = @orogen_state
                 @orogen_state = state
             end
+        end
+
+        def evaluate_stop_transition_deadline
+            return if Time.now < @stop_transition_deadline
+
+            quarantined!(
+                reason: "time out reached while waiting for the task to stop after " \
+                        "it was interrupted"
+            )
+
+            @stop_transition_deadline = nil
         end
 
         # @api private
@@ -1215,6 +1228,7 @@ module Syskit
             info "interrupting #{self}"
 
             if execution_agent && !execution_agent.finishing?
+                @stop_transition_deadline = Time.now + Syskit.conf.stop_transition_timeout
                 promise =
                     execution_engine.promise(description: "promise:#{self}#interrupt") do
                         stop_orocos_task
@@ -1307,6 +1321,7 @@ module Syskit
         on :stop do |_event|
             info "stopped #{self}"
 
+            @stop_transition_deadline = nil
             ensure_remote_state_getter_stopped
 
             if Syskit.conf.opportunistic_recovery_from_quarantine?

--- a/test/live/test_blocking_hooks.rb
+++ b/test/live/test_blocking_hooks.rb
@@ -462,6 +462,33 @@ module Syskit
             end
         end
 
+        describe "stop transition timeout" do
+            attr_reader :deployment
+
+            before do
+                @task = syskit_deploy_configure_and_start(
+                    OroGen.orogen_syskit_tests.Empty
+                          .deployed_as("stop-transition-timeout")
+                )
+                @deployment = @task.execution_agent
+                @__stop_transition_timeout = Syskit.conf.stop_transition_timeout
+            end
+
+            after do
+                cleanup_running_tasks
+                Syskit.conf.stop_transition_timeout = @__stop_transition_timeout
+            end
+
+            it "detects a task that should have stopped but has not" do
+                Syskit.conf.stop_transition_timeout = 1
+                @task.should_receive(:stop_orocos_task)
+                tic = Time.now
+                expect_execution { @task.stop! }
+                    .to_quarantine(@task)
+                assert (Time.now - tic) > 1
+            end
+        end
+
         def trigger_fatal_error(task, &block)
             expect_execution { task.stop! }.to do
                 emit task.fatal_error_event
@@ -484,7 +511,7 @@ module Syskit
         end
 
         def cleanup_running_tasks
-            return unless @deployment.running?
+            return unless deployment.running?
 
             executed_tasks =
                 deployment.each_executed_task.find_all(&:running?)

--- a/test/live/test_exception_transitions.rb
+++ b/test/live/test_exception_transitions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+using_task_library "logger"
+using_task_library "orogen_syskit_tests"
+
+module Syskit
+    class ExceptionTransitionTest < Syskit::Test::ComponentTest
+        run_live
+
+        it "handles a task that transitions to exception in stopHook" do
+            task_m = OroGen.orogen_syskit_tests.ExceptionFromStopHook
+                           .deployed_as("blocking_hooks")
+            task = syskit_deploy_configure_and_start(task_m)
+
+            expect_execution { task.stop! }
+                .to_emit task.custom_exception_event
+        end
+    end
+end


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-orogen_syskit_tests/pull/9

We have had a few instances of tasks that would be STOPPED on the C++ side after syskit attempted to interrupt them, but for which Syskit assumed the task was still running.

Make sure we time out in that case and quarantine the task (which under current configuration should actually kill the deployment)