### PR TITLE
feat: implement fiber-based async resolution (on top of #533)

### DIFF
--- a/lib/syskit/network_generation.rb
+++ b/lib/syskit/network_generation.rb
@@ -10,6 +10,7 @@ end
 
 require "syskit/network_generation/async"
 require "syskit/network_generation/async_threaded"
+require "syskit/network_generation/async_fiber"
 require "syskit/network_generation/dataflow_computation"
 require "syskit/network_generation/dataflow_dynamics"
 require "syskit/network_generation/engine"

--- a/lib/syskit/network_generation/async.rb
+++ b/lib/syskit/network_generation/async.rb
@@ -15,28 +15,6 @@ module Syskit
                 compute_deployments garbage_collect validate_final_network
             ].freeze
 
-            # Whether the network generation step is finished
-            def network_generation_complete?
-                raise NotImplementedError, __method__
-            end
-
-            # Whether the network generation step is finished and successful
-            def network_generation_successful?
-                raise NotImplementedError, __method__
-            end
-
-            # In case the network generation step is successful, return its result
-            #
-            # @return a pair, (required_instances, resolution_errors)
-            def network_generation_result
-                raise NotImplementedError, __method__
-            end
-
-            # In case the network generation step raised an exception, return it
-            def network_generation_error
-                raise NotImplementedError, __method__
-            end
-
             def initialize(
                 plan, requirement_tasks,
                 resolver_options: {}, event_logger: plan.event_logger
@@ -91,34 +69,27 @@ module Syskit
             #
             # @return [nil,SystemNetworkPlanApplyResult] the application result, which is
             #   nil in case of failure or cancellation and a result object otherwise
-            def apply_network_generation
-                unless network_generation_complete?
-                    raise InvalidState,
-                          "attempting to call Async#apply_network_generation while " \
-                          "processing is in progress"
-                end
-
+            def apply_network_generation(result:, error:)
                 if cancelled?
                     @engine.discard_work_plan
                     nil
-                elsif network_generation_successful?
-                    required_instances, resolution_errors = network_generation_result
+                elsif error
+                    @engine.handle_resolution_exception(error, on_error: Engine.on_error)
+                    raise error
+                else
+                    successful_requirements, resolution_errors = result
                     begin
                         @engine.apply_system_network_to_plan(
-                            required_instances, **@apply_system_network_options
+                            successful_requirements, **@apply_system_network_options
                         )
                         SystemNetworkPlanApplyResult.new(
-                            instance_requirement_tasks: required_instances.keys,
+                            instance_requirement_tasks: successful_requirements.keys,
                             errors: resolution_errors
                         )
                     rescue ::Exception => e
                         @engine.handle_resolution_exception(e, on_error: Engine.on_error)
                         raise e
                     end
-                else
-                    error = network_generation_error
-                    @engine.handle_resolution_exception(error, on_error: Engine.on_error)
-                    raise error
                 end
             end
 

--- a/lib/syskit/network_generation/async.rb
+++ b/lib/syskit/network_generation/async.rb
@@ -9,7 +9,7 @@ module Syskit
             include Logger::Hierarchy
             include Roby::DRoby::EventLogging
 
-            attr_reader :event_logger, :requirement_tasks
+            attr_reader :event_logger, :requirement_tasks, :engine
 
             ENGINE_OPTIONS_CARRIED_TO_APPLY_SYSTEM_NETWORK = %I[
                 compute_deployments garbage_collect validate_final_network
@@ -17,13 +17,18 @@ module Syskit
 
             def initialize(
                 plan, requirement_tasks,
-                resolver_options: {}, event_logger: plan.event_logger
+                resolver_options: {}, event_logger: plan.event_logger,
+                resolution_control: Control.new
             )
                 @plan = plan
                 @event_logger = event_logger
                 @requirement_tasks = requirement_tasks
 
-                @engine = Engine.new(plan, event_logger: @event_logger)
+                @engine = Engine.new(
+                    plan,
+                    event_logger: @event_logger,
+                    resolution_control: resolution_control
+                )
                 @resolver_options = resolver_options
                 @apply_system_network_options = resolver_options.slice(
                     *ENGINE_OPTIONS_CARRIED_TO_APPLY_SYSTEM_NETWORK
@@ -47,19 +52,6 @@ module Syskit
                 current.to_set == @requirement_tasks
             end
 
-            # Cancel this resolution
-            #
-            # This is only signalling that the resolution should be cancelled. The
-            # cancellation itself might take some time
-            def cancel
-                @cancelled = true
-            end
-
-            # Whether this resolution has been cancelled
-            def cancelled?
-                @cancelled
-            end
-
             class InvalidState < RuntimeError; end
 
             # Common implementation of the logic that applies the result of the network
@@ -71,25 +63,24 @@ module Syskit
             #   nil in case of failure or cancellation and a result object otherwise
             def apply_network_generation(result:, error:)
                 if cancelled?
-                    @engine.discard_work_plan
-                    nil
+                    throw :syskit_netgen_cancelled
                 elsif error
                     @engine.handle_resolution_exception(error, on_error: Engine.on_error)
                     raise error
-                else
-                    successful_requirements, resolution_errors = result
-                    begin
-                        @engine.apply_system_network_to_plan(
-                            successful_requirements, **@apply_system_network_options
-                        )
-                        SystemNetworkPlanApplyResult.new(
-                            instance_requirement_tasks: successful_requirements.keys,
-                            errors: resolution_errors
-                        )
-                    rescue ::Exception => e
-                        @engine.handle_resolution_exception(e, on_error: Engine.on_error)
-                        raise e
-                    end
+                end
+
+                successful_requirements, resolution_errors = result
+                begin
+                    @engine.apply_system_network_to_plan(
+                        successful_requirements, **@apply_system_network_options
+                    )
+                    SystemNetworkPlanApplyResult.new(
+                        instance_requirement_tasks: successful_requirements.keys,
+                        errors: resolution_errors
+                    )
+                rescue ::Exception => e
+                    @engine.handle_resolution_exception(e, on_error: Engine.on_error)
+                    raise e
                 end
             end
 
@@ -114,6 +105,25 @@ module Syskit
                 NetworkGeneration::SystemNetworkPlanApplyResult.new(
                     errors: [exception], instance_requirement_tasks: old
                 )
+            end
+
+            # Object that is passed to the network generation process to handle
+            # cancellations and yield
+            class Control
+                # Method regularly called by the network generation code to allow
+                # the control class to do its job
+                #
+                # @param [String] name name of the interruption point. It is logged
+                #   on the given logger as a timepoint
+                # @return [Boolean] true if the computation can continue, or false
+                #   if it is cancelled
+                def interruption_point(
+                    event_logger, name,
+                    log_on_interruption_only: false
+                )
+                    event_logger.log_timepoint(name) unless log_on_interruption_only
+                    true
+                end
             end
         end
     end

--- a/lib/syskit/network_generation/async_fiber.rb
+++ b/lib/syskit/network_generation/async_fiber.rb
@@ -4,49 +4,97 @@ module Syskit
     module NetworkGeneration
         # A partially asynchronous requirement resolver built on top of {Engine}
         class AsyncFiber < Async
+            # Object that is passed to the network generation process to handle
+            # cancellations and yield
+            class Control < Async::Control
+                # @param [Float] slice the allowed computation slice in seconds.
+                #   The network generation process will yield back after this long,
+                #   ensuring that the main thread can do some processing
+                def initialize(slice)
+                    super()
+
+                    @slice = slice
+                    @slice_start_time = Time.now
+                end
+
+                # (see Async::Control#interruption_point)
+                def interruption_point(
+                    event_logger, name, log_on_interruption_only: false
+                )
+                    return super if Time.now - @slice_start_time < @slice
+
+                    event_logger.log_timepoint "#{name}:interrupt"
+                    cancelled = Fiber.yield
+                    event_logger.log_timepoint "#{name}:resume"
+                    @slice_start_time = Time.now
+                    !cancelled
+                end
+            end
+
             def initialize(
                 plan, requirement_tasks,
-                event_logger: plan.event_logger, **resolver_options
+                slice: Syskit.conf.resolution_time_slice,
+                event_logger: plan.event_logger, resolver_options: {}
             )
-                super
+                super(plan, requirement_tasks,
+                      resolution_control: Control.new(slice),
+                      event_logger: event_logger, resolver_options: resolver_options)
 
                 @keepalive = Roby::Transaction.new(plan)
                 plan.find_local_tasks(Component).each do |component_task|
                     @keepalive.wrap(component_task) unless component_task.finished?
                 end
 
-                # Resolver is used within the block ... don't assign directly to @future
                 @fiber = Fiber.new do
-                    begin
-                        network_generation_result =
-                            log_timepoint_group "syskit-network-generation" do
-                                @engine.resolve_system_network(
-                                    requirement_tasks, **resolver_options
-                                )
-                            end
-                    rescue Exception => e
-                        network_generation_error = e
+                    catch(:syskit_netgen_cancelled) do
+                        async_phase
                     end
-
-                    @async_phase_running_requirements =
-                        @requirement_tasks.find_all(&:running?)
-
-                    @async_phase_result =
-                        log_timepoint_group "syskit-apply-network-generation" do
-                            apply_network_generation(
-                                result: network_generation_result,
-                                error: network_generation_error
-                            )
-                        end
-                rescue Exception => e # rubocop:disable Lint/RescueException
-                    @async_phase_error = e
                 end
             end
 
+            def async_phase
+                begin
+                    network_generation_result =
+                        log_timepoint_group "syskit-network-generation" do
+                            @engine.resolve_system_network(
+                                @requirement_tasks, **@resolver_options
+                            )
+                        end
+                rescue Exception => e # rubocop:disable Lint/RescueException
+                    network_generation_error = e
+                end
+
+                @async_phase_running_requirements =
+                    @requirement_tasks.find_all(&:running?)
+
+                @async_phase_result =
+                    log_timepoint_group "syskit-apply-network-generation" do
+                        apply_network_generation(
+                            result: network_generation_result,
+                            error: network_generation_error
+                        )
+                    end
+            rescue Exception => e # rubocop:disable Lint/RescueException
+                @async_phase_error = e
+            end
+
             def self.start(
-                plan, requirement_tasks = default_requirement_tasks, **resolver_options
+                plan, requirement_tasks = default_requirement_tasks, resolver_options: {}
             )
-                new(plan, requirement_tasks, **resolver_options)
+                new(plan, requirement_tasks, resolver_options: resolver_options)
+            end
+
+            # Cancel this resolution
+            #
+            # This is only signalling that the resolution should be cancelled. The
+            # cancellation itself might take some time
+            def cancel
+                @cancelled = true
+            end
+
+            # Whether this resolution has been cancelled
+            def cancelled?
+                @cancelled
             end
 
             def finished?
@@ -61,9 +109,10 @@ module Syskit
             #   nil to ignore the test altogether
             def poll(requirement_tasks)
                 return if finished?
+
                 cancel if !cancelled? && requirement_tasks && !valid?(requirement_tasks)
 
-                return @fiber.resume unless async_phase_finished?
+                return @fiber.resume(cancelled?) unless async_phase_finished?
 
                 finalize
             end
@@ -73,28 +122,36 @@ module Syskit
             end
 
             def finalize
-                if @async_phase_error
-                    update_instance_requirement_tasks_on_exception(
+                if cancelled?
+                    @engine.discard_work_plan
+                    return
+                elsif @async_phase_error
+                    @async_phase_result = update_instance_requirement_tasks_on_exception(
                         @async_phase_running_requirements, @async_phase_error
                     )
-                elsif !@async_phase_result
                     return
-                else
-                    update_instance_requirement_tasks_on_result(@async_phase_result)
                 end
+
+                return unless @async_phase_result
+
+                update_instance_requirement_tasks_on_result(@async_phase_result)
             ensure
                 finished!
             end
 
+            def result
+                @async_phase_result
+            end
+
             def finished!
                 @finished = true
-                @keepalive.discard_transaction
+                @keepalive.discard_transaction unless @keepalive.finalized?
             end
 
             # Wait for the resolution to finish and either apply the result or raise if
             # there is an error
             def join(raise_on_error: true)
-                @fiber.resume until async_phase_finished?
+                @fiber.resume(cancelled?) until async_phase_finished?
 
                 if raise_on_error
                     _, _, exception = @async_phase_result

--- a/lib/syskit/network_generation/async_fiber.rb
+++ b/lib/syskit/network_generation/async_fiber.rb
@@ -40,6 +40,10 @@ module Syskit
                       resolution_control: Control.new(slice),
                       event_logger: event_logger, resolver_options: resolver_options)
 
+                # Protect all Component instances against garbage collection
+                # by adding them in a transaction. This is to make sure we don't
+                # tear down, during network generation, subparts of the old network
+                # that are actually needed by the new network.
                 @keepalive = Roby::Transaction.new(plan)
                 plan.find_local_tasks(Component).each do |component_task|
                     @keepalive.wrap(component_task) unless component_task.finished?

--- a/lib/syskit/network_generation/async_fiber.rb
+++ b/lib/syskit/network_generation/async_fiber.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module Syskit
+    module NetworkGeneration
+        # A partially asynchronous requirement resolver built on top of {Engine}
+        class AsyncFiber < Async
+            def initialize(
+                plan, requirement_tasks,
+                event_logger: plan.event_logger, **resolver_options
+            )
+                super
+
+                @keepalive = Roby::Transaction.new(plan)
+                plan.find_local_tasks(Component).each do |component_task|
+                    @keepalive.wrap(component_task) unless component_task.finished?
+                end
+
+                # Resolver is used within the block ... don't assign directly to @future
+                @fiber = Fiber.new do
+                    begin
+                        network_generation_result =
+                            log_timepoint_group "syskit-network-generation" do
+                                @engine.resolve_system_network(
+                                    requirement_tasks, **resolver_options
+                                )
+                            end
+                    rescue Exception => e
+                        network_generation_error = e
+                    end
+
+                    @async_phase_running_requirements =
+                        @requirement_tasks.find_all(&:running?)
+
+                    @async_phase_result =
+                        log_timepoint_group "syskit-apply-network-generation" do
+                            apply_network_generation(
+                                result: network_generation_result,
+                                error: network_generation_error
+                            )
+                        end
+                rescue Exception => e # rubocop:disable Lint/RescueException
+                    @async_phase_error = e
+                end
+            end
+
+            def self.start(
+                plan, requirement_tasks = default_requirement_tasks, **resolver_options
+            )
+                new(plan, requirement_tasks, **resolver_options)
+            end
+
+            def finished?
+                @finished
+            end
+
+            # Periodic polling of the resolution process
+            #
+            # @param [nil,Set<InstanceRequirementTask>] requirement_tasks the requirements
+            #   that currently need to be resolved. The class will cancel the current
+            #   resolution if it does not match the set it is actually resolving. Pass
+            #   nil to ignore the test altogether
+            def poll(requirement_tasks)
+                return if finished?
+                cancel if !cancelled? && requirement_tasks && !valid?(requirement_tasks)
+
+                return @fiber.resume unless async_phase_finished?
+
+                finalize
+            end
+
+            def async_phase_finished?
+                !@fiber.alive?
+            end
+
+            def finalize
+                if @async_phase_error
+                    update_instance_requirement_tasks_on_exception(
+                        @async_phase_running_requirements, @async_phase_error
+                    )
+                elsif !@async_phase_result
+                    return
+                else
+                    update_instance_requirement_tasks_on_result(@async_phase_result)
+                end
+            ensure
+                finished!
+            end
+
+            def finished!
+                @finished = true
+                @keepalive.discard_transaction
+            end
+
+            # Wait for the resolution to finish and either apply the result or raise if
+            # there is an error
+            def join(raise_on_error: true)
+                @fiber.resume until async_phase_finished?
+
+                if raise_on_error
+                    _, _, exception = @async_phase_result
+                    raise exception if exception
+                end
+
+                poll(nil)
+            end
+        end
+    end
+end

--- a/lib/syskit/network_generation/async_threaded.rb
+++ b/lib/syskit/network_generation/async_threaded.rb
@@ -7,11 +7,34 @@ module Syskit
             # The thread pool (or, really, any of Concurrent executor)
             attr_reader :thread_pool
 
+            # Object that is passed to the network generation process to handle
+            # cancellations and yield
+            class Control < Async::Control
+                # @param [Concurrent::Event] cancelled whether the resolution
+                #   has been cancelled or not
+                def initialize(cancelled)
+                    super()
+
+                    @cancelled = cancelled
+                end
+
+                # (see Async::Control#interruption_point)
+                def interruption_point(event_logger, name, **)
+                    event_logger.log_timepoint(name)
+                    !@cancelled.set?
+                end
+            end
+
             def initialize(
                 plan, requirement_tasks,
-                event_logger: plan.event_logger, **resolver_options
+                event_logger: plan.event_logger, resolver_options: {}
             )
-                super
+                @cancelled = Concurrent::Event.new
+                super(
+                    plan, requirement_tasks,
+                    resolution_control: Control.new(@cancelled),
+                    event_logger: event_logger, resolver_options: resolver_options
+                )
 
                 @thread_pool = Concurrent::CachedThreadPool.new
 
@@ -28,9 +51,11 @@ module Syskit
                 @future = Concurrent::Future.new(executor: thread_pool) do
                     Thread.current.name = "syskit-network-generation"
                     log_timepoint_group "syskit-network-generation" do
-                        @engine.resolve_system_network(
-                            requirement_tasks, **resolver_options
-                        )
+                        catch(:syskit_netgen_cancelled) do
+                            @engine.resolve_system_network(
+                                requirement_tasks, **resolver_options
+                            )
+                        end
                     end
                 end
             end
@@ -40,16 +65,31 @@ module Syskit
             end
 
             def self.start(
-                plan, requirement_tasks = default_requirement_tasks, **resolver_options
+                plan, requirement_tasks = default_requirement_tasks, resolver_options: {}
             )
-                async = new(plan, requirement_tasks, **resolver_options)
+                async = new(plan, requirement_tasks, resolver_options: resolver_options)
                 async.start
                 async
+            end
+
+            # Cancel this resolution
+            #
+            # This is only signalling that the resolution should be cancelled. The
+            # cancellation itself might take some time
+            def cancel
+                @cancelled.set
+            end
+
+            # Whether this resolution has been cancelled
+            def cancelled?
+                @cancelled.set?
             end
 
             def finished?
                 @finished
             end
+
+            attr_reader :result
 
             # Periodic polling of the resolution process
             #
@@ -59,11 +99,16 @@ module Syskit
             #   nil to ignore the test altogether
             def poll(requirement_tasks)
                 return if finished?
+
                 cancel if !cancelled? && requirement_tasks && !valid?(requirement_tasks)
 
                 return unless network_generation_complete?
 
-                apply_complete_network_generation
+                success = catch(:syskit_netgen_cancelled) do
+                    @result = finalize
+                    true
+                end
+                @engine.discard_work_plan unless success
             end
 
             def apply_network_generation
@@ -76,11 +121,10 @@ module Syskit
                 super(result: network_generation_result, error: network_generation_error)
             end
 
-            def apply_complete_network_generation
+            def finalize
                 running_requirement_tasks = @requirement_tasks.find_all(&:running?)
 
-                return unless (result = apply_network_generation)
-
+                result = apply_network_generation
                 update_instance_requirement_tasks_on_result(result)
                 result
             rescue Exception => e # rubocop:disable Lint/RescueException
@@ -95,14 +139,9 @@ module Syskit
 
             def finished!
                 @finished = true
-                @keepalive.discard_transaction
+                # Transactions may be discarded externally on e.g. plan teardown
+                @keepalive.discard_transaction unless @keepalive.finalized?
                 @thread_pool.shutdown
-            end
-
-            def cancel
-                super
-
-                @future.cancel
             end
 
             def network_generation_result

--- a/lib/syskit/network_generation/async_threaded.rb
+++ b/lib/syskit/network_generation/async_threaded.rb
@@ -51,14 +51,29 @@ module Syskit
                 @finished
             end
 
+            # Periodic polling of the resolution process
+            #
+            # @param [nil,Set<InstanceRequirementTask>] requirement_tasks the requirements
+            #   that currently need to be resolved. The class will cancel the current
+            #   resolution if it does not match the set it is actually resolving. Pass
+            #   nil to ignore the test altogether
             def poll(requirement_tasks)
                 return if finished?
-
-                cancel if !cancelled? && !valid?(requirement_tasks)
+                cancel if !cancelled? && requirement_tasks && !valid?(requirement_tasks)
 
                 return unless network_generation_complete?
 
                 apply_complete_network_generation
+            end
+
+            def apply_network_generation
+                unless network_generation_complete?
+                    raise InvalidState,
+                          "attempting to call Async#apply_network_generation while " \
+                          "processing is in progress"
+                end
+
+                super(result: network_generation_result, error: network_generation_error)
             end
 
             def apply_complete_network_generation
@@ -100,10 +115,6 @@ module Syskit
 
             def network_generation_complete?
                 @future.complete?
-            end
-
-            def network_generation_successful?
-                @future.fulfilled?
             end
 
             def network_generation_join

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -74,19 +74,31 @@ module Syskit
 
             attr_reader :event_logger
 
-            def initialize(plan, work_plan: Roby::Transaction.new(plan),
-                event_logger: plan.event_logger)
+            def initialize(
+                plan,
+                work_plan: Roby::Transaction.new(plan),
+                event_logger: plan.event_logger,
+                resolution_control: Async::Control.new
+            )
                 @real_plan = plan
                 @work_plan = work_plan
                 @merge_solver = NetworkGeneration::MergeSolver.new(work_plan)
                 @event_logger = event_logger
                 @required_instances = {}
+                @resolution_control = resolution_control
             end
 
             # Returns the set of deployments that are available for this network
             # generation
             def available_deployments
                 Syskit.conf.deployments
+            end
+
+            def interruption_point(name, log_on_interruption_only: false)
+                continue = @resolution_control.interruption_point(
+                    self, name, log_on_interruption_only: log_on_interruption_only
+                )
+                throw :syskit_netgen_cancelled unless continue
             end
 
             # Transform the system network into a deployed network
@@ -101,12 +113,13 @@ module Syskit
                 validate_deployed_network: true
             )
                 resolution_errors = []
-                log_timepoint_group "deploy_system_network" do
+                log_timepoint_group "syskit-netgen-deploy-system-network" do
                     deployer = SystemNetworkDeployer.new(
                         work_plan,
                         event_logger: event_logger,
                         merge_solver: merge_solver,
-                        default_deployment_group: default_deployment_group
+                        default_deployment_group: default_deployment_group,
+                        resolution_control: @resolution_control
                     )
 
                     deployer.deploy(
@@ -124,6 +137,11 @@ module Syskit
                     )
                 end
 
+                interruption_point(
+                    "syskit-netgen-deployed-system-network",
+                    log_on_interruption_only: true
+                )
+
                 # Now that we have a deployed network, we can compute the
                 # connection policies and the port dynamics
                 if compute_policies
@@ -132,11 +150,8 @@ module Syskit
                     @dataflow_dynamics.result.each do |task, dynamics|
                         task.trigger_information = dynamics
                     end
-                    log_timepoint "compute_connection_policies"
+                    interruption_point "compute_connection_policies"
                 end
-
-                @deployment_tasks = work_plan.find_local_tasks(Deployment).to_set
-                @deployed_tasks = work_plan.find_local_tasks(Component).to_set
 
                 resolution_errors
             end
@@ -359,17 +374,19 @@ module Syskit
             # Given the network with deployed tasks, this method looks at how we
             # could adapt the running network to the new one
             def finalize_deployed_tasks
-                debug "finalizing deployed tasks"
-
                 used_deployments = work_plan.find_local_tasks(Deployment).to_set
                 used_tasks       = work_plan.find_local_tasks(Component).to_set
-                log_timepoint "used_tasks"
 
-                import_existing_tasks(used_tasks)
-                log_timepoint "dataflow_graph_cleanup"
+                all_tasks = import_existing_tasks
+                interruption_point "syskit-netgen-apply-imported-existing-tasks"
+                imported_tasks_remove_direct_connections(all_tasks - used_tasks)
+                interruption_point(
+                    "syskit-netgen-apply-imported-tasks-removed-connections"
+                )
+
                 finishing_deployments, existing_deployments =
                     import_existing_deployments(used_deployments)
-                log_timepoint "existing_and_finished_deployments"
+                interruption_point "syskit-netgen-apply-import-existing-deployments"
 
                 debug do
                     debug "  Mapping deployments in the network to the existing ones"
@@ -403,6 +420,10 @@ module Syskit
                     newly_deployed_tasks.merge(new)
                     reused_deployed_tasks.merge(reused)
                     selected_deployment_tasks << selected
+                    interruption_point(
+                        "syskit-netgen-apply:select-deployment",
+                        log_on_interruption_only: true
+                    )
                 end
                 log_timepoint "select_deployments"
 
@@ -521,9 +542,10 @@ module Syskit
             #
             # @param [Array<Syskit::Component>] used_tasks the tasks that are part of the
             #   new network
-            def import_existing_tasks(used_tasks)
+            def import_existing_tasks
                 all_tasks = work_plan.find_tasks(Component).to_set
-                log_timepoint "import_all_tasks_from_plan"
+                interruption_point "syskit-engine:imported-tasks"
+
                 all_tasks.delete_if do |t|
                     if !t.reusable?
                         debug { "  clearing the relations of the finished task #{t}" }
@@ -535,15 +557,17 @@ module Syskit
                         true
                     end
                 end
-                log_timepoint "all_tasks_cleanup"
+                interruption_point "syskit-engine:imported-tasks:cleanup"
 
-                # Remove connections that are not forwarding connections (e.g.
-                # composition exports)
+                all_tasks
+            end
+
+            # Remove connections that are not forwarding connections (e.g.
+            # composition exports)
+            def imported_tasks_remove_direct_connections(tasks)
                 dataflow_graph =
                     work_plan.task_relation_graph_for(Syskit::Flows::DataFlow)
-                all_tasks.each do |t|
-                    next if used_tasks.include?(t)
-
+                tasks.each do |t|
                     dataflow_graph.in_neighbours(t).dup.each do |source_t|
                         connections = dataflow_graph.edge_info(source_t, t).dup
                         connections.delete_if do |(source_port, sink_port), _policy|
@@ -559,6 +583,10 @@ module Syskit
                             dataflow_graph.set_edge_info(source_t, t, connections)
                         end
                     end
+                    interruption_point(
+                        "syskit-engine:imported-tasks:dataflow-cleanup",
+                        log_on_interruption_only: true
+                    )
                 end
             end
 
@@ -738,7 +766,8 @@ module Syskit
                     event_logger: event_logger,
                     merge_solver: merge_solver,
                     default_deployment_group: default_deployment_group,
-                    early_deploy: early_deploy
+                    early_deploy: early_deploy,
+                    resolution_control: @resolution_control
                 )
                 toplevel_tasks =
                     system_network_generator.instanciate_system_network(
@@ -923,10 +952,11 @@ module Syskit
             end
 
             def apply_system_network_to_plan(
-                required_instances, compute_deployments: true,
-                garbage_collect: true, validate_final_network: true
+                required_instances,
+                compute_deployments: true,
+                garbage_collect: true,
+                validate_final_network: true
             )
-
                 # Now, deploy the network by matching the available
                 # deployments to the one in the generated network. Note that
                 # these deployments are *not* yet the running tasks.
@@ -964,7 +994,7 @@ module Syskit
             end
 
             def discard_work_plan
-                work_plan.discard_transaction
+                work_plan.discard_transaction unless work_plan.finalized?
             end
 
             def commit_work_plan
@@ -1016,7 +1046,7 @@ module Syskit
                 elsif on_error == :commit
                     work_plan.commit_transaction
                 else
-                    work_plan.discard_transaction
+                    discard_work_plan
                 end
             end
 

--- a/lib/syskit/network_generation/system_network_deployer.rb
+++ b/lib/syskit/network_generation/system_network_deployer.rb
@@ -35,14 +35,25 @@ module Syskit
             # @return [Models::DeploymentGroup]
             attr_accessor :default_deployment_group
 
-            def initialize(plan,
+            def initialize(
+                plan,
                 event_logger: plan.event_logger,
                 merge_solver: MergeSolver.new(plan),
-                default_deployment_group: Syskit.conf.deployment_group)
+                resolution_control: Async::Control.new,
+                default_deployment_group: Syskit.conf.deployment_group
+            )
                 @plan = plan
                 @event_logger = event_logger
                 @merge_solver = merge_solver
                 @default_deployment_group = default_deployment_group
+                @resolution_control = resolution_control
+            end
+
+            def interruption_point(name, log_on_interruption_only: false)
+                continue = @resolution_control.interruption_point(
+                    self, name, log_on_interruption_only: log_on_interruption_only
+                )
+                throw :syskit_netgen_cancelled unless continue
             end
 
             # Replace non-deployed tasks in the plan by deployed ones
@@ -62,10 +73,10 @@ module Syskit
                 all_tasks = plan.find_local_tasks(TaskContext).to_a
                 selected_deployments, missing_deployments =
                     select_deployments(all_tasks, reuse: reuse_deployments)
-                log_timepoint "select_deployments"
+                interruption_point "select_deployments"
 
                 apply_selected_deployments(selected_deployments, deployment_tasks)
-                log_timepoint "apply_selected_deployments"
+                interruption_point "apply_selected_deployments"
 
                 if validate
                     validate_deployed_network(error_handler: error_handler)

--- a/lib/syskit/network_generation/system_network_generator.rb
+++ b/lib/syskit/network_generation/system_network_generator.rb
@@ -24,12 +24,15 @@ module Syskit
                 @early_deploy
             end
 
-            def initialize(plan, # rubocop:disable Metrics/ParameterLists
+            def initialize( # rubocop:disable Metrics/ParameterLists
+                plan,
                 event_logger: plan.event_logger,
                 merge_solver: MergeSolver.new(plan),
                 default_deployment_group: nil,
                 early_deploy: false,
-                error_handler: RaiseErrorHandler.new)
+                error_handler: RaiseErrorHandler.new,
+                resolution_control: Async::Control.new
+            )
                 if merge_solver.plan != plan
                     raise ArgumentError,
                           "gave #{merge_solver} as merge solver, which applies on " \
@@ -42,6 +45,14 @@ module Syskit
                 @default_deployment_group = default_deployment_group
                 @early_deploy = early_deploy
                 @error_handler = error_handler
+                @resolution_control = resolution_control
+            end
+
+            def interruption_point(name, log_on_interruption_only: false)
+                continue = @resolution_control.interruption_point(
+                    self, name, log_on_interruption_only: log_on_interruption_only
+                )
+                throw :syskit_netgen_cancelled unless continue
             end
 
             # Generate the network in the plan
@@ -142,7 +153,7 @@ module Syskit
                     task.fullfilled_model = [
                         fullfilled_task_m, fullfilled_modules, meaningful_args
                     ]
-                    log_timepoint "task-#{i}"
+                    interruption_point "task-#{i}"
                     task
                 end
 
@@ -237,34 +248,36 @@ module Syskit
             # Compute in #plan the network needed to fullfill the requirements
             #
             # This network is neither validated nor tied to actual deployments
-            def resolve_system_network(error_handler: @error_handler,
+            def resolve_system_network(
+                error_handler: @error_handler,
                 garbage_collect: true,
                 validate_abstract_network: true,
                 validate_generated_network: true,
-                validate_deployed_network: true)
+                validate_deployed_network: true
+            )
                 deployment_tasks = {}
-                deploy(deployment_tasks) if early_deploy?
+                early_deploy(deployment_tasks)
+
                 merge_solver.merge_identical_tasks
-                log_timepoint "merge"
+                interruption_point("syskit-netgen-merge")
+
                 Engine.instanciated_network_postprocessing.each do |block|
                     block.call(self, plan)
-                    log_timepoint "postprocessing:#{block}"
+                    interruption_point("syskit-netgen-postprocessing:#{block}")
                 end
 
                 link_to_busses
-                log_timepoint "link_to_busses"
+                interruption_point("syskit-netgen-link-to-busses")
 
-                deploy(deployment_tasks) if early_deploy?
+                early_deploy(deployment_tasks)
                 merge_solver.merge_identical_tasks
-                log_timepoint "merge"
+                interruption_point("syskit-netgen-merge")
 
                 self.class.remove_abstract_composition_optional_children(plan)
-                log_timepoint "remove-optional"
 
                 # Finally, select 'default' as configuration for all
                 # remaining tasks that do not have a 'conf' argument set
                 plan.find_local_tasks(Component).each(&:freeze_delayed_arguments)
-                log_timepoint "default_conf"
 
                 # Cleanup the remainder of the tasks that are of no use right
                 # now (mostly devices)
@@ -275,8 +288,8 @@ module Syskit
                         # useful anymore
                         plan.remove_task(obj)
                     end
-                    log_timepoint "static_garbage_collect"
                 end
+                interruption_point("syskit-netgen-clean-network")
 
                 # And get rid of the 'permanent' marking we use to be able to
                 # run static_garbage_collect
@@ -287,7 +300,7 @@ module Syskit
                 Engine.system_network_postprocessing.each do |block|
                     block.call(self, plan)
                 end
-                log_timepoint "postprocessing"
+                interruption_point("syskit-netgen-postprocessing")
 
                 validate_network(
                     error_handler: error_handler,
@@ -296,7 +309,15 @@ module Syskit
                     validate_deployed_network:
                         early_deploy? && validate_deployed_network
                 )
+                interruption_point("syskit-netgen-validation")
                 @toplevel_tasks
+            end
+
+            def early_deploy(deployment_tasks)
+                return unless early_deploy?
+
+                deploy(deployment_tasks)
+                interruption_point "syskit-netgen-early-deploy"
             end
 
             # Compute in #plan the network needed to fullfill the requirements

--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -121,6 +121,16 @@ module Syskit
             # likely want this
             attr_predicate :kill_all_on_process_server_connection?, true
 
+            # How long the Fiber-based resolver can compute new networks before
+            # it gives control back to the main thread
+            #
+            # Reducing the value makes the main thread more reactive at the cost
+            # of deployment time. Higher values reduces the system reactivity during
+            # resolutions, but reduces deployment time
+            #
+            # The default is 500ms
+            attr_accessor :resolution_time_slice
+
             # Indicate to the loggers which time field it should use as logical time
             #
             # When a type member is marked with `@meta role logical_time` Syskit will pass
@@ -278,6 +288,8 @@ module Syskit
                 @remote_process_managers_initial_connection_timeout = 60
 
                 @compositions_use_schedule_as = false
+
+                @resolution_time_slice = 0.5
 
                 @log_rotation_period = nil
                 @log_transfer = LogTransferManager::Configuration.new(

--- a/lib/syskit/runtime/apply_requirement_modifications.rb
+++ b/lib/syskit/runtime/apply_requirement_modifications.rb
@@ -2,14 +2,26 @@
 
 module Syskit
     module Runtime
-        module PlanExtension
-            def initialize(*, **)
-                super
+        @syskit_async_method = NetworkGeneration::AsyncThreaded
 
-                @syskit_async_method = NetworkGeneration::AsyncThreaded
-            end
-
+        class << self
             attr_accessor :syskit_async_method
+        end
+
+        module PlanExtension
+            attr_accessor :syskit_pending_forced_resolution
+
+            # Changes the async method used to compute syskit networks
+            #
+            # @see syskit_async_method
+            attr_writer :syskit_async_method
+
+            # Async method to be used to compute syskit networks
+            #
+            # @see Runtime.syskit_async_method
+            def syskit_async_method
+                @syskit_async_method || Runtime.syskit_async_method
+            end
 
             # The currently running resolution
             #
@@ -20,8 +32,6 @@ module Syskit
             def syskit_has_async_resolution?
                 @syskit_current_resolution
             end
-
-            attr_accessor :syskit_pending_forced_resolution
 
             def syskit_pending_forced_resolution?
                 @syskit_pending_forced_resolution
@@ -42,8 +52,8 @@ module Syskit
                 end
 
                 # Protect all toplevel Syskit tasks while the resolution runs
-                @syskit_current_resolution = @syskit_async_method.start(
-                    self, requirement_tasks, **resolver_options
+                @syskit_current_resolution = syskit_async_method.start(
+                    self, requirement_tasks, resolver_options: resolver_options
                 )
             end
 

--- a/lib/syskit/runtime/apply_requirement_modifications.rb
+++ b/lib/syskit/runtime/apply_requirement_modifications.rb
@@ -3,6 +3,14 @@
 module Syskit
     module Runtime
         module PlanExtension
+            def initialize(*, **)
+                super
+
+                @syskit_async_method = NetworkGeneration::AsyncThreaded
+            end
+
+            attr_accessor :syskit_async_method
+
             # The currently running resolution
             #
             # @return [NetworkGeneration::Async,nil]
@@ -34,7 +42,7 @@ module Syskit
                 end
 
                 # Protect all toplevel Syskit tasks while the resolution runs
-                @syskit_current_resolution = NetworkGeneration::AsyncThreaded.start(
+                @syskit_current_resolution = @syskit_async_method.start(
                     self, requirement_tasks, **resolver_options
                 )
             end

--- a/lib/syskit/test/instance_requirement_planning_handler.rb
+++ b/lib/syskit/test/instance_requirement_planning_handler.rb
@@ -85,17 +85,20 @@ module Syskit
             end
 
             def finished?
-                Thread.pass
-
                 if @plan.syskit_has_async_resolution?
-                    return unless @plan.syskit_finished_async_resolution?
+                    Thread.pass
 
-                    resolution_results = @plan.syskit_apply_async_resolution_results
+                    async = @plan.syskit_current_resolution
+                    @plan.syskit_poll_async_resolution(nil)
+                    return if @plan.syskit_has_async_resolution?
+
+                    resolution_results = async.result
                     return true if consider_finished_due_to_errors?(resolution_results)
                     return unless @test.syskit_run_planner_stub?
 
                     replace_tasks_for_stub_network(resolution_results)
                 end
+
                 @planning_tasks.all? { |t| t.resolution_success? || t.finished? }
             end
 

--- a/test/actions/test_profile.rb
+++ b/test/actions/test_profile.rb
@@ -581,7 +581,7 @@ module Syskit
                         task_m = TaskContext.new_submodel(name: "Test")
 
                         profile = Profile.new
-                        profile.use_unmanaged_task task_m => "test"
+                        profile.use_unmanaged_task({ task_m => "test" })
                         profile.define "test", task_m
 
                         # NOTE: so far, deployment groups are applied only when

--- a/test/features/all_features.rb
+++ b/test/features/all_features.rb
@@ -4,3 +4,4 @@ Syskit.conf.early_deploy = true
 Syskit.conf.capture_errors_during_network_resolution = true
 Syskit.conf.compositions_use_schedule_as = true
 Syskit.conf.use_rock_time_field_for_logging = true
+Syskit::Runtime.syskit_async_method = Syskit::NetworkGeneration::AsyncFiber

--- a/test/network_generation/test_async.rb
+++ b/test/network_generation/test_async.rb
@@ -5,8 +5,6 @@ require "syskit/test/self"
 module Syskit
     module NetworkGeneration
         describe Async do
-            subject { Async.new(plan) }
-
             def assert_future_fulfilled(future)
                 result = future.value
                 unless future.fulfilled?
@@ -16,115 +14,17 @@ module Syskit
                 result
             end
 
-            describe "#prepare" do
-                it "computes the system network in a separate plan" do
-                    requirements = Set[flexmock]
-                    resolution = subject.prepare(requirements)
-                    flexmock(resolution.engine).should_receive(:resolve_system_network)
-                                               .with(requirements, any)
-                                               .once.and_return(ret = flexmock)
-                    resolution.execute
-                    assert_equal ret, subject.join
-                end
-            end
-
             describe "#valid?" do
                 it "returns true if the current set of requirements match the set stored in the current resolution" do
                     requirements = Set[flexmock]
-                    flexmock(Engine).new_instances.should_receive(:resolve_system_network)
-                    subject.start(requirements)
-                    assert subject.valid?(requirements)
+                    async = Async.new(plan, requirements)
+                    assert async.valid?(requirements)
                 end
 
                 it "returns false if the current set of requirements does not match the set stored in the current resolution" do
                     requirements = Set[flexmock]
-                    flexmock(Engine).new_instances.should_receive(:resolve_system_network)
-                    subject.start(requirements)
-                    assert !subject.valid?(Set.new)
-                end
-            end
-
-            describe "#cancel" do
-                it "discards the transaction once the future finishes" do
-                    latch = Concurrent::IVar.new
-                    flexmock(Engine).new_instances.should_receive(:resolve_system_network)
-                                    .and_return { latch.value }
-                    future = subject.start(Set[flexmock])
-                    work_plan = future.engine.work_plan
-                    flexmock(work_plan).should_receive(:discard_transaction).once
-                                       .pass_thru
-                    subject.cancel
-                    latch.set true
-                    future.value
-                    subject.apply
-
-                    assert work_plan.finalized?
-                end
-            end
-
-            describe "#apply" do
-                it "applies the computed network on the plan" do
-                    requirements = Set[flexmock]
-                    resolution = subject.prepare(requirements)
-                    engine = flexmock(resolution.engine, :strict)
-                    engine.should_receive(:resolve_system_network)
-                          .with(requirements, any).once
-                          .and_return(ret = { requirements => [] })
-
-                    if RUBY_VERSION >= "2.7"
-                        engine.should_receive(:apply_system_network_to_plan).with(ret).once
-                    else
-                        engine.should_receive(:apply_system_network_to_plan).with(ret, {}).once
-                    end
-                    resolution.execute
-                    subject.join
-                    assert subject.finished?
-                    subject.apply
-                end
-
-                it "carries forward options passed to prepare " \
-                   "that are relevant to the apply step" do
-                    requirements = Set[flexmock]
-                    resolution = subject.prepare(
-                        requirements, compute_deployments: false
-                    )
-                    engine = flexmock(resolution.engine, :strict)
-                    engine.should_receive(:resolve_system_network)
-                          .with(requirements, any).once
-                          .and_return(ret = { requirements => [] })
-                    engine.should_receive(:apply_system_network_to_plan)
-                          .with(ret, compute_deployments: false).once
-                    resolution.execute
-                    subject.join
-                    assert subject.finished?
-                    subject.apply
-                end
-
-                it "discards the transcation if applying the plan fails" do
-                    error_t = Class.new(RuntimeError)
-                    requirements = Set[flexmock]
-                    resolution = subject.prepare(requirements)
-                    engine = flexmock(resolution.engine, :strict)
-                    engine.should_receive(:resolve_system_network).and_return(ret = flexmock)
-                    engine.should_receive(:apply_system_network_to_plan).and_raise(error_t)
-                    flexmock(engine.work_plan).should_receive(:discard_transaction).once
-                    resolution.execute
-                    subject.join
-                    assert_raises(error_t) { subject.apply }
-                end
-
-                it "passes any exception raised inside the future and discards the transaction" do
-                    error_t = Class.new(RuntimeError)
-                    requirements = Set[flexmock]
-                    resolution = subject.prepare(requirements)
-                    engine = flexmock(resolution.engine, :strict)
-                    engine.should_receive(:resolve_system_network).and_raise(error_t)
-                    engine.should_receive(:apply_system_network_to_plan).never
-                    flexmock(engine.work_plan).should_receive(:discard_transaction).once.pass_thru
-                    resolution.execute
-                    assert_raises(error_t) { subject.join }
-                    assert subject.finished?
-                    assert_raises(error_t) { subject.apply }
+                    async = Async.new(plan, requirements)
+                    refute async.valid?(Set.new)
                 end
             end
         end

--- a/test/network_generation/test_async_threaded.rb
+++ b/test/network_generation/test_async_threaded.rb
@@ -5,6 +5,10 @@ require "syskit/test/self"
 module Syskit
     module NetworkGeneration
         describe AsyncThreaded do
+            before do
+                plan.syskit_async_method = AsyncThreaded
+            end
+
             describe "#poll" do
                 it "ignores instance requirement tasks added to the plan after the " \
                    "resolution was started and would have succeded without errors" do
@@ -25,7 +29,7 @@ module Syskit
                     execute { other_t_requirement.start! }
 
                     execute do
-                        plan.syskit_current_resolution.apply_complete_network_generation
+                        plan.syskit_current_resolution.finalize
                     end
                     assert requirement_task.resolution_success_event.emitted?
                     # Ensures that other_t was never considered during the resolution as
@@ -51,7 +55,6 @@ module Syskit
                     execute { other_t_requirement.start! }
 
                     expect_execution do
-                        yield if block_given?
                         plan.syskit_join_current_resolution(raise_on_error: false)
                     end.to_have_error_matching(Roby::PlanningFailedError)
 
@@ -60,6 +63,106 @@ module Syskit
                     # it was added after the resolution started
                     refute other_t_requirement.failed_event.emitted?
                 end
+            end
+
+            describe "#cancel" do
+                it "discards the transaction once the future finishes" do
+                    latch = Concurrent::IVar.new
+                    flexmock(Engine)
+                        .new_instances.should_receive(:resolve_system_network)
+                        .and_return { latch.value }
+
+                    async = AsyncThreaded.start(plan, Set[requirement_task_mock])
+                    work_plan = async.engine.work_plan
+                    flexmock(async.engine)
+                        .should_receive(:discard_work_plan).once
+                        .pass_thru
+                    async.cancel
+                    latch.set true
+                    async.poll(nil) until async.finished?
+
+                    assert work_plan.finalized?
+                end
+            end
+
+            describe "#poll" do
+                it "applies the computed network on the plan" do
+                    requirements = Set[requirement_task_mock]
+                    async = AsyncThreaded.start(plan, requirements)
+                    engine = flexmock(async.engine, :strict)
+                    engine.should_receive(:resolve_system_network)
+                          .with(requirements, any).once
+                          .and_return(ret = { requirements => [] })
+
+                    engine.should_receive(:apply_system_network_to_plan)
+                          .with(ret).once
+
+                    async.network_generation_result # waits for the thread
+                    execute { async.poll(nil) }
+                    assert async.finished?
+                end
+
+                it "carries forward options relevant to applying " \
+                   "the network to the existing plan" do
+                    requirements = Set[requirement_task_mock]
+                    async = AsyncThreaded.start(
+                        plan, requirements,
+                        resolver_options: { compute_deployments: false }
+                    )
+                    engine = flexmock(async.engine, :strict)
+                    engine.should_receive(:resolve_system_network)
+                          .with(requirements, any).once
+                          .and_return(ret = { requirements => [] })
+                    engine.should_receive(:apply_system_network_to_plan)
+                          .with(ret, compute_deployments: false).once
+                    async.network_generation_result # waits for the future to finish
+                    execute { async.poll(nil) }
+                    assert async.finished?
+                end
+
+                it "discards the transcation if applying the plan fails" do
+                    error_t = Class.new(RuntimeError)
+                    requirements = Set[requirement_task_mock]
+                    async = AsyncThreaded.start(plan, requirements)
+                    engine = flexmock(async.engine, :strict)
+                    engine.should_receive(:resolve_system_network)
+                          .and_return(flexmock)
+                    engine.should_receive(:apply_system_network_to_plan)
+                          .and_raise(error_t)
+                    flexmock(engine).should_receive(:discard_work_plan).once.pass_thru
+                    async.network_generation_result
+                    execute { async.poll(nil) }
+                end
+
+                it "passes any exception raised inside the future and discards the " \
+                   "transaction" do
+                    error_t = Class.new(RuntimeError)
+                    requirements = Set[requirement_task_mock]
+                    async = AsyncThreaded.start(plan, requirements)
+                    engine = flexmock(async.engine, :strict)
+                    engine.should_receive(:resolve_system_network).and_raise(error_t)
+                    engine.should_receive(:apply_system_network_to_plan).never
+                    flexmock(async.engine)
+                        .should_receive(:discard_work_plan)
+                        .once.pass_thru
+                    async.network_generation_result
+                    execute { async.poll(nil) }
+                    assert async.finished?
+                end
+            end
+
+            def requirement_task_m
+                @requirement_task_m ||= Roby::Task.new_submodel do
+                    terminates
+
+                    event :resolution_success
+                end
+            end
+
+            def requirement_task_mock
+                plan.add(task = requirement_task_m.new)
+                execute { task.start_event.emit }
+                task
             end
         end
     end

--- a/test/network_generation/test_system_network_generator.rb
+++ b/test/network_generation/test_system_network_generator.rb
@@ -225,11 +225,14 @@ module Syskit
                     attr_reader :error_handler, :generator
 
                     before do
+                        @__capture_errors_feature =
+                            Syskit.conf.capture_errors_during_network_resolution?
                         Syskit.conf.capture_errors_during_network_resolution = true
                     end
 
                     after do
-                        Syskit.conf.capture_errors_during_network_resolution = false
+                        Syskit.conf.capture_errors_during_network_resolution =
+                            @__capture_errors_feature
                     end
 
                     it "capture errors regarding device allocation conflicts" do

--- a/test/runtime/test_apply_requirement_modifications.rb
+++ b/test/runtime/test_apply_requirement_modifications.rb
@@ -4,7 +4,7 @@ require "syskit/test/self"
 
 module Syskit
     module Runtime
-        [NetworkGeneration::AsyncThreaded, NetworkGeneration::AsyncFiber].each do |async_method|
+        [NetworkGeneration::AsyncThreaded, NetworkGeneration::AsyncFiber].each do |async_method| # rubocop:disable Metrics/BlockLength
             describe "apply_requirement_modifications(async: #{async_method})" do
                 before do
                     @__async_method = plan.syskit_async_method
@@ -39,8 +39,9 @@ module Syskit
                             refute plan.syskit_has_async_resolution?
                         end
 
-                        it "keeps the plan in a state that allows to detect modifications " \
-                           "to instance requirement tasks that could have happened in-between" do
+                        it "keeps the plan in a state that allows to detect " \
+                           "modifications to instance requirement tasks that could " \
+                           "have happened in-between" do
                             plan.add_permanent_task(
                                 cmp = @cmp_m.to_instance_requirements.as_plan
                             )
@@ -76,8 +77,9 @@ module Syskit
                             refute plan.syskit_has_async_resolution?
                         end
 
-                        it "keeps the plan in a state that allows to detect modifications " \
-                           "to instance requirement tasks that could have happened in-between" do
+                        it "keeps the plan in a state that allows to detect " \
+                           "modifications to instance requirement tasks that could " \
+                           "have happened in-between" do
                             plan.add_permanent_task(
                                 cmp = @cmp_m.to_instance_requirements.as_plan
                             )
@@ -134,9 +136,11 @@ module Syskit
                                      plan.syskit_current_resolution.requirement_tasks
                     end
 
-                    it "stops the current async resolution if all running IR tasks became useless" do
+                    it "stops the current async resolution if all running IR tasks " \
+                       "became useless" do
                         cmp_m = Composition.new_submodel
-                        requirement_task = plan.add_permanent_task(cmp_m.to_instance_requirements.as_plan)
+                        requirement_task =
+                            plan.add_permanent_task(cmp_m.to_instance_requirements)
                         execute { requirement_task.planning_task.start! }
                         execute { Runtime.apply_requirement_modifications(plan) }
 
@@ -154,7 +158,7 @@ module Syskit
                        "stopped in the meantime" do
                         cmp_m = Composition.new_submodel
                         requirement_task =
-                            plan.add_permanent_task(cmp_m.to_instance_requirements.as_plan)
+                            plan.add_permanent_task(cmp_m.to_instance_requirements)
                         execute { requirement_task.planning_task.start! }
                         execute { Runtime.apply_requirement_modifications(plan) }
 
@@ -172,7 +176,8 @@ module Syskit
                         refute plan.syskit_current_resolution
                     end
 
-                    it "restarts an async resolution if one of the IR tasks became useless" do
+                    it "restarts an async resolution if one of the IR tasks " \
+                       "became useless" do
                         cmp_m = Composition.new_submodel
                         requirement_tasks = []
                         requirement_tasks << plan.add_permanent_task(cmp_m)
@@ -206,21 +211,22 @@ module Syskit
                         refute plan.syskit_current_resolution
                     end
 
-                    it "applies the computed network and emits the planning task's resolution " \
-                       "success event" do
+                    it "applies the computed network and emits the planning task's " \
+                       "resolution success event" do
                         cmp_m = Composition.new_submodel
-                        plan.add_permanent_task(requirement_task = cmp_m.to_instance_requirements.as_plan)
+                        requirement_task =
+                            plan.add_permanent_task(cmp_m.to_instance_requirements)
                         requirement_task = requirement_task.planning_task
                         execute { requirement_task.start! }
                         assert_resolution_succeeds
                         assert requirement_task.resolution_success?
                     end
 
-                    it "applies the computed network and emits the planning task's failed " \
-                       "event if it raises" do
+                    it "applies the computed network and emits the planning task's " \
+                       "failed event if it raises" do
                         task_m = TaskContext.new_submodel
                         requirement_task =
-                            plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
+                            plan.add_permanent_task(task_m.to_instance_requirements)
                         requirement_task = requirement_task.planning_task
                         execute { requirement_task.start! }
                         refute_resolution_succeeds
@@ -232,10 +238,11 @@ module Syskit
                         )
                     end
 
-                    it "keeps old running tasks when an exception was raised during planning" do
+                    it "keeps old running tasks when an exception was raised " \
+                       "during planning" do
                         task_m = Composition.new_submodel
                         requirement_task =
-                            plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
+                            plan.add_permanent_task(task_m.to_instance_requirements)
                         requirement_task = requirement_task.planning_task
                         execute { requirement_task.start! }
                         execute { Runtime.apply_requirement_modifications(plan) }
@@ -244,7 +251,7 @@ module Syskit
 
                         other_task_m = TaskContext.new_submodel
                         other_requirement_task =
-                            plan.add_permanent_task(other_task_m.to_instance_requirements.as_plan)
+                            plan.add_permanent_task(other_task_m.to_instance_requirements)
                         other_requirement_task = other_requirement_task.planning_task
                         execute { other_requirement_task.start! }
                         execute { Runtime.apply_requirement_modifications(plan) }
@@ -255,14 +262,14 @@ module Syskit
                         assert other_requirement_task.failed?
                     end
 
-                    it "resolves all requirements that were added to the plan in successive " \
-                       "#apply_requirement_modifications calls" do
+                    it "resolves all requirements that were added to the plan in " \
+                       "successive #apply_requirement_modifications calls" do
                         task_m = Composition.new_submodel
                         task_m2 = Composition.new_submodel
                         task_m3 = Composition.new_submodel
                         reqs = [task_m, task_m2, task_m3].map do |t|
                             requirement_task =
-                                plan.add_permanent_task(t.to_instance_requirements.as_plan)
+                                plan.add_permanent_task(t.to_instance_requirements)
                             requirement_task.planning_task
                         end
                         reqs.each do |req|
@@ -270,19 +277,24 @@ module Syskit
                             execute { Runtime.apply_requirement_modifications(plan) }
                         end
                         execute { Runtime.apply_requirement_modifications(plan) }
-                        assert plan.syskit_has_async_resolution?
 
-                        execute { plan.syskit_join_current_resolution }
+                        loop do
+                            break unless plan.syskit_has_async_resolution?
+
+                            execute { plan.syskit_join_current_resolution }
+                            execute { Runtime.apply_requirement_modifications(plan) }
+                        end
+
                         reqs.each do |req|
                             assert req.resolution_success?
                         end
                     end
 
-                    it "while using force, cancels pending resolutions and executes the last " \
-                       "one" do
+                    it "while using force, cancels pending resolutions and executes " \
+                       "the last one" do
                         task_m = Composition.new_submodel
                         requirement_task =
-                            plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
+                            plan.add_permanent_task(task_m.to_instance_requirements)
                         requirement_task = requirement_task.planning_task
 
                         execute { requirement_task.start! }
@@ -291,34 +303,42 @@ module Syskit
                         assert plan.syskit_has_async_resolution?
                         FlexMock.use(plan.syskit_current_resolution) do |mock|
                             mock.should_receive(:poll).once
-                            execute { Runtime.apply_requirement_modifications(plan, force: true) }
+                            execute do
+                                Runtime.apply_requirement_modifications(plan, force: true)
+                            end
                         end
                         assert plan.syskit_current_resolution.cancelled?
                         join_current_resolution
 
                         # Applies the previously cancelled resolution
-                        execute { Runtime.apply_requirement_modifications(plan, force: true) }
+                        execute do
+                            Runtime.apply_requirement_modifications(plan, force: true)
+                        end
                         # Starts a new resolution
-                        execute { Runtime.apply_requirement_modifications(plan, force: true) }
+                        execute do
+                            Runtime.apply_requirement_modifications(plan, force: true)
+                        end
                         assert plan.syskit_has_async_resolution?
                         refute plan.syskit_current_resolution.cancelled?
                     end
 
-                    it "triggers a new resolution once with force: false when a force was " \
-                       "used while a resolution was pending" do
+                    it "triggers a new resolution once with force: false when " \
+                       "a force was used while a resolution was pending" do
                         task_m = Composition.new_submodel
-                        # `apply_requirement_modifications` never does anything if there are
-                        # no requirements
+                        # `apply_requirement_modifications` never does anything if
+                        # there are no requirements
                         requirement_task =
-                            plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
+                            plan.add_permanent_task(task_m.to_instance_requirements)
                         requirement_task = requirement_task.planning_task
                         execute { requirement_task.start! }
 
-                        # Finish one resolution, we're checking behaviour related to the force
-                        # flag
+                        # Finish one resolution, we're checking behaviour related to
+                        # the force flag
                         assert_resolution_succeeds
 
-                        execute { Runtime.apply_requirement_modifications(plan, force: true) }
+                        execute do
+                            Runtime.apply_requirement_modifications(plan, force: true)
+                        end
                         assert plan.syskit_has_async_resolution?
                         refute plan.syskit_pending_forced_resolution?
 
@@ -327,63 +347,10 @@ module Syskit
                             # Cancels resolution, but does nothing else as
                             # there is a pending unfinished resolution
                             #
-                            # The test is to check that the `force` flag is remembered and will
-                            # be used the next time
-                            execute { Runtime.apply_requirement_modifications(plan, force: true) }
-                        end
-                        assert plan.syskit_pending_forced_resolution?
-                        assert plan.syskit_current_resolution.cancelled?
-
-                        # Finish and apply the current resolution
-                        join_current_resolution
-                        execute { Runtime.apply_requirement_modifications(plan) }
-                        refute plan.syskit_has_async_resolution?
-                        assert plan.syskit_pending_forced_resolution?
-
-                        # Triggers new resolution because of the last 'force'
-                        execute { Runtime.apply_requirement_modifications(plan) }
-                        assert plan.syskit_has_async_resolution?
-                        refute plan.syskit_current_resolution.cancelled?
-                        refute plan.syskit_pending_forced_resolution?
-
-                        # Resolution was not cancelled so we can join and apply it to the plan
-                        join_current_resolution
-                        execute { Runtime.apply_requirement_modifications(plan) }
-                        refute plan.syskit_has_async_resolution?
-
-                        # From now on, all is well, this should not do anything
-                        execute { Runtime.apply_requirement_modifications(plan) }
-                        refute plan.syskit_has_async_resolution?
-                    end
-
-                    it "triggers a new resolution once with force: false when a sequence of " \
-                       "force: true and force: false was used while the resolution was pending" do
-                        task_m = Composition.new_submodel
-                        # `apply_requirement_modifications` never does anything if there are
-                        # no requirements
-                        requirement_task =
-                            plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
-                        requirement_task = requirement_task.planning_task
-                        execute { requirement_task.start! }
-
-                        # Finish one resolution, we're checking behaviour related to the force
-                        # flag
-                        assert_resolution_succeeds
-
-                        execute { Runtime.apply_requirement_modifications(plan, force: true) }
-                        assert plan.syskit_has_async_resolution?
-                        refute plan.syskit_pending_forced_resolution?
-
-                        FlexMock.use(plan.syskit_current_resolution) do |mock|
-                            mock.should_receive(:poll).twice
-                            # Cancels resolution, but does nothing else as
-                            # there is a pending unfinished resolution
-                            #
-                            # The test is to check that the `force` flag is remembered and will
-                            # be used the next time
-                            execute { Runtime.apply_requirement_modifications(plan, force: true) }
+                            # The test is to check that the `force` flag is remembered
+                            # and will be used the next time
                             execute do
-                                Runtime.apply_requirement_modifications(plan, force: false)
+                                Runtime.apply_requirement_modifications(plan, force: true)
                             end
                         end
                         assert plan.syskit_pending_forced_resolution?
@@ -401,7 +368,70 @@ module Syskit
                         refute plan.syskit_current_resolution.cancelled?
                         refute plan.syskit_pending_forced_resolution?
 
-                        # Resolution was not cancelled so we can join and apply it to the plan
+                        # Resolution was not cancelled so we can join and apply it to the
+                        # plan join_current_resolution
+                        execute { plan.syskit_join_current_resolution }
+                        refute plan.syskit_has_async_resolution?
+
+                        # From now on, all is well, this should not do anything
+                        execute { Runtime.apply_requirement_modifications(plan) }
+                        refute plan.syskit_has_async_resolution?
+                    end
+
+                    it "triggers a new resolution once with force: false when a " \
+                       "sequence of force: true and force: false was used while the " \
+                       "resolution was pending" do
+                        task_m = Composition.new_submodel
+                        # `apply_requirement_modifications` never does anything if there
+                        # are no requirements
+                        requirement_task =
+                            plan.add_permanent_task(task_m.to_instance_requirements)
+                        requirement_task = requirement_task.planning_task
+                        execute { requirement_task.start! }
+
+                        # Finish one resolution, we're checking behaviour related to
+                        # the force flag
+                        assert_resolution_succeeds
+
+                        execute do
+                            Runtime.apply_requirement_modifications(plan, force: true)
+                        end
+                        assert plan.syskit_has_async_resolution?
+                        refute plan.syskit_pending_forced_resolution?
+
+                        FlexMock.use(plan.syskit_current_resolution) do |mock|
+                            mock.should_receive(:poll).twice
+                            # Cancels resolution, but does nothing else as
+                            # there is a pending unfinished resolution
+                            #
+                            # The test is to check that the `force` flag is remembered
+                            # and will be used the next time
+                            execute do
+                                Runtime.apply_requirement_modifications(plan, force: true)
+                            end
+                            execute do
+                                Runtime.apply_requirement_modifications(
+                                    plan, force: false
+                                )
+                            end
+                        end
+                        assert plan.syskit_pending_forced_resolution?
+                        assert plan.syskit_current_resolution.cancelled?
+
+                        # Finish and apply the current resolution
+                        join_current_resolution
+                        execute { Runtime.apply_requirement_modifications(plan) }
+                        refute plan.syskit_has_async_resolution?
+                        assert plan.syskit_pending_forced_resolution?
+
+                        # Triggers new resolution because of the last 'force'
+                        execute { Runtime.apply_requirement_modifications(plan) }
+                        assert plan.syskit_has_async_resolution?
+                        refute plan.syskit_current_resolution.cancelled?
+                        refute plan.syskit_pending_forced_resolution?
+
+                        # Resolution was not cancelled so we can join and apply it to the
+                        # plan
                         assert_resolution_succeeds
                         refute plan.syskit_has_async_resolution?
 
@@ -413,10 +443,10 @@ module Syskit
                     it "does not emit anything on instance requirement tasks when " \
                        "the resolution is cancelled" do
                         task_m = Composition.new_submodel
-                        # `apply_requirement_modifications` never does anything if there are
-                        # no requirements
+                        # `apply_requirement_modifications` never does anything if there
+                        # are no requirements
                         requirement_task =
-                            plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
+                            plan.add_permanent_task(task_m.to_instance_requirements)
                         requirement_task = requirement_task.planning_task
                         execute { requirement_task.start! }
 
@@ -443,18 +473,18 @@ module Syskit
                                 @__capture_errors_feature_flag
                         end
 
-                        it "applies the computed network for the well-defined instance tasks " \
-                           "and fails with an error for badly-defined instance tasks" do
+                        it "applies the computed network for the well-defined " \
+                           "instance tasks and fails with an error for badly-defined " \
+                           "instance tasks" do
                             task_m = TaskContext.new_submodel
                             cmp_m = Composition.new_submodel
                             req_task1 =
-                                plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
+                                plan.add_permanent_task(task_m.to_instance_requirements)
                             req_task2 =
-                                plan.add_permanent_task(cmp_m.to_instance_requirements.as_plan)
-                            requirement_tasks = [req_task1, req_task2].map(&:planning_task)
-                            execute do
-                                requirement_tasks.each(&:start!)
-                            end
+                                plan.add_permanent_task(cmp_m.to_instance_requirements)
+                            requirement_tasks =
+                                [req_task1, req_task2].map(&:planning_task)
+                            execute { requirement_tasks.each(&:start!) }
                             refute_resolution_succeeds
 
                             req_task1, req_task2 = requirement_tasks
@@ -512,7 +542,8 @@ module Syskit
                             # This one triggers the cancellation
                             Runtime.apply_requirement_modifications(plan)
 
-                            # This one is necessary if the future has started to be processed
+                            # This one is necessary if the future has started to be
+                            # processed
                             if plan.syskit_has_async_resolution?
                                 assert plan.syskit_current_resolution.cancelled?
                                 plan.syskit_join_current_resolution
@@ -534,12 +565,15 @@ module Syskit
                     end
 
                     def refute_resolution_succeeds(
-                        with_exception: !Syskit.conf.capture_errors_during_network_resolution?
+                        with_exception:
+                            !Syskit.conf.capture_errors_during_network_resolution?
                     )
                         execute { Runtime.apply_requirement_modifications(plan) }
                         expect_execution do
                             yield if block_given?
-                            plan.syskit_join_current_resolution(raise_on_error: !with_exception)
+                            plan.syskit_join_current_resolution(
+                                raise_on_error: !with_exception
+                            )
                         end.to_have_error_matching(Roby::PlanningFailedError)
                     end
                 end

--- a/test/runtime/test_apply_requirement_modifications.rb
+++ b/test/runtime/test_apply_requirement_modifications.rb
@@ -4,531 +4,545 @@ require "syskit/test/self"
 
 module Syskit
     module Runtime
-        describe "#syskit_join_current_resolution" do
-            describe "with a valid resolution running" do
+        [NetworkGeneration::AsyncThreaded, NetworkGeneration::AsyncFiber].each do |async_method|
+            describe "apply_requirement_modifications(async: #{async_method})" do
                 before do
-                    @cmp_m = Composition.new_submodel
-                    plan.add_permanent_task(
-                        cmp = @cmp_m.to_instance_requirements.as_plan
-                    )
-                    @requirement_task = cmp.planning_task
-                    execute { @requirement_task.start! }
-                    execute { Runtime.apply_requirement_modifications(plan) }
-                end
-
-                it "waits for the resolution end and applies the result" do
-                    execute { plan.syskit_join_current_resolution }
-
-                    refute @requirement_task.planned_task.abstract?
-                    assert @requirement_task.resolution_success_event.emitted?
-                end
-
-                it "does not start a new resolution" do
-                    execute { plan.syskit_join_current_resolution }
-                    refute plan.syskit_has_async_resolution?
-                end
-
-                it "keeps the plan in a state that allows to detect modifications " \
-                   "to instance requirement tasks that could have happened in-between" do
-                    plan.add_permanent_task(
-                        cmp = @cmp_m.to_instance_requirements.as_plan
-                    )
-                    execute { cmp.planning_task.start! }
-                    execute { plan.syskit_join_current_resolution }
-                    refute plan.syskit_has_async_resolution?
-                    execute { Runtime.apply_requirement_modifications(plan) }
-                    assert plan.syskit_has_async_resolution?
-                end
-            end
-
-            describe "with a cancelled resolution running" do
-                before do
-                    @cmp_m = Composition.new_submodel
-                    plan.add_permanent_task(
-                        cmp = @cmp_m.to_instance_requirements.as_plan
-                    )
-                    @requirement_task = cmp.planning_task
-                    execute { @requirement_task.start! }
-                    execute { Runtime.apply_requirement_modifications(plan) }
-                    execute { plan.syskit_cancel_async_resolution }
-                end
-
-                it "waits for the resolution end but does not apply the result" do
-                    execute { plan.syskit_join_current_resolution }
-
-                    assert @requirement_task.planned_task.abstract?
-                    refute @requirement_task.resolution_success_event.emitted?
-                end
-
-                it "does not start a new resolution" do
-                    execute { plan.syskit_join_current_resolution }
-                    refute plan.syskit_has_async_resolution?
-                end
-
-                it "keeps the plan in a state that allows to detect modifications " \
-                   "to instance requirement tasks that could have happened in-between" do
-                    plan.add_permanent_task(
-                        cmp = @cmp_m.to_instance_requirements.as_plan
-                    )
-                    execute { cmp.planning_task.start! }
-                    execute { plan.syskit_join_current_resolution }
-                    refute plan.syskit_has_async_resolution?
-                    execute { Runtime.apply_requirement_modifications(plan) }
-                    assert plan.syskit_has_async_resolution?
-                end
-            end
-        end
-
-        describe ".apply_requirement_modifications" do
-            before do
-                @__capture_errors_feature_flag =
-                    Syskit.conf.capture_errors_during_network_resolution?
-                Syskit.conf.capture_errors_during_network_resolution = false
-            end
-
-            after do
-                Syskit.conf.capture_errors_during_network_resolution =
-                    @__capture_errors_feature_flag
-            end
-
-            it "does nothing by default" do
-                Runtime.apply_requirement_modifications(plan)
-                refute plan.syskit_current_resolution
-            end
-
-            it "starts an async resolution when new IR tasks are started" do
-                cmp_m = Composition.new_submodel
-                requirement_task = plan.add_permanent_task(cmp_m)
-                execute { requirement_task.planning_task.start! }
-                execute { Runtime.apply_requirement_modifications(plan) }
-                assert plan.syskit_current_resolution
-                assert_equal Set[requirement_task.planning_task],
-                             plan.syskit_current_resolution.requirement_tasks
-            end
-
-            it "restarts the current async resolution if a new IR task appears" do
-                cmp_m = Composition.new_submodel
-                requirement_tasks = []
-                requirement_tasks << plan.add_permanent_task(cmp_m)
-                execute { requirement_tasks[0].planning_task.start! }
-                execute { Runtime.apply_requirement_modifications(plan) }
-
-                requirement_tasks << plan.add_permanent_task(cmp_m)
-                assert_resolution_cancelled do
-                    execute { requirement_tasks[1].planning_task.start! }
-                end
-
-                assert plan.syskit_current_resolution
-                assert_equal Set[*requirement_tasks.map(&:planning_task)],
-                             plan.syskit_current_resolution.requirement_tasks
-            end
-
-            it "stops the current async resolution if all running IR tasks became useless" do
-                cmp_m = Composition.new_submodel
-                requirement_task = plan.add_permanent_task(cmp_m.to_instance_requirements.as_plan)
-                execute { requirement_task.planning_task.start! }
-                execute { Runtime.apply_requirement_modifications(plan) }
-
-                assert_resolution_cancelled do
-                    expect_execution do
-                        plan.unmark_permanent_task(requirement_task)
-                        requirement_task.planning_task.stop!
-                    end.to_have_error_matching(Roby::PlanningFailedError)
-                end
-
-                refute plan.syskit_current_resolution
-            end
-
-            it "ignores resolution errors if all requirements have been " \
-               "stopped in the meantime" do
-                cmp_m = Composition.new_submodel
-                requirement_task =
-                    plan.add_permanent_task(cmp_m.to_instance_requirements.as_plan)
-                execute { requirement_task.planning_task.start! }
-                execute { Runtime.apply_requirement_modifications(plan) }
-
-                error_m = Class.new(RuntimeError)
-                flexmock(plan.syskit_current_resolution)
-                    .should_receive(:apply_network_generation).and_raise(error_m)
-
-                assert_resolution_cancelled do
-                    expect_execution do
-                        plan.unmark_permanent_task(requirement_task)
-                        requirement_task.planning_task.stop!
-                    end.to_have_error_matching(Roby::PlanningFailedError)
-                end
-
-                refute plan.syskit_current_resolution
-            end
-
-            it "restarts an async resolution if one of the IR tasks became useless" do
-                cmp_m = Composition.new_submodel
-                requirement_tasks = []
-                requirement_tasks << plan.add_permanent_task(cmp_m)
-                requirement_tasks << plan.add_permanent_task(cmp_m)
-                execute do
-                    requirement_tasks.each { |t| t.planning_task.start! }
-                end
-                Runtime.apply_requirement_modifications(plan)
-
-                assert_resolution_cancelled do
-                    execute { plan.unmark_permanent_task(requirement_tasks[1]) }
-                end
-
-                assert plan.syskit_current_resolution
-                assert_equal Set[requirement_tasks[0].planning_task],
-                             plan.syskit_current_resolution.requirement_tasks
-            end
-
-            it "cancels an async resolution if one of the IR tasks " \
-               "has been interrupted" do
-                cmp_m = Composition.new_submodel
-                requirement_task = plan.add_permanent_task(cmp_m)
-                execute { requirement_task.planning_task.start! }
-                execute { Runtime.apply_requirement_modifications(plan) }
-
-                assert_resolution_cancelled do
-                    expect_execution { requirement_task.planning_task.stop! }
-                        .to { have_error_matching Roby::PlanningFailedError }
-                end
-
-                refute plan.syskit_current_resolution
-            end
-
-            it "applies the computed network and emits the planning task's resolution " \
-               "success event" do
-                cmp_m = Composition.new_submodel
-                plan.add_permanent_task(requirement_task = cmp_m.to_instance_requirements.as_plan)
-                requirement_task = requirement_task.planning_task
-                execute { requirement_task.start! }
-                assert_resolution_succeeds
-                assert requirement_task.resolution_success?
-            end
-
-            it "applies the computed network and emits the planning task's failed " \
-               "event if it raises" do
-                task_m = TaskContext.new_submodel
-                requirement_task =
-                    plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
-                requirement_task = requirement_task.planning_task
-                execute { requirement_task.start! }
-                refute_resolution_succeeds
-                assert requirement_task.failed?
-                exception = requirement_task.failed_event.last.context.first
-                assert_kind_of Syskit::MissingDeployment, exception
-                assert_exception_can_be_pretty_printed(
-                    requirement_task.failed_event.last.context.first
-                )
-            end
-
-            it "keeps old running tasks when an exception was raised during planning" do
-                task_m = Composition.new_submodel
-                requirement_task =
-                    plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
-                requirement_task = requirement_task.planning_task
-                execute { requirement_task.start! }
-                execute { Runtime.apply_requirement_modifications(plan) }
-                execute { plan.syskit_join_current_resolution }
-                assert requirement_task.resolution_success?
-
-                other_task_m = TaskContext.new_submodel
-                other_requirement_task =
-                    plan.add_permanent_task(other_task_m.to_instance_requirements.as_plan)
-                other_requirement_task = other_requirement_task.planning_task
-                execute { other_requirement_task.start! }
-                execute { Runtime.apply_requirement_modifications(plan) }
-                expect_execution do
-                    plan.syskit_join_current_resolution(raise_on_error: false)
-                end.to { have_error_matching Roby::PlanningFailedError }
-                refute requirement_task.failed?
-                assert other_requirement_task.failed?
-            end
-
-            it "resolves all requirements that were added to the plan in successive " \
-               "#apply_requirement_modifications calls" do
-                task_m = Composition.new_submodel
-                task_m2 = Composition.new_submodel
-                task_m3 = Composition.new_submodel
-                reqs = [task_m, task_m2, task_m3].map do |t|
-                    requirement_task =
-                        plan.add_permanent_task(t.to_instance_requirements.as_plan)
-                    requirement_task.planning_task
-                end
-                reqs.each do |req|
-                    execute { req.start! }
-                    execute { Runtime.apply_requirement_modifications(plan) }
-                end
-                assert plan.syskit_has_async_resolution?
-
-                execute { plan.syskit_join_current_resolution }
-                reqs.each do |req|
-                    assert req.resolution_success?
-                end
-            end
-
-            it "while using force, cancels pending resolutions and executes the last " \
-               "one" do
-                task_m = Composition.new_submodel
-                requirement_task =
-                    plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
-                requirement_task = requirement_task.planning_task
-
-                execute { requirement_task.start! }
-                execute { Runtime.apply_requirement_modifications(plan) }
-
-                assert plan.syskit_has_async_resolution?
-                FlexMock.use(plan.syskit_current_resolution) do |mock|
-                    mock.should_receive(:poll).once
-                    execute { Runtime.apply_requirement_modifications(plan, force: true) }
-                end
-                assert plan.syskit_current_resolution.cancelled?
-                join_current_resolution
-
-                # Applies the previously cancelled resolution
-                execute { Runtime.apply_requirement_modifications(plan, force: true) }
-                # Starts a new resolution
-                execute { Runtime.apply_requirement_modifications(plan, force: true) }
-                assert plan.syskit_has_async_resolution?
-                refute plan.syskit_current_resolution.cancelled?
-            end
-
-            it "triggers a new resolution once with force: false when a force was " \
-               "used while a resolution was pending" do
-                task_m = Composition.new_submodel
-                # `apply_requirement_modifications` never does anything if there are
-                # no requirements
-                requirement_task =
-                    plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
-                requirement_task = requirement_task.planning_task
-                execute { requirement_task.start! }
-
-                # Finish one resolution, we're checking behaviour related to the force
-                # flag
-                assert_resolution_succeeds
-
-                execute { Runtime.apply_requirement_modifications(plan, force: true) }
-                assert plan.syskit_has_async_resolution?
-                refute plan.syskit_pending_forced_resolution?
-
-                FlexMock.use(plan.syskit_current_resolution) do |mock|
-                    mock.should_receive(:poll).once
-                    # Cancels resolution, but does nothing else as
-                    # there is a pending unfinished resolution
-                    #
-                    # The test is to check that the `force` flag is remembered and will
-                    # be used the next time
-                    execute { Runtime.apply_requirement_modifications(plan, force: true) }
-                end
-                assert plan.syskit_pending_forced_resolution?
-                assert plan.syskit_current_resolution.cancelled?
-
-                # Finish and apply the current resolution
-                join_current_resolution
-                execute { Runtime.apply_requirement_modifications(plan) }
-                refute plan.syskit_has_async_resolution?
-                assert plan.syskit_pending_forced_resolution?
-
-                # Triggers new resolution because of the last 'force'
-                execute { Runtime.apply_requirement_modifications(plan) }
-                assert plan.syskit_has_async_resolution?
-                refute plan.syskit_current_resolution.cancelled?
-                refute plan.syskit_pending_forced_resolution?
-
-                # Resolution was not cancelled so we can join and apply it to the plan
-                join_current_resolution
-                execute { Runtime.apply_requirement_modifications(plan) }
-                refute plan.syskit_has_async_resolution?
-
-                # From now on, all is well, this should not do anything
-                execute { Runtime.apply_requirement_modifications(plan) }
-                refute plan.syskit_has_async_resolution?
-            end
-
-            it "triggers a new resolution once with force: false when a sequence of " \
-               "force: true and force: false was used while the resolution was pending" do
-                task_m = Composition.new_submodel
-                # `apply_requirement_modifications` never does anything if there are
-                # no requirements
-                requirement_task =
-                    plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
-                requirement_task = requirement_task.planning_task
-                execute { requirement_task.start! }
-
-                # Finish one resolution, we're checking behaviour related to the force
-                # flag
-                assert_resolution_succeeds
-
-                execute { Runtime.apply_requirement_modifications(plan, force: true) }
-                assert plan.syskit_has_async_resolution?
-                refute plan.syskit_pending_forced_resolution?
-
-                FlexMock.use(plan.syskit_current_resolution) do |mock|
-                    mock.should_receive(:poll).twice
-                    # Cancels resolution, but does nothing else as
-                    # there is a pending unfinished resolution
-                    #
-                    # The test is to check that the `force` flag is remembered and will
-                    # be used the next time
-                    execute { Runtime.apply_requirement_modifications(plan, force: true) }
-                    execute do
-                        Runtime.apply_requirement_modifications(plan, force: false)
-                    end
-                end
-                assert plan.syskit_pending_forced_resolution?
-                assert plan.syskit_current_resolution.cancelled?
-
-                # Finish and apply the current resolution
-                join_current_resolution
-                execute { Runtime.apply_requirement_modifications(plan) }
-                refute plan.syskit_has_async_resolution?
-                assert plan.syskit_pending_forced_resolution?
-
-                # Triggers new resolution because of the last 'force'
-                execute { Runtime.apply_requirement_modifications(plan) }
-                assert plan.syskit_has_async_resolution?
-                refute plan.syskit_current_resolution.cancelled?
-                refute plan.syskit_pending_forced_resolution?
-
-                # Resolution was not cancelled so we can join and apply it to the plan
-                assert_resolution_succeeds
-                refute plan.syskit_has_async_resolution?
-
-                # From now on, all is well, this should not do anything
-                execute { Runtime.apply_requirement_modifications(plan) }
-                refute plan.syskit_has_async_resolution?
-            end
-
-            it "does not emit anything on instance requirement tasks when " \
-               "the resolution is cancelled" do
-                task_m = Composition.new_submodel
-                # `apply_requirement_modifications` never does anything if there are
-                # no requirements
-                requirement_task =
-                    plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
-                requirement_task = requirement_task.planning_task
-                execute { requirement_task.start! }
-
-                # Starts a new resolution
-                execute { Runtime.apply_requirement_modifications(plan) }
-                # Now cancel it
-                plan.syskit_cancel_async_resolution
-
-                assert plan.syskit_current_resolution.cancelled?
-                join_current_resolution
-                expect_execution { Runtime.apply_requirement_modifications(plan) }
-                    .to_not_emit { requirement_task.resolution_success_event }
-            end
-
-            describe "capture_errors" do
-                before do
-                    @__capture_errors_feature_flag =
-                        Syskit.conf.capture_errors_during_network_resolution?
-                    Syskit.conf.capture_errors_during_network_resolution = true
+                    @__async_method = plan.syskit_async_method
+                    plan.syskit_async_method = async_method
                 end
 
                 after do
-                    Syskit.conf.capture_errors_during_network_resolution =
-                        @__capture_errors_feature_flag
+                    plan.syskit_async_method = @__async_method
                 end
 
-                it "applies the computed network for the well-defined instance tasks " \
-                   "and fails with an error for badly-defined instance tasks" do
-                    task_m = TaskContext.new_submodel
-                    cmp_m = Composition.new_submodel
-                    req_task1 =
-                        plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
-                    req_task2 =
-                        plan.add_permanent_task(cmp_m.to_instance_requirements.as_plan)
-                    requirement_tasks = [req_task1, req_task2].map(&:planning_task)
-                    execute do
-                        requirement_tasks.each(&:start!)
-                    end
-                    refute_resolution_succeeds
+                describe "#syskit_join_current_resolution" do
+                    describe "with a valid resolution running" do
+                        before do
+                            @cmp_m = Composition.new_submodel
+                            plan.add_permanent_task(
+                                cmp = @cmp_m.to_instance_requirements.as_plan
+                            )
+                            @requirement_task = cmp.planning_task
+                            execute { @requirement_task.start! }
+                            execute { Runtime.apply_requirement_modifications(plan) }
+                        end
 
-                    req_task1, req_task2 = requirement_tasks
+                        it "waits for the resolution end and applies the result" do
+                            execute { plan.syskit_join_current_resolution }
 
-                    assert req_task2.resolution_success?
+                            refute @requirement_task.planned_task.abstract?
+                            assert @requirement_task.resolution_success_event.emitted?
+                        end
 
-                    assert req_task1.failed?
-                    exceptions = req_task1.failed_event.last.context
-                    assert_equal 1, exceptions.size
-                    assert_kind_of Syskit::MissingDeployment, exceptions.first
-                    assert_exception_can_be_pretty_printed(exceptions.first)
-                end
+                        it "does not start a new resolution" do
+                            execute { plan.syskit_join_current_resolution }
+                            refute plan.syskit_has_async_resolution?
+                        end
 
-                it "applies the computed network and emits the planning task's " \
-                   "resolution success event" do
-                    cmp_m = Composition.new_submodel
-                    requirement_task = cmp_m.to_instance_requirements.as_plan
-                    plan.add_permanent_task(requirement_task)
-                    requirement_task = requirement_task.planning_task
-                    execute { requirement_task.start! }
-                    assert_resolution_succeeds
-                    assert requirement_task.resolution_success?
-                end
-
-                it "clears leftover failed tasks from the plan" do
-                    srv_m = Syskit::DataService.new_submodel
-                    task_m = Syskit::TaskContext.new_submodel
-                    task_m.provides srv_m, as: "srv"
-                    cmp_m = Composition.new_submodel do
-                        add srv_m, as: "test"
+                        it "keeps the plan in a state that allows to detect modifications " \
+                           "to instance requirement tasks that could have happened in-between" do
+                            plan.add_permanent_task(
+                                cmp = @cmp_m.to_instance_requirements.as_plan
+                            )
+                            execute { cmp.planning_task.start! }
+                            execute { plan.syskit_join_current_resolution }
+                            refute plan.syskit_has_async_resolution?
+                            execute { Runtime.apply_requirement_modifications(plan) }
+                            assert plan.syskit_has_async_resolution?
+                        end
                     end
 
-                    t1 = cmp_m.as_plan
-                    requirement_task = t1.as_plan
-                    plan.add_permanent_task(requirement_task)
-                    requirement_task = requirement_task.planning_task
-                    execute { requirement_task.start! }
-                    execute { Runtime.apply_requirement_modifications(plan) }
-                    expect_execution do
-                        plan.syskit_join_current_resolution
-                    end.to_have_error_matching(Roby::PlanningFailedError)
-                    assert requirement_task.failed?
-                    refute plan.find_tasks(srv_m).first
+                    describe "with a cancelled resolution running" do
+                        before do
+                            @cmp_m = Composition.new_submodel
+                            plan.add_permanent_task(
+                                cmp = @cmp_m.to_instance_requirements.as_plan
+                            )
+                            @requirement_task = cmp.planning_task
+                            execute { @requirement_task.start! }
+                            execute { Runtime.apply_requirement_modifications(plan) }
+                            execute { plan.syskit_cancel_async_resolution }
+                        end
+
+                        it "waits for the resolution end but does not apply the result" do
+                            execute { plan.syskit_join_current_resolution }
+
+                            assert @requirement_task.planned_task.abstract?
+                            refute @requirement_task.resolution_success_event.emitted?
+                        end
+
+                        it "does not start a new resolution" do
+                            execute { plan.syskit_join_current_resolution }
+                            refute plan.syskit_has_async_resolution?
+                        end
+
+                        it "keeps the plan in a state that allows to detect modifications " \
+                           "to instance requirement tasks that could have happened in-between" do
+                            plan.add_permanent_task(
+                                cmp = @cmp_m.to_instance_requirements.as_plan
+                            )
+                            execute { cmp.planning_task.start! }
+                            execute { plan.syskit_join_current_resolution }
+                            refute plan.syskit_has_async_resolution?
+                            execute { Runtime.apply_requirement_modifications(plan) }
+                            assert plan.syskit_has_async_resolution?
+                        end
+                    end
                 end
-            end
 
-            def assert_resolution_cancelled # rubocop:disable Metrics/AbcSize
-                flexmock(plan.syskit_current_resolution)
-                    .should_receive(:cancel).at_least.once
-                    .pass_thru
+                describe ".apply_requirement_modifications" do
+                    before do
+                        @__capture_errors_feature_flag =
+                            Syskit.conf.capture_errors_during_network_resolution?
+                        Syskit.conf.capture_errors_during_network_resolution = false
+                    end
 
-                yield
+                    after do
+                        Syskit.conf.capture_errors_during_network_resolution =
+                            @__capture_errors_feature_flag
+                    end
 
-                execute do
-                    # This one triggers the cancellation
-                    Runtime.apply_requirement_modifications(plan)
+                    it "does nothing by default" do
+                        Runtime.apply_requirement_modifications(plan)
+                        refute plan.syskit_current_resolution
+                    end
 
-                    # This one is necessary if the future has started to be processed
-                    if plan.syskit_has_async_resolution?
+                    it "starts an async resolution when new IR tasks are started" do
+                        cmp_m = Composition.new_submodel
+                        requirement_task = plan.add_permanent_task(cmp_m)
+                        execute { requirement_task.planning_task.start! }
+                        execute { Runtime.apply_requirement_modifications(plan) }
+                        assert plan.syskit_current_resolution
+                        assert_equal Set[requirement_task.planning_task],
+                                     plan.syskit_current_resolution.requirement_tasks
+                    end
+
+                    it "restarts the current async resolution if a new IR task appears" do
+                        cmp_m = Composition.new_submodel
+                        requirement_tasks = []
+                        requirement_tasks << plan.add_permanent_task(cmp_m)
+                        execute { requirement_tasks[0].planning_task.start! }
+                        execute { Runtime.apply_requirement_modifications(plan) }
+
+                        requirement_tasks << plan.add_permanent_task(cmp_m)
+                        assert_resolution_cancelled do
+                            execute { requirement_tasks[1].planning_task.start! }
+                        end
+
+                        assert plan.syskit_current_resolution
+                        assert_equal Set[*requirement_tasks.map(&:planning_task)],
+                                     plan.syskit_current_resolution.requirement_tasks
+                    end
+
+                    it "stops the current async resolution if all running IR tasks became useless" do
+                        cmp_m = Composition.new_submodel
+                        requirement_task = plan.add_permanent_task(cmp_m.to_instance_requirements.as_plan)
+                        execute { requirement_task.planning_task.start! }
+                        execute { Runtime.apply_requirement_modifications(plan) }
+
+                        assert_resolution_cancelled do
+                            expect_execution do
+                                plan.unmark_permanent_task(requirement_task)
+                                requirement_task.planning_task.stop!
+                            end.to_have_error_matching(Roby::PlanningFailedError)
+                        end
+
+                        refute plan.syskit_current_resolution
+                    end
+
+                    it "ignores resolution errors if all requirements have been " \
+                       "stopped in the meantime" do
+                        cmp_m = Composition.new_submodel
+                        requirement_task =
+                            plan.add_permanent_task(cmp_m.to_instance_requirements.as_plan)
+                        execute { requirement_task.planning_task.start! }
+                        execute { Runtime.apply_requirement_modifications(plan) }
+
+                        error_m = Class.new(RuntimeError)
+                        flexmock(plan.syskit_current_resolution)
+                            .should_receive(:apply_network_generation).and_raise(error_m)
+
+                        assert_resolution_cancelled do
+                            expect_execution do
+                                plan.unmark_permanent_task(requirement_task)
+                                requirement_task.planning_task.stop!
+                            end.to_have_error_matching(Roby::PlanningFailedError)
+                        end
+
+                        refute plan.syskit_current_resolution
+                    end
+
+                    it "restarts an async resolution if one of the IR tasks became useless" do
+                        cmp_m = Composition.new_submodel
+                        requirement_tasks = []
+                        requirement_tasks << plan.add_permanent_task(cmp_m)
+                        requirement_tasks << plan.add_permanent_task(cmp_m)
+                        execute do
+                            requirement_tasks.each { |t| t.planning_task.start! }
+                        end
+                        Runtime.apply_requirement_modifications(plan)
+
+                        assert_resolution_cancelled do
+                            execute { plan.unmark_permanent_task(requirement_tasks[1]) }
+                        end
+
+                        assert plan.syskit_current_resolution
+                        assert_equal Set[requirement_tasks[0].planning_task],
+                                     plan.syskit_current_resolution.requirement_tasks
+                    end
+
+                    it "cancels an async resolution if one of the IR tasks " \
+                       "has been interrupted" do
+                        cmp_m = Composition.new_submodel
+                        requirement_task = plan.add_permanent_task(cmp_m)
+                        execute { requirement_task.planning_task.start! }
+                        execute { Runtime.apply_requirement_modifications(plan) }
+
+                        assert_resolution_cancelled do
+                            expect_execution { requirement_task.planning_task.stop! }
+                                .to { have_error_matching Roby::PlanningFailedError }
+                        end
+
+                        refute plan.syskit_current_resolution
+                    end
+
+                    it "applies the computed network and emits the planning task's resolution " \
+                       "success event" do
+                        cmp_m = Composition.new_submodel
+                        plan.add_permanent_task(requirement_task = cmp_m.to_instance_requirements.as_plan)
+                        requirement_task = requirement_task.planning_task
+                        execute { requirement_task.start! }
+                        assert_resolution_succeeds
+                        assert requirement_task.resolution_success?
+                    end
+
+                    it "applies the computed network and emits the planning task's failed " \
+                       "event if it raises" do
+                        task_m = TaskContext.new_submodel
+                        requirement_task =
+                            plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
+                        requirement_task = requirement_task.planning_task
+                        execute { requirement_task.start! }
+                        refute_resolution_succeeds
+                        assert requirement_task.failed?
+                        exception = requirement_task.failed_event.last.context.first
+                        assert_kind_of Syskit::MissingDeployment, exception
+                        assert_exception_can_be_pretty_printed(
+                            requirement_task.failed_event.last.context.first
+                        )
+                    end
+
+                    it "keeps old running tasks when an exception was raised during planning" do
+                        task_m = Composition.new_submodel
+                        requirement_task =
+                            plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
+                        requirement_task = requirement_task.planning_task
+                        execute { requirement_task.start! }
+                        execute { Runtime.apply_requirement_modifications(plan) }
+                        execute { plan.syskit_join_current_resolution }
+                        assert requirement_task.resolution_success?
+
+                        other_task_m = TaskContext.new_submodel
+                        other_requirement_task =
+                            plan.add_permanent_task(other_task_m.to_instance_requirements.as_plan)
+                        other_requirement_task = other_requirement_task.planning_task
+                        execute { other_requirement_task.start! }
+                        execute { Runtime.apply_requirement_modifications(plan) }
+                        expect_execution do
+                            plan.syskit_join_current_resolution(raise_on_error: false)
+                        end.to { have_error_matching Roby::PlanningFailedError }
+                        refute requirement_task.failed?
+                        assert other_requirement_task.failed?
+                    end
+
+                    it "resolves all requirements that were added to the plan in successive " \
+                       "#apply_requirement_modifications calls" do
+                        task_m = Composition.new_submodel
+                        task_m2 = Composition.new_submodel
+                        task_m3 = Composition.new_submodel
+                        reqs = [task_m, task_m2, task_m3].map do |t|
+                            requirement_task =
+                                plan.add_permanent_task(t.to_instance_requirements.as_plan)
+                            requirement_task.planning_task
+                        end
+                        reqs.each do |req|
+                            execute { req.start! }
+                            execute { Runtime.apply_requirement_modifications(plan) }
+                        end
+                        execute { Runtime.apply_requirement_modifications(plan) }
+                        assert plan.syskit_has_async_resolution?
+
+                        execute { plan.syskit_join_current_resolution }
+                        reqs.each do |req|
+                            assert req.resolution_success?
+                        end
+                    end
+
+                    it "while using force, cancels pending resolutions and executes the last " \
+                       "one" do
+                        task_m = Composition.new_submodel
+                        requirement_task =
+                            plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
+                        requirement_task = requirement_task.planning_task
+
+                        execute { requirement_task.start! }
+                        execute { Runtime.apply_requirement_modifications(plan) }
+
+                        assert plan.syskit_has_async_resolution?
+                        FlexMock.use(plan.syskit_current_resolution) do |mock|
+                            mock.should_receive(:poll).once
+                            execute { Runtime.apply_requirement_modifications(plan, force: true) }
+                        end
                         assert plan.syskit_current_resolution.cancelled?
-                        plan.syskit_join_current_resolution
+                        join_current_resolution
+
+                        # Applies the previously cancelled resolution
+                        execute { Runtime.apply_requirement_modifications(plan, force: true) }
+                        # Starts a new resolution
+                        execute { Runtime.apply_requirement_modifications(plan, force: true) }
+                        assert plan.syskit_has_async_resolution?
+                        refute plan.syskit_current_resolution.cancelled?
                     end
 
-                    refute plan.syskit_current_resolution
-                    Runtime.apply_requirement_modifications(plan)
+                    it "triggers a new resolution once with force: false when a force was " \
+                       "used while a resolution was pending" do
+                        task_m = Composition.new_submodel
+                        # `apply_requirement_modifications` never does anything if there are
+                        # no requirements
+                        requirement_task =
+                            plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
+                        requirement_task = requirement_task.planning_task
+                        execute { requirement_task.start! }
+
+                        # Finish one resolution, we're checking behaviour related to the force
+                        # flag
+                        assert_resolution_succeeds
+
+                        execute { Runtime.apply_requirement_modifications(plan, force: true) }
+                        assert plan.syskit_has_async_resolution?
+                        refute plan.syskit_pending_forced_resolution?
+
+                        FlexMock.use(plan.syskit_current_resolution) do |mock|
+                            mock.should_receive(:poll).once
+                            # Cancels resolution, but does nothing else as
+                            # there is a pending unfinished resolution
+                            #
+                            # The test is to check that the `force` flag is remembered and will
+                            # be used the next time
+                            execute { Runtime.apply_requirement_modifications(plan, force: true) }
+                        end
+                        assert plan.syskit_pending_forced_resolution?
+                        assert plan.syskit_current_resolution.cancelled?
+
+                        # Finish and apply the current resolution
+                        join_current_resolution
+                        execute { Runtime.apply_requirement_modifications(plan) }
+                        refute plan.syskit_has_async_resolution?
+                        assert plan.syskit_pending_forced_resolution?
+
+                        # Triggers new resolution because of the last 'force'
+                        execute { Runtime.apply_requirement_modifications(plan) }
+                        assert plan.syskit_has_async_resolution?
+                        refute plan.syskit_current_resolution.cancelled?
+                        refute plan.syskit_pending_forced_resolution?
+
+                        # Resolution was not cancelled so we can join and apply it to the plan
+                        join_current_resolution
+                        execute { Runtime.apply_requirement_modifications(plan) }
+                        refute plan.syskit_has_async_resolution?
+
+                        # From now on, all is well, this should not do anything
+                        execute { Runtime.apply_requirement_modifications(plan) }
+                        refute plan.syskit_has_async_resolution?
+                    end
+
+                    it "triggers a new resolution once with force: false when a sequence of " \
+                       "force: true and force: false was used while the resolution was pending" do
+                        task_m = Composition.new_submodel
+                        # `apply_requirement_modifications` never does anything if there are
+                        # no requirements
+                        requirement_task =
+                            plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
+                        requirement_task = requirement_task.planning_task
+                        execute { requirement_task.start! }
+
+                        # Finish one resolution, we're checking behaviour related to the force
+                        # flag
+                        assert_resolution_succeeds
+
+                        execute { Runtime.apply_requirement_modifications(plan, force: true) }
+                        assert plan.syskit_has_async_resolution?
+                        refute plan.syskit_pending_forced_resolution?
+
+                        FlexMock.use(plan.syskit_current_resolution) do |mock|
+                            mock.should_receive(:poll).twice
+                            # Cancels resolution, but does nothing else as
+                            # there is a pending unfinished resolution
+                            #
+                            # The test is to check that the `force` flag is remembered and will
+                            # be used the next time
+                            execute { Runtime.apply_requirement_modifications(plan, force: true) }
+                            execute do
+                                Runtime.apply_requirement_modifications(plan, force: false)
+                            end
+                        end
+                        assert plan.syskit_pending_forced_resolution?
+                        assert plan.syskit_current_resolution.cancelled?
+
+                        # Finish and apply the current resolution
+                        join_current_resolution
+                        execute { Runtime.apply_requirement_modifications(plan) }
+                        refute plan.syskit_has_async_resolution?
+                        assert plan.syskit_pending_forced_resolution?
+
+                        # Triggers new resolution because of the last 'force'
+                        execute { Runtime.apply_requirement_modifications(plan) }
+                        assert plan.syskit_has_async_resolution?
+                        refute plan.syskit_current_resolution.cancelled?
+                        refute plan.syskit_pending_forced_resolution?
+
+                        # Resolution was not cancelled so we can join and apply it to the plan
+                        assert_resolution_succeeds
+                        refute plan.syskit_has_async_resolution?
+
+                        # From now on, all is well, this should not do anything
+                        execute { Runtime.apply_requirement_modifications(plan) }
+                        refute plan.syskit_has_async_resolution?
+                    end
+
+                    it "does not emit anything on instance requirement tasks when " \
+                       "the resolution is cancelled" do
+                        task_m = Composition.new_submodel
+                        # `apply_requirement_modifications` never does anything if there are
+                        # no requirements
+                        requirement_task =
+                            plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
+                        requirement_task = requirement_task.planning_task
+                        execute { requirement_task.start! }
+
+                        # Starts a new resolution
+                        execute { Runtime.apply_requirement_modifications(plan) }
+                        # Now cancel it
+                        plan.syskit_cancel_async_resolution
+
+                        assert plan.syskit_current_resolution.cancelled?
+                        join_current_resolution
+                        expect_execution { Runtime.apply_requirement_modifications(plan) }
+                            .to_not_emit { requirement_task.resolution_success_event }
+                    end
+
+                    describe "capture_errors" do
+                        before do
+                            @__capture_errors_feature_flag =
+                                Syskit.conf.capture_errors_during_network_resolution?
+                            Syskit.conf.capture_errors_during_network_resolution = true
+                        end
+
+                        after do
+                            Syskit.conf.capture_errors_during_network_resolution =
+                                @__capture_errors_feature_flag
+                        end
+
+                        it "applies the computed network for the well-defined instance tasks " \
+                           "and fails with an error for badly-defined instance tasks" do
+                            task_m = TaskContext.new_submodel
+                            cmp_m = Composition.new_submodel
+                            req_task1 =
+                                plan.add_permanent_task(task_m.to_instance_requirements.as_plan)
+                            req_task2 =
+                                plan.add_permanent_task(cmp_m.to_instance_requirements.as_plan)
+                            requirement_tasks = [req_task1, req_task2].map(&:planning_task)
+                            execute do
+                                requirement_tasks.each(&:start!)
+                            end
+                            refute_resolution_succeeds
+
+                            req_task1, req_task2 = requirement_tasks
+
+                            assert req_task2.resolution_success?
+
+                            assert req_task1.failed?
+                            exceptions = req_task1.failed_event.last.context
+                            assert_equal 1, exceptions.size
+                            assert_kind_of Syskit::MissingDeployment, exceptions.first
+                            assert_exception_can_be_pretty_printed(exceptions.first)
+                        end
+
+                        it "applies the computed network and emits the planning task's " \
+                           "resolution success event" do
+                            cmp_m = Composition.new_submodel
+                            requirement_task = cmp_m.to_instance_requirements.as_plan
+                            plan.add_permanent_task(requirement_task)
+                            requirement_task = requirement_task.planning_task
+                            execute { requirement_task.start! }
+                            assert_resolution_succeeds
+                            assert requirement_task.resolution_success?
+                        end
+
+                        it "clears leftover failed tasks from the plan" do
+                            srv_m = Syskit::DataService.new_submodel
+                            task_m = Syskit::TaskContext.new_submodel
+                            task_m.provides srv_m, as: "srv"
+                            cmp_m = Composition.new_submodel do
+                                add srv_m, as: "test"
+                            end
+
+                            t1 = cmp_m.as_plan
+                            requirement_task = t1.as_plan
+                            plan.add_permanent_task(requirement_task)
+                            requirement_task = requirement_task.planning_task
+                            execute { requirement_task.start! }
+                            execute { Runtime.apply_requirement_modifications(plan) }
+                            expect_execution do
+                                plan.syskit_join_current_resolution
+                            end.to_have_error_matching(Roby::PlanningFailedError)
+                            assert requirement_task.failed?
+                            refute plan.find_tasks(srv_m).first
+                        end
+                    end
+
+                    def assert_resolution_cancelled # rubocop:disable Metrics/AbcSize
+                        flexmock(plan.syskit_current_resolution)
+                            .should_receive(:cancel).at_least.once
+                            .pass_thru
+
+                        yield
+
+                        execute do
+                            # This one triggers the cancellation
+                            Runtime.apply_requirement_modifications(plan)
+
+                            # This one is necessary if the future has started to be processed
+                            if plan.syskit_has_async_resolution?
+                                assert plan.syskit_current_resolution.cancelled?
+                                plan.syskit_join_current_resolution
+                            end
+
+                            refute plan.syskit_current_resolution
+                            Runtime.apply_requirement_modifications(plan)
+                        end
+                    end
+
+                    def join_current_resolution
+                        execute { plan.syskit_current_resolution.join }
+                    rescue Concurrent::CancelledOperationError # rubocop:disable Lint/SuppressedException
+                    end
+
+                    def assert_resolution_succeeds
+                        execute { Runtime.apply_requirement_modifications(plan) }
+                        execute { plan.syskit_join_current_resolution }
+                    end
+
+                    def refute_resolution_succeeds(
+                        with_exception: !Syskit.conf.capture_errors_during_network_resolution?
+                    )
+                        execute { Runtime.apply_requirement_modifications(plan) }
+                        expect_execution do
+                            yield if block_given?
+                            plan.syskit_join_current_resolution(raise_on_error: !with_exception)
+                        end.to_have_error_matching(Roby::PlanningFailedError)
+                    end
                 end
-            end
-
-            def join_current_resolution
-                execute { plan.syskit_current_resolution.join }
-            rescue Concurrent::CancelledOperationError # rubocop:disable Lint/SuppressedException
-            end
-
-            def assert_resolution_succeeds
-                execute { Runtime.apply_requirement_modifications(plan) }
-                execute { plan.syskit_join_current_resolution }
-            end
-
-            def refute_resolution_succeeds(
-                with_exception: !Syskit.conf.capture_errors_during_network_resolution?
-            )
-                execute { Runtime.apply_requirement_modifications(plan) }
-                expect_execution do
-                    yield if block_given?
-                    plan.syskit_join_current_resolution(raise_on_error: !with_exception)
-                end.to_have_error_matching(Roby::PlanningFailedError)
             end
         end
     end


### PR DESCRIPTION
On top of #533 

"Fibers" are cooperative concurrency primitives in Ruby. The thread-based implementation clearly does not work - the main thread will seldom interact with "the outside world" while syskit is deploying, which is a major source of issues.