### PR TITLE
fix: make a syskit-specific subclass of Roby's Global scheduler

### DIFF
--- a/lib/syskit.rb
+++ b/lib/syskit.rb
@@ -131,6 +131,7 @@ require "syskit/network_generation_exception_helpers"
 require "syskit/exceptions"
 require "syskit/network_generation"
 require "syskit/runtime"
+require "syskit/schedulers/global"
 
 require "syskit/instance_requirements_task"
 

--- a/lib/syskit/component.rb
+++ b/lib/syskit/component.rb
@@ -169,7 +169,7 @@ module Syskit
         # has been emitted. This is used to sequence configurations with
         # other system events, but should not be required in most cases
         def should_configure_after(object)
-            # To make the scheduler happy
+            # To make the temporal scheduler happy
             should_start_after object
             object.add_syskit_configuration_precedence(start_event)
         end

--- a/lib/syskit/composition.rb
+++ b/lib/syskit/composition.rb
@@ -192,7 +192,13 @@ module Syskit
         #
         # will return false if any of the children is not executable.
         def executable? # :nodoc:
-            return super if Syskit.conf.compositions_use_schedule_as?
+            if @global_scheduler.nil?
+                return false unless plan.executable?
+
+                @global_scheduler =
+                    plan.execution_engine.scheduler.kind_of?(Schedulers::Global)
+            end
+            return super if @global_scheduler
 
             return false unless super
             return true if @executable

--- a/lib/syskit/models/composition.rb
+++ b/lib/syskit/models/composition.rb
@@ -1104,10 +1104,6 @@ module Syskit
                         end
 
                         self_task.depends_on(child_task, dependency_options)
-                        if Syskit.conf.compositions_use_schedule_as?
-                            self_task.schedule_as(child_task)
-                        end
-
                         self_task.child_selection[child_name] = selected_child
                         if (main = main_task) && (main.child_name == child_name)
                             child_task.each_event do |ev|

--- a/lib/syskit/roby_app/configuration.rb
+++ b/lib/syskit/roby_app/configuration.rb
@@ -240,7 +240,10 @@ module Syskit
             # a composition and its children
             #
             # @see #compositions_use_schedule_as?
-            attr_writer :compositions_use_schedule_as
+            def compositions_use_schedule_as=(flag)
+                Syskit.warn "compositions_use_schedule_as is a no-op now, " \
+                            "use the global scheduler instead"
+            end
 
             # Which mechanism Syskit uses to synchronize a composition and its children
             #
@@ -249,7 +252,8 @@ module Syskit
             # when the child of a composition was swapped for another (unstarted) one
             # dynamically
             def compositions_use_schedule_as?
-                @compositions_use_schedule_as
+                Syskit.warn "compositions_use_schedule_as is a no-op now, " \
+                            "use the global scheduler instead"
             end
 
             # Controls whether the orogen types should be exported as Ruby

--- a/lib/syskit/schedulers/global.rb
+++ b/lib/syskit/schedulers/global.rb
@@ -6,6 +6,15 @@ module Syskit
     module Schedulers
         # Subclass of Roby's Global scheduler to handle Syskit-specific relations
         class Global < Roby::Schedulers::Global
+            def scheduling_graph_add_edges(graph)
+                super
+
+                @plan.task_relation_graph_for(Roby::TaskStructure::Dependency)
+                     .each_edge do |a, b|
+                         graph.add_edge(a, b) if a.kind_of?(Composition)
+                     end
+            end
+
             def non_executable_resolution_tasks(non_executable_task)
                 return super if non_executable_task.abstract? ||
                                 !non_executable_task.kind_of?(Component)

--- a/lib/syskit/schedulers/global.rb
+++ b/lib/syskit/schedulers/global.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "roby/schedulers/global"
+
+module Syskit
+    module Schedulers
+        # Subclass of Roby's Global scheduler to handle Syskit-specific relations
+        class Global < Roby::Schedulers::Global
+            def non_executable_resolution_tasks(non_executable_task)
+                return super if non_executable_task.abstract? ||
+                                !non_executable_task.kind_of?(Component)
+
+                graph = @plan.event_relation_graph_for(
+                    Roby::EventStructure::SyskitConfigurationPrecedence
+                )
+
+                # a->b in the graph means that 'a' needs to happen for 'b' to be
+                # configured, where 'b' is always the start event of a task
+                related = graph.in_neighbours(non_executable_task.start_event).map do |ev|
+                    ev.task if ev.respond_to?(:task)
+                end
+
+                super | related.compact
+            end
+        end
+    end
+end

--- a/test/schedulers/test_global.rb
+++ b/test/schedulers/test_global.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "syskit/test/self"
+require "syskit/schedulers/global"
+
+module Syskit
+    module Schedulers
+        describe Global do
+            before do
+                @scheduler = Global.new(plan)
+            end
+
+            it "schedules the configuration precedence task of a non-executable task" do
+                task_m = TaskContext.new_submodel
+                plan.add(root = task_m.new)
+                root.depends_on(precedence = task_m.new)
+                precedence.executable = true
+                root.should_configure_after(precedence.start_event)
+
+                assert_scheduled_tasks([precedence])
+            end
+
+            def assert_scheduled_tasks(set)
+                assert_equal set.to_set, @scheduler.compute_tasks_to_schedule
+            end
+        end
+    end
+end

--- a/test/schedulers/test_global.rb
+++ b/test/schedulers/test_global.rb
@@ -20,6 +20,16 @@ module Syskit
                 assert_scheduled_tasks([precedence])
             end
 
+            it "does not schedule the configuration precedence if " \
+               "it is itself not executable" do
+                task_m = TaskContext.new_submodel
+                plan.add(root = task_m.new)
+                root.depends_on(precedence = task_m.new)
+                root.should_configure_after(precedence.start_event)
+
+                assert_scheduled_tasks([])
+            end
+
             def assert_scheduled_tasks(set)
                 assert_equal set.to_set, @scheduler.compute_tasks_to_schedule
             end


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-roby/pull/363

It is needed to properly handle the configuration precedence relation