### PR TITLE
fix: path too long error in CI on test teardown

### DIFF
--- a/lib/syskit/test/spec.rb
+++ b/lib/syskit/test/spec.rb
@@ -28,7 +28,7 @@ module Syskit
 
             PATH_ELEMENT_MAX = 256
 
-            def test_name_to_path_basename
+            def generate_path_basename_from_test_name
                 max_basename_size =
                     PATH_ELEMENT_MAX - "-partial-hierarchy.svg".size
                 basename = __full_name__.gsub("/", "_")
@@ -39,7 +39,7 @@ module Syskit
 
             def teardown
                 if !passed? && app.public_logs?
-                    basename = test_name_to_path_basename
+                    basename = generate_path_basename_from_test_name
                     dataflow = "#{basename}-partial-dataflow.svg"
                     hierarchy = "#{basename}-partial-hierarchy.svg"
                     Graphviz.new(plan).to_file(

--- a/lib/syskit/test/spec.rb
+++ b/lib/syskit/test/spec.rb
@@ -26,13 +26,22 @@ module Syskit
                 Syskit.conf.logs.disable_port_logging
             end
 
+            PATH_ELEMENT_MAX = 256
+
+            def test_name_to_path_basename
+                max_basename_size =
+                    PATH_ELEMENT_MAX - "-partial-hierarchy.svg".size
+                basename = __full_name__.gsub("/", "_")
+                return basename if basename.size < max_basename_size
+
+                basename[0, max_basename_size - 10] + "-#{rand}"
+            end
+
             def teardown
                 if !passed? && app.public_logs?
-                    dataflow = __full_name__ + "-partial-dataflow.svg"
-                    hierarchy = __full_name__ + "-partial-hierarchy.svg"
-                    dataflow, hierarchy = [dataflow, hierarchy].map do |filename|
-                        filename.gsub("/", "_")
-                    end
+                    basename = test_name_to_path_basename
+                    dataflow = "#{basename}-partial-dataflow.svg"
+                    hierarchy = "#{basename}-partial-hierarchy.svg"
                     Graphviz.new(plan).to_file(
                         "dataflow", "svg", File.join(app.log_dir, dataflow)
                     )


### PR DESCRIPTION
The overall limit of paths on Linux is 4096, but there is also a limit of 256 bytes per element. Make sure that tests don't pass the second limit