### PR TITLE
fix: poll async resolutions within the test harness

### DIFF
--- a/lib/syskit/runtime/connection_management.rb
+++ b/lib/syskit/runtime/connection_management.rb
@@ -769,7 +769,10 @@ module Syskit
             # update RequiredDataFlow and then do a diff against ActualDataFlow.
             def update
                 # Don't do anything if the engine is deploying
-                return if plan.syskit_has_async_resolution?
+                if plan.syskit_has_async_resolution?
+                    debug "connection: skipping, async resolution in progress"
+                    return
+                end
 
                 update_pending_changes_from_modified_tasks
                 add_dangling_connections_to_pending_changes

--- a/lib/syskit/test/base.rb
+++ b/lib/syskit/test/base.rb
@@ -18,6 +18,8 @@ module Syskit
                 @old_loglevel = Orocos.logger.level
                 @__syskit_test_updated_attrs = {}
 
+                @expect_execution_process_async_resolutions = true
+
                 super
             end
 
@@ -41,6 +43,12 @@ module Syskit
                     raise teardown_failure
                 end
             end
+
+            # Controls at the test level whether the execution expectation harness
+            # should poll async resolution results
+            #
+            # @see ExecutionExpectations#process_async_resolutions?
+            attr_accessor :expect_execution_process_async_resolutions
 
             def __syskit_test_disable_taskcontext_info_messages
                 registered_plans.each do |p|

--- a/lib/syskit/test/base.rb
+++ b/lib/syskit/test/base.rb
@@ -18,8 +18,6 @@ module Syskit
                 @old_loglevel = Orocos.logger.level
                 @__syskit_test_updated_attrs = {}
 
-                @expect_execution_process_async_resolutions = true
-
                 super
             end
 
@@ -43,12 +41,6 @@ module Syskit
                     raise teardown_failure
                 end
             end
-
-            # Controls at the test level whether the execution expectation harness
-            # should poll async resolution results
-            #
-            # @see ExecutionExpectations#process_async_resolutions?
-            attr_accessor :expect_execution_process_async_resolutions
 
             def __syskit_test_disable_taskcontext_info_messages
                 registered_plans.each do |p|

--- a/lib/syskit/test/execution_expectations.rb
+++ b/lib/syskit/test/execution_expectations.rb
@@ -4,6 +4,14 @@ module Syskit
     module Test
         # Definition of expectations for Roby's expect_execution harness
         module ExecutionExpectations
+            Roby::Test::ExecutionExpectations.poll do |test, plan|
+                InstanceRequirementPlanningHandler.process_async_resolution(test, plan)
+            end
+
+            Roby::Test::ExecutionExpectations.exit_allowed_condition do |test, plan|
+                !plan.syskit_has_async_resolution?
+            end
+
             # @api private
             #
             # Helper used to resolve reader objects

--- a/lib/syskit/test/execution_expectations.rb
+++ b/lib/syskit/test/execution_expectations.rb
@@ -4,12 +4,42 @@ module Syskit
     module Test
         # Definition of expectations for Roby's expect_execution harness
         module ExecutionExpectations
+            # Controls whether the execution expectation harness should explicitly
+            # process async resolutions and wait for them to finish
+            #
+            # The default is true
+            #
+            # @see #process_async_resolutions?
+            def process_async_resolutions(flag)
+                @process_async_resolutions = flag
+                self
+            end
+
+            # Controls whether the execution expectation harness should explicitly
+            # process async resolutions and wait for them to finish
+            #
+            # The default is true
+            #
+            # It can be controlled at the test level with
+            # {Base#expect_execution_process_async_resolutions=}
+            #
+            # @see #process_async_resolutions
+            def process_async_resolutions?
+                if @process_async_resolutions.nil?
+                    @test.expect_execution_process_async_resolutions
+                else
+                    @process_async_resolutions
+                end
+            end
+
             Roby::Test::ExecutionExpectations.poll do |test, plan|
-                InstanceRequirementPlanningHandler.process_async_resolution(test, plan)
+                test.process_async_resolutions? &&
+                    InstanceRequirementPlanningHandler
+                        .process_async_resolution(test, plan)
             end
 
             Roby::Test::ExecutionExpectations.exit_allowed_condition do |test, plan|
-                !plan.syskit_has_async_resolution?
+                !test.process_async_resolutions? || !plan.syskit_has_async_resolution?
             end
 
             # @api private

--- a/lib/syskit/test/expect_execution.rb
+++ b/lib/syskit/test/expect_execution.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Syskit
+    module Test
+        # Extensions to the execution expectation API that is mixed in the test classes
+        module ExpectExecution
+            def setup
+                super
+
+                @expect_execution_process_async_resolutions = true
+            end
+
+            # Controls at the test level whether the execution expectation harness
+            # should poll async resolution results
+            #
+            # @see ExecutionExpectations#process_async_resolutions?
+            attr_accessor :expect_execution_process_async_resolutions
+        end
+    end
+end

--- a/lib/syskit/test/instance_requirement_planning_handler.rb
+++ b/lib/syskit/test/instance_requirement_planning_handler.rb
@@ -56,15 +56,15 @@ module Syskit
                 )
             end
 
-            def replace_tasks_for_stub_network(results)
+            def self.replace_tasks_for_stub_network(test, plan, results)
                 root_tasks = results.instance_requirement_tasks.map(&:planned_task)
-                stub_network = StubNetwork.new(@test)
+                stub_network = StubNetwork.new(test)
 
                 # NOTE: this is a run-planner equivalent to syskit_stub_network
                 # we will have to investigate whether we could implement one with
                 # the other (probably), but in the meantime we must keep both
                 # in sync
-                mapped_tasks = @plan.in_transaction do |trsc|
+                mapped_tasks = plan.in_transaction do |trsc|
                     mapped_tasks =
                         stub_network.apply_in_transaction(trsc, root_tasks)
                     trsc.commit_transaction
@@ -80,24 +80,31 @@ module Syskit
             # This is only relevant when we arent capturing errors during the network
             # resolution. When we are capturing errors, the capture pipeline already deals
             # with the failed task, and can deploy the stub network safely.
-            def consider_finished_due_to_errors?(results)
+            def self.consider_finished_due_to_errors?(results)
                 !Syskit.conf.capture_errors_during_network_resolution? && results.error?
             end
 
+            def self.process_async_resolution(test, plan)
+                return unless plan.syskit_has_async_resolution?
+
+                Thread.pass
+
+                async = plan.syskit_current_resolution
+                plan.syskit_poll_async_resolution(nil)
+                return if plan.syskit_has_async_resolution?
+
+                resolution_results = async.result
+                return unless resolution_results # cancelled
+                return true if consider_finished_due_to_errors?(resolution_results)
+                return unless test.syskit_run_planner_stub?
+
+                replace_tasks_for_stub_network(
+                    test, plan, resolution_results
+                )
+            end
+
             def finished?
-                if @plan.syskit_has_async_resolution?
-                    Thread.pass
-
-                    async = @plan.syskit_current_resolution
-                    @plan.syskit_poll_async_resolution(nil)
-                    return if @plan.syskit_has_async_resolution?
-
-                    resolution_results = async.result
-                    return true if consider_finished_due_to_errors?(resolution_results)
-                    return unless @test.syskit_run_planner_stub?
-
-                    replace_tasks_for_stub_network(resolution_results)
-                end
+                self.class.process_async_resolution(@test, @plan)
 
                 @planning_tasks.all? { |t| t.resolution_success? || t.finished? }
             end

--- a/lib/syskit/test/instance_requirement_planning_handler.rb
+++ b/lib/syskit/test/instance_requirement_planning_handler.rb
@@ -2,6 +2,7 @@
 
 require "roby/test/spec"
 require "syskit/test/execution_expectations"
+require "syskit/test/expect_execution"
 
 module Syskit
     module Test # :nodoc:
@@ -182,5 +183,7 @@ module Syskit
         )
 
         Roby::Test::ExecutionExpectations.include ExecutionExpectations
+        Roby::Test::TeardownPlans.include ExpectExecution
+        Minitest::Test.include ExpectExecution
     end
 end

--- a/lib/syskit/test/spec.rb
+++ b/lib/syskit/test/spec.rb
@@ -61,6 +61,7 @@ module Syskit
 
                 plan.syskit_cancel_async_resolution
                 plan.syskit_join_current_resolution
+                plan.syskit_pending_forced_resolution = false
             end
 
             def teardown_registered_plans

--- a/test/network_generation/test_async_threaded.rb
+++ b/test/network_generation/test_async_threaded.rb
@@ -7,6 +7,7 @@ module Syskit
         describe AsyncThreaded do
             before do
                 plan.syskit_async_method = AsyncThreaded
+                self.expect_execution_process_async_resolutions = false
             end
 
             describe "#poll" do

--- a/test/runtime/test_apply_requirement_modifications.rb
+++ b/test/runtime/test_apply_requirement_modifications.rb
@@ -9,6 +9,7 @@ module Syskit
                 before do
                     @__async_method = plan.syskit_async_method
                     plan.syskit_async_method = async_method
+                    self.expect_execution_process_async_resolutions = false
                 end
 
                 after do

--- a/test/test/test_execution_expectations.rb
+++ b/test/test/test_execution_expectations.rb
@@ -22,10 +22,27 @@ module Syskit
                    "created during the generation block" do
                     plan.add(@task_m.as_plan)
                     expect_execution { Syskit::Runtime.apply_requirement_modifications(plan, force: true) }
-                        .to do
-                            achieve { plan.syskit_has_async_resolution? }
-                            achieve { !plan.syskit_has_async_resolution? }
-                        end
+                        .process_async_resolutions(true)
+                        .to_achieve { !plan.syskit_has_async_resolution? }
+                end
+
+                it "finishes at the end of the test the resolutions " \
+                   "created during the generation block" do
+                    plan.add(@task_m.as_plan)
+                    expect_execution { Syskit::Runtime.apply_requirement_modifications(plan, force: true) }
+                        .process_async_resolutions(true)
+                        .to_run
+
+                    refute plan.syskit_has_async_resolution?
+                end
+
+                it "does not wait for resolutions to stop if disabled" do
+                    plan.add(@task_m.as_plan)
+                    expect_execution { Syskit::Runtime.apply_requirement_modifications(plan, force: true) }
+                        .process_async_resolutions(false)
+                        .to_run
+
+                    assert plan.syskit_has_async_resolution?
                 end
 
                 it "finishes within the test the resolutions " \
@@ -33,6 +50,7 @@ module Syskit
                     plan.add(@task_m.as_plan)
                     applied = false
                     expect_execution
+                        .process_async_resolutions(true)
                         .poll do
                             unless applied
                                 Syskit::Runtime.apply_requirement_modifications(
@@ -40,10 +58,7 @@ module Syskit
                                 )
                                 applied = true
                             end
-                        end.to do
-                            achieve { plan.syskit_has_async_resolution? }
-                            achieve { !plan.syskit_has_async_resolution? }
-                        end
+                        end.to_achieve { !plan.syskit_has_async_resolution? }
                 end
 
                 it "finishes at the end of the test resolutions " \
@@ -51,6 +66,7 @@ module Syskit
                     plan.add(@task_m.as_plan)
                     done = false
                     expect_execution
+                        .process_async_resolutions(true)
                         .poll do
                             unless done
                                 Syskit::Runtime.apply_requirement_modifications(
@@ -59,7 +75,7 @@ module Syskit
                                 done = true
                             end
                         end
-                        .to_achieve { plan.syskit_has_async_resolution? }
+                        .to_run
 
                     refute plan.syskit_has_async_resolution?
                 end

--- a/test/test/test_execution_expectations.rb
+++ b/test/test/test_execution_expectations.rb
@@ -9,12 +9,60 @@ module Syskit
             attr_reader :task
 
             before do
-                task_m = Syskit::RubyTaskContext.new_submodel do
+                @task_m = task_m = Syskit::RubyTaskContext.new_submodel do
                     input_port "in", "/int"
                     output_port "out", "/int"
                 end
                 use_ruby_tasks task_m => "test", on: "stubs"
                 @task = syskit_deploy_configure_and_start(task_m)
+            end
+
+            describe "handling of apply_requirement_modifications" do
+                it "finishes within the test the resolutions " \
+                   "created during the generation block" do
+                    plan.add(@task_m.as_plan)
+                    expect_execution { Syskit::Runtime.apply_requirement_modifications(plan, force: true) }
+                        .to do
+                            achieve { plan.syskit_has_async_resolution? }
+                            achieve { !plan.syskit_has_async_resolution? }
+                        end
+                end
+
+                it "finishes within the test the resolutions " \
+                   "created during the execution" do
+                    plan.add(@task_m.as_plan)
+                    applied = false
+                    expect_execution
+                        .poll do
+                            unless applied
+                                Syskit::Runtime.apply_requirement_modifications(
+                                    plan, force: true
+                                )
+                                applied = true
+                            end
+                        end.to do
+                            achieve { plan.syskit_has_async_resolution? }
+                            achieve { !plan.syskit_has_async_resolution? }
+                        end
+                end
+
+                it "finishes at the end of the test resolutions " \
+                   "created during the execution" do
+                    plan.add(@task_m.as_plan)
+                    done = false
+                    expect_execution
+                        .poll do
+                            unless done
+                                Syskit::Runtime.apply_requirement_modifications(
+                                    plan, force: true
+                                )
+                                done = true
+                            end
+                        end
+                        .to_achieve { plan.syskit_has_async_resolution? }
+
+                    refute plan.syskit_has_async_resolution?
+                end
             end
 
             describe "#have_one_new_sample" do

--- a/test/test/test_spec.rb
+++ b/test/test/test_spec.rb
@@ -53,7 +53,6 @@ module Syskit
 
                 assert_equal false, cycles[0].planning_task_starting
                 assert_equal true, cycles[0].planning_task_running
-                assert cycles[0].has_async_resolution
             end
 
             it "waits for the planning tasks to be started before it triggers the async resolution" do

--- a/test/test_instance_requirements_task.rb
+++ b/test/test_instance_requirements_task.rb
@@ -20,7 +20,9 @@ describe Syskit::InstanceRequirementsTask do
 
     it "triggers a network resolution when started" do
         task = plan.add_permanent_task(cmp_m.as_plan)
-        execute { task.planning_task.start! }
+        expect_execution { task.planning_task.start! }
+            .process_async_resolutions(false)
+            .to_run
         assert plan.syskit_current_resolution
     end
 

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -480,12 +480,14 @@ module Syskit
             end
 
             after do
-                if task.start_event.pending?
-                    task.start_event.emit
-                end
-                if task.running?
-                    expect_execution { task.stop! }
-                        .to { emit task.stop_event }
+                if task
+                    if task.start_event.pending?
+                        task.start_event.emit
+                    end
+                    if task.running?
+                        expect_execution { task.stop! }
+                            .to { emit task.stop_event }
+                    end
                 end
             end
 


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-roby/pull/368
- [ ] https://github.com/rock-core/tools-roby/pull/376
- [ ] https://github.com/rock-core/tools-roby/pull/383

So far, if code executed during the test called apply_requirement_modifications,
the test would have created an async resolution but never resolved it. This
interferes with the rest of the test, and in particular if the test relies on
connection management (which is "paused" during resolution)

Make sure the expectation harness calls async_poll to finish the resolution