### PR TITLE
fix: ensure to remove tasks with errors from used deployments

### DIFF
--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -133,8 +133,12 @@ module Syskit
                         lazy: lazy_deploy
                     )
                     @used_deployments = @used_deployments.merge(used_deployments)
-                    resolution_errors = error_handler.process_failures(
-                        required_instances, cleanup_failed_tasks: true
+                    @used_deployments.transform_keys! do |task|
+                        merge_solver.replacement_for(task)
+                    end
+                    resolution_errors, @used_deployments = process_failures(
+                        error_handler, required_instances, @used_deployments,
+                        cleanup_failed_tasks: true
                     )
                     # Sanity check that the plan was properly cleaned up
                     SystemNetworkDeployer.verify_all_tasks_deployed(
@@ -406,8 +410,10 @@ module Syskit
                 toplevel_tasks_to_requirements =
                     system_network_generator.toplevel_tasks_to_requirements
 
-                resolution_errors = error_handler.process_failures(
+                resolution_errors, @used_deployments = process_failures(
+                    error_handler,
                     required_instances,
+                    @used_deployments,
                     cleanup_failed_tasks: cleanup_resolution_errors
                 )
                 if cleanup_resolution_errors
@@ -421,6 +427,21 @@ module Syskit
                     )
                 end
                 [required_instances, resolution_errors, toplevel_tasks_to_requirements]
+            end
+
+            def process_failures(
+                error_handler, required_instances, used_deployments, cleanup_failed_tasks:
+            )
+                resolution_errors = error_handler.process_failures(required_instances)
+                return [resolution_errors, used_deployments] unless cleanup_failed_tasks
+
+                removed_tasks = error_handler.cleanup_resolution_errors(
+                    resolution_errors, required_instances, work_plan
+                )
+                removed_tasks.each do |task|
+                    used_deployments.delete(task)
+                end
+                [resolution_errors, used_deployments]
             end
 
             # Computes the system network, that is the network that fullfills

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -89,7 +89,6 @@ module Syskit
                     event_logger: event_logger,
                     resolution_control: resolution_control
                 )
-                @used_deployments = {}
                 @required_instances = {}
             end
 
@@ -128,17 +127,12 @@ module Syskit
                         resolution_control: @resolution_control
                     )
 
-                    used_deployments, = deployer.deploy(
+                    deployer.deploy(
                         error_handler: error_handler, validate: validate_deployed_network,
                         lazy: lazy_deploy
                     )
-                    @used_deployments = @used_deployments.merge(used_deployments)
-                    @used_deployments.transform_keys! do |task|
-                        merge_solver.replacement_for(task)
-                    end
-                    resolution_errors, @used_deployments = process_failures(
-                        error_handler, required_instances, @used_deployments,
-                        cleanup_failed_tasks: true
+                    resolution_errors = process_failures(
+                        error_handler, required_instances, cleanup_failed_tasks: true
                     )
                     # Sanity check that the plan was properly cleaned up
                     SystemNetworkDeployer.verify_all_tasks_deployed(
@@ -178,7 +172,7 @@ module Syskit
                 @deployment_tasks, @deployed_tasks =
                     log_timepoint_group "finalize_deployed_tasks" do
                         adaptation = RuntimeNetworkAdaptation.new(
-                            work_plan, @used_deployments,
+                            work_plan,
                             merge_solver: @merge_solver,
                             event_logger: @event_logger,
                             resolution_control: @resolution_control
@@ -398,7 +392,7 @@ module Syskit
                         instance_requirements
                     )
 
-                _, @used_deployments = system_network_generator.resolve_system_network(
+                system_network_generator.resolve_system_network(
                     garbage_collect: garbage_collect,
                     validate_abstract_network: validate_abstract_network,
                     validate_generated_network: validate_generated_network,
@@ -410,10 +404,9 @@ module Syskit
                 toplevel_tasks_to_requirements =
                     system_network_generator.toplevel_tasks_to_requirements
 
-                resolution_errors, @used_deployments = process_failures(
+                resolution_errors = process_failures(
                     error_handler,
                     required_instances,
-                    @used_deployments,
                     cleanup_failed_tasks: cleanup_resolution_errors
                 )
                 if cleanup_resolution_errors
@@ -429,19 +422,14 @@ module Syskit
                 [required_instances, resolution_errors, toplevel_tasks_to_requirements]
             end
 
-            def process_failures(
-                error_handler, required_instances, used_deployments, cleanup_failed_tasks:
-            )
+            def process_failures(error_handler, required_instances, cleanup_failed_tasks:)
                 resolution_errors = error_handler.process_failures(required_instances)
-                return [resolution_errors, used_deployments] unless cleanup_failed_tasks
+                return resolution_errors unless cleanup_failed_tasks
 
-                removed_tasks = error_handler.cleanup_resolution_errors(
+                error_handler.cleanup_resolution_errors(
                     resolution_errors, required_instances, work_plan
                 )
-                removed_tasks.each do |task|
-                    used_deployments.delete(task)
-                end
-                [resolution_errors, used_deployments]
+                resolution_errors
             end
 
             # Computes the system network, that is the network that fullfills

--- a/lib/syskit/network_generation/resolution_error_handler.rb
+++ b/lib/syskit/network_generation/resolution_error_handler.rb
@@ -151,7 +151,7 @@ module Syskit
                 end
             end
 
-            def process_failures(required_instances, cleanup_failed_tasks:)
+            def process_failures(required_instances)
                 requirement_tasks = required_instances.keys
                 toplevel_tasks = required_instances.values
 
@@ -164,12 +164,6 @@ module Syskit
                         instance = requirement_tasks[i]
                         failure.to_resolution_errors(instance)
                     end
-                end
-
-                if cleanup_failed_tasks
-                    cleanup_resolution_errors(
-                        resolution_errors, required_instances, @plan
-                    )
                 end
 
                 resolution_errors
@@ -188,19 +182,24 @@ module Syskit
                     requirement_task = error.planning_task
                     required_instances.delete requirement_task
                 end
-                return if resolution_errors.empty?
+                return [] if resolution_errors.empty?
 
                 NetworkGeneration.debug "cleanup up after error resolution"
                 protected_tasks = required_instances.values.map do |v|
                     @merge_solver.replacement_for(v)
                 end
+
+                removed_tasks = []
                 work_plan
                     .static_garbage_collect(protected_roots: protected_tasks) do |obj|
                         NetworkGeneration.debug { "  removing #{obj}" }
                         # Remove tasks that are not useful anymore
                         @plan.remove_task(obj)
+                        removed_tasks << obj
                     end
                 @resolution_failures.clear
+
+                removed_tasks
             end
         end
 
@@ -214,6 +213,9 @@ module Syskit
             # errors, since it raises if any errors happened
             def process_failures(*)
                 []
+            end
+
+            def cleanup_resolution_errors(*)
             end
         end
     end

--- a/lib/syskit/network_generation/resolution_error_handler.rb
+++ b/lib/syskit/network_generation/resolution_error_handler.rb
@@ -155,7 +155,7 @@ module Syskit
                 requirement_tasks = required_instances.keys
                 toplevel_tasks = required_instances.values
 
-                resolution_errors = @resolution_failures.flat_map do |failure|
+                @resolution_failures.flat_map do |failure|
                     failed_task = failure.failed_task
                     indexes = find_index_of_toplevel_tasks_depending_on(
                         failed_task, toplevel_tasks, failure.plan, failure.merge_solver
@@ -165,8 +165,6 @@ module Syskit
                         failure.to_resolution_errors(instance)
                     end
                 end
-
-                resolution_errors
             end
 
             # Cleanup the requirement tasks and toplevel tasks that encountered resolution
@@ -215,8 +213,7 @@ module Syskit
                 []
             end
 
-            def cleanup_resolution_errors(*)
-            end
+            def cleanup_resolution_errors(*); end
         end
     end
 end

--- a/lib/syskit/network_generation/runtime_network_adaptation.rb
+++ b/lib/syskit/network_generation/runtime_network_adaptation.rb
@@ -14,7 +14,7 @@ module Syskit
             # @param [{Component=>DeploymentGroup::DeployedTask}] used_deployments the
             #   mapping from task instances to the deployment used for it
             def initialize(
-                work_plan, used_deployments,
+                work_plan,
                 merge_solver:,
                 event_logger: work_plan.event_logger,
                 resolution_control: Async::Control.new
@@ -24,6 +24,7 @@ module Syskit
                 @resolution_control = resolution_control
                 @merge_solver = merge_solver
 
+                used_deployments = find_used_deployments(work_plan)
                 tasks_per_configured_deployments =
                     used_deployments.each_with_object({}) do |(task, deployed_task), h|
                         (h[deployed_task.configured_deployment] ||= []) << task
@@ -34,6 +35,12 @@ module Syskit
                             configured_deployment: configured_deployment, tasks: tasks
                         )
                     end
+            end
+
+            def find_used_deployments(work_plan)
+                work_plan.find_local_tasks(TaskContext).each_with_object({}) do |t, h|
+                    h[t] = t.deployed_task
+                end
             end
 
             def apply

--- a/lib/syskit/network_generation/system_network_deployer.rb
+++ b/lib/syskit/network_generation/system_network_deployer.rb
@@ -281,12 +281,11 @@ module Syskit
                     task.orogen_model = sel.orogen_model
                     task.orogen_model.master
                 end
-                if with_master.empty?
-                    selected_deployments.each do |task, sel|
-                        task.deployed_task = sel
-                    end
-                    return selected_deployments
+                selected_deployments.each do |task, sel|
+                    task.deployed_task = sel
                 end
+
+                return selected_deployments if with_master.empty?
 
                 used_deployments = selected_deployments.dup
                 by_name = selected_deployments

--- a/lib/syskit/network_generation/system_network_deployer.rb
+++ b/lib/syskit/network_generation/system_network_deployer.rb
@@ -236,6 +236,7 @@ module Syskit
                         # subnet. This is not the goal here.
                         merge_solver.apply_merge_group(task => deployed_task)
                         used_deployments[deployed_task] = deployed_task_m
+                        deployed_task.deployed_task = deployed_task_m
 
                         used_deployments.merge!(
                             apply_selected_deployments_discover_schedulers(
@@ -261,6 +262,7 @@ module Syskit
                 recursive = apply_selected_deployments_discover_schedulers(
                     scheduler_task, configured_deployment
                 )
+                scheduler_task.deployed_task = scheduler_deployed_task
                 { scheduler_task => scheduler_deployed_task }.merge(recursive)
             end
 
@@ -279,7 +281,12 @@ module Syskit
                     task.orogen_model = sel.orogen_model
                     task.orogen_model.master
                 end
-                return selected_deployments if with_master.empty?
+                if with_master.empty?
+                    selected_deployments.each do |task, sel|
+                        task.deployed_task = sel
+                    end
+                    return selected_deployments
+                end
 
                 used_deployments = selected_deployments.dup
                 by_name = selected_deployments
@@ -294,6 +301,7 @@ module Syskit
                     scheduler_deployed_task = Models::DeploymentGroup::DeployedTask.new(
                         deployment, scheduler_name
                     )
+                    scheduler_task.deployed_task = task.deployed_task
                     used_deployments[scheduler_task] = scheduler_deployed_task
                 end
                 used_deployments

--- a/lib/syskit/network_generation/system_network_generator.rb
+++ b/lib/syskit/network_generation/system_network_generator.rb
@@ -268,7 +268,6 @@ module Syskit
                 validate_deployed_network: true
             )
                 deployment_tasks = {}
-                @used_deployments = {}
                 early_deploy(deployment_tasks)
 
                 merge_solver.merge_identical_tasks
@@ -324,15 +323,13 @@ module Syskit
                 )
                 interruption_point("syskit-netgen:validation")
 
-                @used_deployments.transform_keys! { @merge_solver.replacement_for(_1) }
-                [@toplevel_tasks, @used_deployments]
+                @toplevel_tasks
             end
 
             def early_deploy(deployment_tasks)
                 return unless early_deploy?
 
-                used_deployments, = deploy(deployment_tasks)
-                @used_deployments.merge!(used_deployments)
+                deploy(deployment_tasks)
                 interruption_point "syskit-netgen:early-deploy"
             end
 

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -59,6 +59,8 @@ module Syskit
         # The last state before we went to orogen_state
         attr_reader :last_orogen_state
 
+        attr_accessor :deployed_task
+
         # @api private
         #
         # Initialize the communication with the remote task

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -328,6 +328,10 @@ module Syskit
             if merged_task.orocos_task && !orocos_task
                 self.orocos_task = merged_task.orocos_task
             end
+            
+            if merged_task.deployed_task && !deployed_task
+                self.deployed_task = merged_task.deployed_task
+            end
             nil
         end
 

--- a/lib/syskit/task_context.rb
+++ b/lib/syskit/task_context.rb
@@ -328,7 +328,7 @@ module Syskit
             if merged_task.orocos_task && !orocos_task
                 self.orocos_task = merged_task.orocos_task
             end
-            
+
             if merged_task.deployed_task && !deployed_task
                 self.deployed_task = merged_task.deployed_task
             end

--- a/test/network_generation/test_engine.rb
+++ b/test/network_generation/test_engine.rb
@@ -529,7 +529,7 @@ module Syskit
                     assert_master_slave_pattern_correct
                 end
 
-                it "deploys slave tasks when the deploymentc exists" do
+                it "deploys slave tasks when the deployment exists" do
                     deployment_task = @configured_deployment.new(plan: plan)
 
                     syskit_deploy(
@@ -715,7 +715,6 @@ module Syskit
                                        errors.first.original_exception
                     end
 
-
                     it "handles deployment errors during network adaption with bad new " \
                        "task" do
                         t1 = @task_m.with_arguments(arg: 1).as_plan
@@ -748,7 +747,7 @@ module Syskit
                             assert_kind_of ConflictingDeploymentAllocation,
                                            e.original_exception
                         end
-                     end
+                    end
                 end
             end
 

--- a/test/network_generation/test_engine.rb
+++ b/test/network_generation/test_engine.rb
@@ -693,6 +693,63 @@ module Syskit
                         assert_equal [t2.planning_task], required_instances.keys
                     end
                 end
+
+                describe "#resolve" do
+                    it "handles deployment errors during final deployment resolution " \
+                       "gracefully" do
+                        task2_m = Syskit::TaskContext.new_submodel
+                        task2_m.provides @srv_m, as: "srv"
+
+                        t1 = @cmp_m.use("test" => @task_m.new(arg: 2),
+                                        "other" => task2_m.new).as_plan
+                        plan.add(t1)
+
+                        errors = syskit_engine.resolve(
+                            requirement_tasks: [t1.planning_task],
+                            capture_errors_during_network_resolution: true,
+                            default_deployment_group: default_deployment_group,
+                            cleanup_resolution_errors: true
+                        )
+                        assert_equal 1, errors.size
+                        assert_kind_of MissingDeployment,
+                                       errors.first.original_exception
+                    end
+
+
+                    it "handles deployment errors during network adaption with bad new " \
+                       "task" do
+                        t1 = @task_m.with_arguments(arg: 1).as_plan
+                        plan.add(t1)
+
+                        t1 = t1.as_service
+                        syskit_engine.resolve(
+                            requirement_tasks: [t1.planning_task],
+                            default_deployment_group: default_deployment_group,
+                            capture_errors_during_network_resolution: true,
+                            early_deploy: true,
+                            cleanup_resolution_errors: true
+                        )
+
+                        new_engine = Syskit::NetworkGeneration::Engine.new(plan)
+                        t2 = @task_m.with_arguments(arg: 2).as_plan
+                        plan.add(t2)
+
+                        errors = new_engine.resolve(
+                            requirement_tasks: [t1.planning_task, t2.planning_task],
+                            default_deployment_group: default_deployment_group,
+                            capture_errors_during_network_resolution: true,
+                            early_deploy: true,
+                            cleanup_resolution_errors: true
+                        )
+                        # Both of the tasks will emit a ConflictingDeploymentAllocation
+                        # with one another
+                        assert_equal 2, errors.size
+                        errors.each do |e|
+                            assert_kind_of ConflictingDeploymentAllocation,
+                                           e.original_exception
+                        end
+                     end
+                end
             end
 
             describe "when scheduling tasks for reconfiguration" do

--- a/test/network_generation/test_runtime_network_adaptation.rb
+++ b/test/network_generation/test_runtime_network_adaptation.rb
@@ -727,8 +727,9 @@ module Syskit
 
                 tasks.each do |task|
                     name = task.execution_agent.process_name
-                    task.deployed_task = 
-                        flexmock(configured_deployment: configured_deployments.fetch(name))
+                    task.deployed_task = flexmock(
+                        configured_deployment: configured_deployments.fetch(name)
+                    )
                 end
             end
 

--- a/test/network_generation/test_runtime_network_adaptation.rb
+++ b/test/network_generation/test_runtime_network_adaptation.rb
@@ -22,9 +22,8 @@ module Syskit
                         deployment_m = create_deployment_model(task_count: 1)
                         _, initial =
                             add_deployment_and_tasks(work_plan, deployment_m, %w[task0])
-                        adapter = create_adapter(
-                            used_deployments_from_tasks(initial)
-                        )
+                        register_deployments_for_tasks(initial)
+                        adapter = create_adapter
 
                         existing_deployment, =
                             add_deployment_and_tasks(plan, deployment_m, %w[task0])
@@ -39,7 +38,7 @@ module Syskit
                         deployment_m = create_deployment_model(task_count: 1)
                         add_deployment_and_tasks(plan, deployment_m, %w[task0])
 
-                        adapter = create_adapter({})
+                        adapter = create_adapter
                         selected_deployments, = adapter.finalize_deployed_tasks
                         assert selected_deployments.empty?
                     end
@@ -49,9 +48,8 @@ module Syskit
                         required_deployment, tasks =
                             add_deployment_and_tasks(work_plan, deployment,
                                                      %w[task0 task1])
-                        adapter = create_adapter(
-                            used_deployments_from_tasks(tasks)
-                        )
+                        register_deployments_for_tasks(tasks)
+                        adapter = create_adapter
 
                         selected_deployments, selected_deployed_tasks =
                             adapter.finalize_deployed_tasks
@@ -74,9 +72,11 @@ module Syskit
                         # automatically create the scheduler too
                         required_deployment, =
                             add_deployment_and_tasks(work_plan, deployment, %w[scheduled])
-                        adapter = create_adapter(
-                            used_deployments_from_tasks(plan.find_tasks(task_m).to_a)
-                        )
+
+                        tasks = required_deployment.related_tasks
+                        register_deployments_for_tasks(tasks)
+                        adapter = create_adapter
+
                         adapter.finalize_deployed_tasks
 
                         tasks = @work_plan.find_tasks(task_m).sort_by(&:orocos_name)
@@ -100,9 +100,8 @@ module Syskit
                                 work_plan, deployment_m, %w[task0 task2]
                             )
 
-                        adapter = create_adapter(
-                            used_deployments_from_tasks([required0, task2])
-                        )
+                        register_deployments_for_tasks([required0, task2])
+                        adapter = create_adapter
 
                         selected_deployments, selected_deployed_tasks =
                             adapter.finalize_deployed_tasks
@@ -133,9 +132,9 @@ module Syskit
 
                         existing0.depends_on(existing1)
 
-                        adapter = create_adapter(
-                            used_deployments_from_tasks([required0, required1])
-                        )
+                        register_deployments_for_tasks([required0, required1])
+                        adapter = create_adapter
+
                         adapter.finalize_deployed_tasks
 
                         assert work_plan[existing0].depends_on?(work_plan[existing1])
@@ -153,9 +152,10 @@ module Syskit
                         required0.depends_on required2
                         required1.depends_on required2
 
-                        adapter = create_adapter(
-                            used_deployments_from_tasks([required0, required1, required2])
-                        )
+                        register_deployments_for_tasks([required0, required1,
+                                                        required2])
+                        adapter = create_adapter
+
                         adapter.finalize_deployed_tasks
 
                         required2 = work_plan[existing0].children.first
@@ -171,7 +171,8 @@ module Syskit
                         _, tasks =
                             add_deployment_and_tasks(work_plan, deployment_m, %w[task0])
 
-                        adapter = create_adapter(used_deployments_from_tasks(tasks))
+                        register_deployments_for_tasks(tasks)
+                        adapter = create_adapter
                         assert_raises Syskit::InternalError do
                             adapter.finalize_deployed_tasks
                         end
@@ -193,9 +194,9 @@ module Syskit
                         add_deployment_and_tasks(
                             work_plan, deployment_m, %w[scheduled1 scheduled2]
                         )
-                        adapter = create_adapter(
-                            used_deployments_from_tasks(work_plan.find_tasks(task_m).to_a)
-                        )
+                        register_deployments_for_tasks(work_plan.find_tasks(task_m).to_a)
+                        adapter = create_adapter
+
                         adapter.finalize_deployed_tasks
 
                         tasks = @work_plan.find_tasks(task_m).sort_by(&:orocos_name)
@@ -227,9 +228,9 @@ module Syskit
                         add_deployment_and_tasks(
                             work_plan, deployment_m, %w[scheduled1 scheduled2]
                         )
-                        adapter = create_adapter(
-                            used_deployments_from_tasks(work_plan.find_tasks(task_m).to_a)
-                        )
+                        register_deployments_for_tasks(work_plan.find_tasks(task_m).to_a)
+                        adapter = create_adapter
+
                         adapter.finalize_deployed_tasks
 
                         tasks = @work_plan.find_tasks(task_m).sort_by(&:orocos_name)
@@ -253,9 +254,8 @@ module Syskit
                         existing_deployment, =
                             add_deployment_and_tasks(plan, deployment_m, %w[task0])
                         initial = add_lazy_tasks(work_plan, deployment_m, %w[task0])
-                        adapter = create_adapter(
-                            used_deployments_from_lazy(initial, deployment_m)
-                        )
+                        lazy_register_deployments_for_tasks(initial, deployment_m)
+                        adapter = create_adapter
 
                         selected_deployments, = adapter.finalize_deployed_tasks
                         assert_equal [work_plan[existing_deployment]],
@@ -267,7 +267,7 @@ module Syskit
                         deployment_m = create_deployment_model(task_count: 1)
                         add_deployment_and_tasks(plan, deployment_m, %w[task0])
 
-                        adapter = create_adapter({})
+                        adapter = create_adapter
                         selected_deployments, = adapter.finalize_deployed_tasks
                         assert selected_deployments.empty?
                     end
@@ -275,9 +275,8 @@ module Syskit
                     it "creates a new deployment if needed" do
                         deployment_m = create_deployment_model(task_count: 2)
                         tasks = add_lazy_tasks(work_plan, deployment_m, %w[task0 task1])
-                        adapter = create_adapter(
-                            used_deployments_from_lazy(tasks, deployment_m)
-                        )
+                        lazy_register_deployments_for_tasks(tasks, deployment_m)
+                        adapter = create_adapter
 
                         selected_deployments, =
                             adapter.finalize_deployed_tasks
@@ -298,9 +297,9 @@ module Syskit
                             work_plan, deployment_m, %w[task0 task2]
                         )
 
-                        adapter = create_adapter(
-                            used_deployments_from_lazy([required0, task2], deployment_m)
-                        )
+                        lazy_register_deployments_for_tasks([required0, task2],
+                                                            deployment_m)
+                        adapter = create_adapter
 
                         selected_deployments, selected_deployed_tasks =
                             adapter.finalize_deployed_tasks
@@ -330,11 +329,11 @@ module Syskit
 
                         existing0.depends_on(existing1)
 
-                        adapter = create_adapter(
-                            used_deployments_from_lazy(
-                                [required0, required1], deployment_m
-                            )
+                        lazy_register_deployments_for_tasks(
+                            [required0, required1], deployment_m
                         )
+                        adapter = create_adapter
+
                         adapter.finalize_deployed_tasks
 
                         assert work_plan[existing0].depends_on?(work_plan[existing1])
@@ -351,11 +350,11 @@ module Syskit
                         required0.depends_on required2
                         required1.depends_on required2
 
-                        adapter = create_adapter(
-                            used_deployments_from_lazy(
-                                [required0, required1, required2], deployment_m
-                            )
+                        lazy_register_deployments_for_tasks(
+                            [required0, required1, required2], deployment_m
                         )
+                        adapter = create_adapter
+
                         adapter.finalize_deployed_tasks
 
                         required2 = work_plan[existing0].children.first
@@ -370,9 +369,9 @@ module Syskit
                         add_deployment_and_tasks(plan, deployment_m, %w[task0])
                         tasks = add_lazy_tasks(work_plan, deployment_m, %w[task0])
 
-                        adapter = create_adapter(
-                            used_deployments_from_lazy(tasks, deployment_m)
-                        )
+                        lazy_register_deployments_for_tasks(tasks, deployment_m)
+                        adapter = create_adapter
+
                         assert_raises Syskit::InternalError do
                             adapter.finalize_deployed_tasks
                         end
@@ -393,9 +392,8 @@ module Syskit
                         )
                         tasks[0].depends_on(tasks.last)
                         tasks[1].depends_on(tasks.last)
-                        adapter = create_adapter(
-                            used_deployments_from_lazy(tasks, deployment_m)
-                        )
+                        lazy_register_deployments_for_tasks(tasks, deployment_m)
+                        adapter = create_adapter
                         adapter.finalize_deployed_tasks
 
                         tasks = @work_plan.find_tasks(task_m).sort_by(&:orocos_name)
@@ -428,9 +426,8 @@ module Syskit
                         )
                         tasks[0].depends_on(tasks.last)
                         tasks[1].depends_on(tasks.last)
-                        adapter = create_adapter(
-                            used_deployments_from_lazy(tasks, deployment_m)
-                        )
+                        lazy_register_deployments_for_tasks(tasks, deployment_m)
+                        adapter = create_adapter
                         adapter.finalize_deployed_tasks
 
                         tasks = @work_plan.find_tasks(task_m).sort_by(&:orocos_name)
@@ -464,9 +461,9 @@ module Syskit
                         )
                         tasks[0].depends_on(tasks.last)
                         tasks[1].depends_on(tasks.last)
-                        adapter = create_adapter(
-                            used_deployments_from_lazy(tasks, deployment_m)
-                        )
+                        lazy_register_deployments_for_tasks(tasks, deployment_m)
+                        adapter = create_adapter
+
                         adapter.finalize_deployed_tasks
 
                         tasks = @work_plan.find_tasks(task_m).sort_by(&:orocos_name)
@@ -512,7 +509,7 @@ module Syskit
             describe "#reconfigure_tasks_on_static_port_modification" do
                 before do
                     @adapter = RuntimeNetworkAdaptation.new(
-                        @work_plan, {}, merge_solver: @merge_solver
+                        @work_plan, merge_solver: @merge_solver
                     )
                 end
 
@@ -588,7 +585,7 @@ module Syskit
                         .pass_thru
                     work_plan.add(@deployment_task = EngineTestStubDeployment.new(task_m))
                     @adapter = RuntimeNetworkAdaptation.new(
-                        @work_plan, {}, merge_solver: @merge_solver
+                        @work_plan, merge_solver: @merge_solver
                     )
                 end
 
@@ -687,7 +684,7 @@ module Syskit
                     task1.should_configure_after(task0.stop_event)
                     task0 = work_plan[task0]
                     task1 = work_plan[task1]
-                    adapter = create_adapter([])
+                    adapter = create_adapter
                     assert_equal task1, adapter.find_current_deployed_task([task0, task1])
                 end
 
@@ -700,7 +697,7 @@ module Syskit
                     execute { plan.garbage_task(task0) }
                     task0 = work_plan[task0]
                     task1 = work_plan[task1]
-                    adapter = create_adapter([])
+                    adapter = create_adapter
                     assert_equal task1, adapter.find_current_deployed_task([task0, task1])
                 end
 
@@ -713,36 +710,34 @@ module Syskit
                     task1.do_not_reuse
                     task0 = work_plan[task0]
                     task1 = work_plan[task1]
-                    adapter = create_adapter([])
+                    adapter = create_adapter
                     assert_equal task1, adapter.find_current_deployed_task([task0, task1])
                 end
             end
 
-            def create_adapter(used_deployments)
-                RuntimeNetworkAdaptation.new(work_plan, used_deployments,
-                                             merge_solver: @merge_solver)
+            def create_adapter
+                RuntimeNetworkAdaptation.new(work_plan, merge_solver: @merge_solver)
             end
 
-            def used_deployments_from_tasks(tasks)
+            def register_deployments_for_tasks(tasks)
                 configured_deployments = tasks.each_with_object({}) do |task, per_name|
                     name = task.execution_agent.process_name
                     per_name[name] ||= flexmock(process_name: name)
                 end
 
-                tasks.each_with_object({}) do |task, used_deployments|
+                tasks.each do |task|
                     name = task.execution_agent.process_name
-                    used_deployments[task] = flexmock(
-                        configured_deployment: configured_deployments.fetch(name)
-                    )
+                    task.deployed_task = 
+                        flexmock(configured_deployment: configured_deployments.fetch(name))
                 end
             end
 
-            def used_deployments_from_lazy(tasks, deployment_m)
+            def lazy_register_deployments_for_tasks(tasks, deployment_m)
                 configured_deployment = Models::ConfiguredDeployment.new(
                     "localhost", deployment_m
                 )
-                tasks.each_with_object({}) do |task, used_deployments|
-                    used_deployments[task] =
+                tasks.each_with_object({}) do |task, _used_deployments|
+                    task.deployed_task =
                         flexmock(configured_deployment: configured_deployment)
                 end
             end

--- a/test/network_generation/test_system_network_generator.rb
+++ b/test/network_generation/test_system_network_generator.rb
@@ -488,9 +488,7 @@ module Syskit
                             )
                             required_instances =
                                 Hash[requirement_tasks.zip(toplevel_tasks)]
-                            errors = error_handler.process_failures(
-                                required_instances, cleanup_failed_tasks: true
-                            )
+                            errors = error_handler.process_failures(required_instances)
                             [toplevel_tasks, errors]
                         end
                     end

--- a/test/network_generation/test_system_network_generator.rb
+++ b/test/network_generation/test_system_network_generator.rb
@@ -236,7 +236,7 @@ module Syskit
                         default_deployment_group: Models::DeploymentGroup.new,
                         early_deploy: true, lazy_deploy: true
                     )
-                    toplevel_tasks, = local_net_gen.compute_system_network(
+                    toplevel_tasks = local_net_gen.compute_system_network(
                         [task_m.to_instance_requirements
                                .use_deployment(deployment_m)],
                         validate_deployed_network: true

--- a/test/network_generation/test_system_network_generator.rb
+++ b/test/network_generation/test_system_network_generator.rb
@@ -444,6 +444,10 @@ module Syskit
 
                         expected_message = <<~MSG
                             deployed task 'task1' from deployment 'task1' defined in '' on 'stubs' is assigned to 2 tasks. Below is the list of the dependent non-deployed actions. Right after the list is a detailed explanation of why the first two tasks are not merged:
+                            T<id:X>(arg: 1, conf: ["default"], orocos_name: task1, read_only: false) is needed by the following definitions:
+                              #<Class:0xXXXXXX>.use( task => T .with_arguments( arg => 1 )
+                            T<id:X>(arg: 2, conf: ["default"], orocos_name: task1, read_only: false) is needed by the following definitions:
+                              #<Class:0xXXXXXX>.use( task => T .with_arguments( arg => 2 )
                             Chain 1 cannot be merged in chain 2:
                             Chain 1:
                               T<id:X> pending

--- a/test/test_task_context.rb
+++ b/test/test_task_context.rb
@@ -1497,12 +1497,23 @@ module Syskit
                     emit dev_driver.start_event
                 end
             end
+            bus_msgs = messages.find_all do |m|
+                m.include?("bus_task") || m.include?("BusDriver")
+            end
+            dev_msgs = messages.find_all do |m|
+                m.include?("dev_task") ||
+                    (m.include?("Driver") && !m.include?("BusDriver"))
+            end
+
             assert_equal ["applied configuration [\"default\"] to #{bus_driver.orocos_name}",
                           "setting up #{bus_driver}",
-                          "starting #{bus_driver}",
-                          "applied configuration [\"default\"] to #{dev_driver.orocos_name}",
+                          "starting #{bus_driver}"], bus_msgs
+            assert_equal ["applied configuration [\"default\"] to #{dev_driver.orocos_name}",
                           "setting up #{dev_driver}",
-                          "starting #{dev_driver}"], messages
+                          "starting #{dev_driver}"], dev_msgs
+
+            assert_operator messages.index("starting #{bus_driver}"), :<,
+                            messages.index("starting #{dev_driver}")
         end
 
         describe "transaction commit" do


### PR DESCRIPTION
There were two different scenarios where we got the same kind of error, which looked like this:

```
NoMethodError: undefined method `[]' for nil:NilClass
    /home/jhonas/dev/wetpaint/tools/roby/lib/roby/relations/space.rb:340:in `block (2 levels) in relation'
    /home/jhonas/dev/wetpaint/tools/syskit/lib/syskit/network_generation/runtime_network_adaptation.rb:454:in `adapt_existing_deployment'
    /home/jhonas/dev/wetpaint/tools/syskit/lib/syskit/network_generation/runtime_network_adaptation.rb:177:in `handle_required_deployment'
    /home/jhonas/dev/wetpaint/tools/syskit/lib/syskit/network_generation/runtime_network_adaptation.rb:129:in `block in finalize_used_deployments'
    /home/jhonas/dev/wetpaint/tools/syskit/lib/syskit/network_generation/runtime_network_adaptation.rb:127:in `each'
    /home/jhonas/dev/wetpaint/tools/syskit/lib/syskit/network_generation/runtime_network_adaptation.rb:127:in `finalize_used_deployments'
    /home/jhonas/dev/wetpaint/tools/syskit/lib/syskit/network_generation/runtime_network_adaptation.rb:66:in `finalize_deployed_tasks'
    /home/jhonas/dev/wetpaint/tools/syskit/lib/syskit/network_generation/runtime_network_adaptation.rb:40:in `apply'
    /home/jhonas/dev/wetpaint/tools/syskit/lib/syskit/network_generation/engine.rb:186:in `block in apply_deployed_network_to_plan'
    /home/jhonas/dev/wetpaint/tools/roby/lib/roby/event_logging/mixin.rb:43:in `log_timepoint_group'
    /home/jhonas/dev/wetpaint/tools/syskit/lib/syskit/network_generation/engine.rb:179:in `apply_deployed_network_to_plan'
    /home/jhonas/dev/wetpaint/tools/syskit/lib/syskit/network_generation/engine.rb:613:in `block in apply_system_network_to_plan'
    /home/jhonas/dev/wetpaint/tools/roby/lib/roby/event_logging/mixin.rb:43:in `log_timepoint_group'
    /home/jhonas/dev/wetpaint/tools/syskit/lib/syskit/network_generation/engine.rb:612:in `apply_system_network_to_plan'
    /home/jhonas/dev/wetpaint/tools/syskit/lib/syskit/network_generation/engine.rb:587:in `resolve'
    /home/jhonas/dev/wetpaint/tools/syskit/test/network_generation/test_engine.rb:737:in `block (4 levels) in <module:NetworkGeneration>'
```


That happened because we were removing tasks from the plan due to a resolution error during the #apply_deployed_network_to_plan step, but we never removed them from the used_deployments, therefore the system was still trying to solve for tasks that were not in the plan anymore.