### PR TITLE
fix: explicitly remove deployments with no deployed tasks before network adaptation

### DIFF
--- a/lib/syskit/network_generation/runtime_network_adaptation.rb
+++ b/lib/syskit/network_generation/runtime_network_adaptation.rb
@@ -44,6 +44,7 @@ module Syskit
             end
 
             def apply
+                cleanup_dangling_deployments
                 result = finalize_deployed_tasks
                 sever_old_plan_from_new_plan
                 log_timepoint "syskit-netgen:sever-old-from-new-plan"
@@ -601,6 +602,25 @@ module Syskit
                 used_deployments_with_existing.each do |used, existing, _|
                     debug "    network:  #{used}"
                     debug "    existing: #{existing}"
+                end
+            end
+
+            # Remove all non-proxy deployments that have no deployed tasks
+            #
+            # When doing early deploy, we may get "leftover" deployments after error
+            # cleanup: the tasks have been removed, but the deployments stay. These
+            # deployments are not processed during adaptation. We instead remove them
+            # explicitly
+            def cleanup_dangling_deployments
+                graph =
+                    @work_plan
+                    .task_relation_graph_for(Roby::TaskStructure::ExecutionAgent)
+                dangling = @work_plan.find_tasks(Syskit::Deployment).find_all do |t|
+                    !t.transaction_proxy? && graph.root?(t)
+                end
+
+                dangling.each do |t|
+                    @work_plan.remove_task(t)
                 end
             end
         end

--- a/test/network_generation/test_engine.rb
+++ b/test/network_generation/test_engine.rb
@@ -748,6 +748,43 @@ module Syskit
                                            e.original_exception
                         end
                     end
+
+                    it "does not create deployment duplicates when all deployed tasks " \
+                       "of a deployment have been cleaned up because of an error" do
+                        # Regression test for a bug that was caused by "dangling"
+                        # deployments, that is deployments that had no deployed tasks,
+                        # caused by error cleanup.
+                        #
+                        # The (then new) adaptation code would simply ignore these
+                        # deployments as it would only iterate over the deployments
+                        # from its deployed tasks.
+                        t1 = @task_m.with_arguments(arg: 1).as_plan
+                        plan.add_mission_task(t1)
+
+                        t1 = t1.as_service
+                        engine = Syskit::NetworkGeneration::Engine.new(plan)
+                        engine.resolve(
+                            requirement_tasks: [t1.planning_task],
+                            default_deployment_group: default_deployment_group,
+                            capture_errors_during_network_resolution: true,
+                            early_deploy: true,
+                            cleanup_resolution_errors: true
+                        )
+
+                        t2 = @task_m.with_arguments(arg: 2).as_plan
+                        plan.add(t2)
+
+                        engine = Syskit::NetworkGeneration::Engine.new(plan)
+                        engine.resolve(
+                            requirement_tasks: [t1.planning_task, t2.planning_task],
+                            default_deployment_group: default_deployment_group,
+                            capture_errors_during_network_resolution: true,
+                            early_deploy: true,
+                            cleanup_resolution_errors: true
+                        )
+
+                        assert_equal 1, plan.find_tasks(Syskit::Deployment).to_a.size
+                    end
                 end
             end
 


### PR DESCRIPTION
With early_deploy: true and lazy_deploy: false, the system network might contain deployments that have no deployed tasks, when the tasks have been removed by error handling

RuntimeNetworkAdaptation will not "see" these deployments during adaptation, as it iterates over the tasks. They end up in the final transaction and we get duplicate deployments.

This commit fixes the problem by explicitly removing these deployments at the beginning of {#apply}

Note that I could have "solved" it at the end of the network generation step, but IMO that makes little sense. In a way, the system network generated is valid. It is the runtime network adaptation that cannot handle a well-formed plan as-is.