### PR TITLE
fix: handle cmp child-loss when managing dynamic port bindings

### DIFF
--- a/lib/syskit/dynamic_port_binding.rb
+++ b/lib/syskit/dynamic_port_binding.rb
@@ -336,18 +336,18 @@ module Syskit
 
         # @api private
         #
-        # Resolver object that returns a port from a composition
+        # Resolver object that returns a port from a component
         class ComponentPortResolver
             def initialize(port)
                 @port = port
             end
 
-            def current_selection_valid?(port)
-                !!port.component.plan
+            def current_selection_valid?(_port)
+                false
             end
 
             def update
-                @port if @port.component.plan
+                @port if @port.component.plan && !@port.component.finished?
             end
 
             def self.instanciate(task, model)
@@ -360,22 +360,33 @@ module Syskit
         # Resolver object that resolves a port from a composition child,
         # and returns it until the underlying task is finalized
         class CompositionChildPortResolver
-            def initialize(port)
-                @port = port
+            def initialize(task, model)
+                @task = task
+                @model = model
             end
 
-            def current_selection_valid?(port)
-                !!port.component.to_task.plan
+            def current_selection_valid?(_port)
+                # current_selection_valid? is an optimization to avoid calling
+                # `update`. But in this particular case, `current_selection_valid?`
+                # will be as expensive as `update` ...
+                false
             end
 
             def update
-                @port if @port.component.to_task.plan
+                child = @model.port_model.component_model
+                              .try_resolve_and_bind_child_recursive(@task)
+                return unless child
+
+                child_task = child.to_task
+                return if child_task.finished? || !child_task.plan
+                return @port if @current_child == child
+
+                @current_child = child
+                @port = @model.port_model.bind(child)
             end
 
             def self.instanciate(task, model)
-                child = model.port_model.component_model
-                             .resolve_and_bind_child_recursive(task)
-                new(model.port_model.bind(child))
+                new(task, model)
             end
         end
     end

--- a/test/test_dynamic_port_binding.rb
+++ b/test/test_dynamic_port_binding.rb
@@ -454,6 +454,81 @@ module Syskit
                 assert_equal [false, nil], @port_binding.update
             end
         end
+
+        describe "#update behavior for compositions that handle child loss cleanly" do
+            before do
+                @srv_m = Syskit::DataService.new_submodel do
+                    output_port "srv_out", "/double"
+                end
+                @task_m = Syskit::TaskContext.new_submodel do
+                    output_port "out", "/double"
+                end
+                @task_m.provides @srv_m, as: "test"
+            end
+
+            it "returns [true, nil] when a child is removed from the composition" do
+                srv_m = @srv_m
+                cmp_m = Syskit::Composition.new_submodel do
+                    add srv_m, as: "test"
+                end
+                cmp = syskit_stub_and_deploy(
+                    cmp_m.use("test" => @task_m),
+                    remote_task: false
+                )
+                port_binding_m =
+                    Models::DynamicPortBinding
+                    .create_from_component_port(cmp_m.test_child.srv_out_port)
+                port_binding = port_binding_m.instanciate.attach_to_task(cmp)
+                syskit_configure_and_start(cmp)
+                port_binding.update
+
+                cmp.remove_child(cmp.test_child)
+                assert_equal [true, nil], port_binding.update
+            end
+
+            it "returns [true, nil] when a child is finished" do
+                srv_m = @srv_m
+                cmp_m = Syskit::Composition.new_submodel do
+                    add(srv_m, as: "test")
+                end
+                cmp = syskit_stub_and_deploy(
+                    cmp_m.use("test" => @task_m), remote_task: false
+                )
+                port_binding_m =
+                    Models::DynamicPortBinding
+                    .create_from_component_port(cmp_m.test_child.srv_out_port)
+                port_binding = port_binding_m.instanciate.attach_to_task(cmp)
+                syskit_configure_and_start(cmp)
+                port_binding.update
+
+                test_child = cmp.test_child
+                flexmock(test_child).should_receive(:finished?).and_return(true)
+                assert test_child.finished?
+
+                assert_equal [true, nil], port_binding.update
+            end
+
+            it "returns [true, port] when the underlying child changes" do
+                srv_m = @srv_m
+                cmp_m = Syskit::Composition.new_submodel do
+                    add(srv_m, as: "test")
+                end
+                cmp = syskit_stub_and_deploy(
+                    cmp_m.use("test" => @task_m), remote_task: false
+                )
+                port_binding_m =
+                    Models::DynamicPortBinding
+                    .create_from_component_port(cmp_m.test_child.srv_out_port)
+                port_binding = port_binding_m.instanciate.attach_to_task(cmp)
+                syskit_configure_and_start(cmp)
+
+                cmp.remove_child(cmp.test_child)
+                task = syskit_stub_deploy_configure_and_start(@task_m)
+                cmp.depends_on(task, role: "test")
+
+                assert_equal [true, task.out_port], port_binding.update
+            end
+        end
     end
 
     describe DynamicPortBinding::Accessor do


### PR DESCRIPTION
Since its possible for one to create compositions that remove children and stay running, the port bindings should support this as well. When a  child is removed from a cmp or is finished, the port bindings should be disconnected as well.