### PR TITLE
fix: exception reporting that raise in early/lazy deploy modes

### DIFF
--- a/lib/syskit/exceptions.rb
+++ b/lib/syskit/exceptions.rb
@@ -441,11 +441,15 @@ module Syskit
             !!@can_merge
         end
 
-        def initialize(device, task0, task1, toplevel_tasks_to_requirements = {})
+        def initialize(
+            device, task0, task1, toplevel_tasks_to_requirements = {},
+            early_deploy:
+        )
             @device = device
             @tasks = [task0, task1]
             @merge_result = NetworkGeneration::MergeSolver.resolve_merge(
-                tasks[0].plan, tasks[0], tasks[1], {}
+                tasks[0].plan, tasks[0], tasks[1], {},
+                merge_task_contexts_with_same_agent: early_deploy
             )
 
             @involved_definitions = @tasks.map do |t|
@@ -469,14 +473,17 @@ module Syskit
 
         attr_reader :orocos_name
 
-        def initialize(orocos_name, tasks, toplevel_tasks_to_requirements = {})
+        def initialize(
+            orocos_name, tasks, toplevel_tasks_to_requirements = {}, early_deploy:
+        )
             @orocos_name = orocos_name
             @tasks = tasks
             @toplevel_tasks_to_requirements = toplevel_tasks_to_requirements
 
             @configured_deployment = tasks.first.deployed_task.configured_deployment
             @merge_result = NetworkGeneration::MergeSolver.resolve_merge(
-                tasks[0].plan, tasks[0], tasks[1], {}
+                tasks[0].plan, tasks[0], tasks[1], {},
+                merge_task_contexts_with_same_agent: early_deploy
             )
         end
 

--- a/lib/syskit/exceptions.rb
+++ b/lib/syskit/exceptions.rb
@@ -473,18 +473,20 @@ module Syskit
             @orocos_name = orocos_name
             @tasks = tasks
             @toplevel_tasks_to_requirements = toplevel_tasks_to_requirements
-            @agent = tasks.first.execution_agent
+
+            @configured_deployment = tasks.first.deployed_task.configured_deployment
             @merge_result = NetworkGeneration::MergeSolver.resolve_merge(
                 tasks[0].plan, tasks[0], tasks[1], {}
             )
         end
 
         def pretty_print(pp)
-            deployment_m = @agent.deployed_orogen_model_by_name(orocos_name)
+            deployment_m = @configured_deployment.model.orogen_model
+            process_server_name = @configured_deployment.process_server_name
             pp.text(
                 "deployed task '#{orocos_name}' from deployment " \
                 "'#{deployment_m.name}' defined in " \
-                "'#{deployment_m.project.name}' on '#{@agent.process_server_name}' " \
+                "'#{deployment_m.project.name}' on '#{process_server_name}' " \
                 "is assigned to #{@tasks.size} tasks. Below is the list of " \
                 "the dependent non-deployed actions. Right after the list " \
                 "is a detailed explanation of why the first two tasks are not merged:"

--- a/lib/syskit/network_generation/engine.rb
+++ b/lib/syskit/network_generation/engine.rb
@@ -114,6 +114,7 @@ module Syskit
                 required_instances: [],
                 default_deployment_group: Syskit.conf.deployment_group,
                 compute_policies: true,
+                early_deploy: Syskit.conf.early_deploy?,
                 lazy_deploy: Syskit.conf.lazy_deploy?,
                 validate_deployed_network: true
             )
@@ -139,7 +140,8 @@ module Syskit
                         work_plan, default_deployment_group, lazy: lazy_deploy
                     )
                     SystemNetworkGenerator.verify_all_deployments_are_unique(
-                        work_plan, toplevel_tasks_to_requirements.dup
+                        work_plan, toplevel_tasks_to_requirements.dup,
+                        early_deploy: early_deploy
                     )
                 end
 
@@ -499,6 +501,7 @@ module Syskit
                                 required_instances: required_instances,
                                 default_deployment_group: default_deployment_group,
                                 compute_policies: compute_policies,
+                                early_deploy: early_deploy,
                                 lazy_deploy: lazy_deploy,
                                 validate_deployed_network: validate_deployed_network
                             )

--- a/lib/syskit/network_generation/merge_solver.rb
+++ b/lib/syskit/network_generation/merge_solver.rb
@@ -39,7 +39,8 @@ module Syskit
             def initialize(
                 plan,
                 event_logger: plan.event_logger,
-                resolution_control: Async::Control.new
+                resolution_control: Async::Control.new,
+                merge_task_contexts_with_same_agent: false
             )
                 @plan = plan
                 @event_logger = event_logger
@@ -49,7 +50,7 @@ module Syskit
                 @task_replacement_graph = Roby::Relations::BidirectionalDirectedAdjacencyGraph.new
                 @resolved_replacements = {}
                 @invalid_merges = Set.new
-                @merge_task_contexts_with_same_agent = false
+                @merge_task_contexts_with_same_agent = merge_task_contexts_with_same_agent
                 @resolution_control = resolution_control
             end
 
@@ -212,8 +213,14 @@ module Syskit
 
             # Create a new solver on the given plan and perform
             # {#merge_identical_tasks}
-            def self.merge_identical_tasks(plan)
-                solver = MergeSolver.new(plan)
+            def self.merge_identical_tasks(
+                plan, merge_task_contexts_with_same_agent: false
+            )
+                solver = MergeSolver.new(
+                    plan,
+                    merge_task_contexts_with_same_agent:
+                        merge_task_contexts_with_same_agent
+                )
                 solver.merge_identical_tasks
             end
 
@@ -516,8 +523,15 @@ module Syskit
                 end
             end
 
-            def self.resolve_merge(plan, merged_task, task, mappings)
-                solver = MergeSolver.new(plan)
+            def self.resolve_merge(
+                plan, merged_task, task, mappings,
+                merge_task_contexts_with_same_agent: false
+            )
+                solver = MergeSolver.new(
+                    plan,
+                    merge_task_contexts_with_same_agent:
+                        merge_task_contexts_with_same_agent
+                )
                 solver.resolve_merge(merged_task, task, mappings)
             end
 

--- a/lib/syskit/network_generation/system_network_generator.rb
+++ b/lib/syskit/network_generation/system_network_generator.rb
@@ -337,12 +337,14 @@ module Syskit
             # Compute in #plan the network needed to fullfill the requirements
             #
             # This network is neither validated nor tied to actual deployments
-            def compute_system_network(instance_requirements,
+            def compute_system_network( # rubocop:disable Metrics/ParameterLists
+                instance_requirements,
+                error_handler: RaiseErrorHandler.new,
                 garbage_collect: true,
                 validate_abstract_network: true,
                 validate_generated_network: true,
-                validate_deployed_network: true)
-                error_handler = RaiseErrorHandler.new
+                validate_deployed_network: true
+            )
                 instanciate_system_network(instance_requirements)
                 resolve_system_network(
                     error_handler: error_handler,
@@ -363,12 +365,12 @@ module Syskit
                 end
 
                 if validate_generated_network
-                    self.validate_generated_network(error_handler: error_handler)
+                    validate_generated_network(error_handler: error_handler)
                     log_timepoint "syskit-netgen:validate_generated_network"
                 end
                 return unless early_deploy? && validate_deployed_network
 
-                self.validate_deployed_network(error_handler: error_handler)
+                validate_deployed_network(error_handler: error_handler)
                 log_timepoint "syskit-netgen:validate_deployed_network"
             end
 
@@ -445,7 +447,7 @@ module Syskit
             #   components due to a conflicting device allocation
             def self.verify_conflicting_device_allocation(
                 components, toplevel_tasks_to_requirements = {},
-                error_handler: RaiseErrorHandler.new
+                early_deploy:, error_handler: RaiseErrorHandler.new
             )
                 devices = {}
                 components.each do |task|
@@ -453,7 +455,8 @@ module Syskit
                         device_name = dev.full_name
                         if (old_task = devices[device_name])
                             allocation_err = ConflictingDeviceAllocation.new(
-                                dev, task, old_task, toplevel_tasks_to_requirements
+                                dev, task, old_task, toplevel_tasks_to_requirements,
+                                early_deploy: early_deploy
                             )
                             error_handler.register_resolution_failures_from_exception(
                                 [task, old_task], allocation_err
@@ -481,7 +484,7 @@ module Syskit
             #   components due to bad device allocation
             def self.verify_device_allocation(
                 plan, toplevel_tasks_to_requirements = {},
-                error_handler: RaiseErrorHandler.new
+                early_deploy:, error_handler: RaiseErrorHandler.new
             )
                 components = plan.find_local_tasks(Syskit::Device).to_a
 
@@ -504,12 +507,13 @@ module Syskit
 
                 verify_conflicting_device_allocation(
                     allocated_devices, toplevel_tasks_to_requirements,
-                    error_handler: error_handler
+                    error_handler: error_handler, early_deploy: early_deploy
                 )
             end
 
             def self.verify_all_deployments_are_unique(
-                plan, toplevel_tasks_to_requirements, error_handler: RaiseErrorHandler.new
+                plan, toplevel_tasks_to_requirements,
+                early_deploy:, error_handler: RaiseErrorHandler.new
             )
                 deployment_to_task_map = plan.find_local_tasks(Syskit::TaskContext)
                                              .group_by(&:orocos_name)
@@ -523,7 +527,8 @@ module Syskit
 
                 using_same_deployment.each do |orocos_name, tasks|
                     exception = ConflictingDeploymentAllocation.new(
-                        orocos_name, tasks, toplevel_tasks_to_requirements
+                        orocos_name, tasks, toplevel_tasks_to_requirements,
+                        early_deploy: early_deploy
                     )
                     exception = exception.exception("deployment used multiple times")
                     error_handler.register_resolution_failures_from_exception(
@@ -546,7 +551,8 @@ module Syskit
                 self.class.verify_task_allocation(plan, error_handler: error_handler)
 
                 self.class.verify_device_allocation(
-                    plan, toplevel_tasks_to_requirements, error_handler: error_handler
+                    plan, toplevel_tasks_to_requirements,
+                    early_deploy: early_deploy?, error_handler: error_handler
                 )
                 super if defined? super
             end
@@ -557,7 +563,8 @@ module Syskit
                     error_handler: error_handler, lazy: lazy_deploy?
                 )
                 self.class.verify_all_deployments_are_unique(
-                    plan, toplevel_tasks_to_requirements.dup, error_handler: error_handler
+                    plan, toplevel_tasks_to_requirements.dup,
+                    error_handler: error_handler, early_deploy: early_deploy?
                 )
                 super if defined? super
             end

--- a/lib/syskit/network_generation/system_network_generator.rb
+++ b/lib/syskit/network_generation/system_network_generator.rb
@@ -33,9 +33,9 @@ module Syskit
 
             def initialize(plan, # rubocop:disable Metrics/ParameterLists
                 event_logger: plan.event_logger,
-                default_deployment_group: nil,
-                early_deploy: false,
-                lazy_deploy: false,
+                default_deployment_group: Syskit.conf.deployment_group,
+                early_deploy: Syskit.conf.early_deploy?,
+                lazy_deploy: Syskit.conf.lazy_deploy?,
                 error_handler: RaiseErrorHandler.new,
                 resolution_control: Async::Control.new,
                 merge_solver: nil)
@@ -236,7 +236,8 @@ module Syskit
                 network_deployer = SystemNetworkDeployer.new(
                     plan,
                     merge_solver: merge_solver,
-                    default_deployment_group: default_deployment_group
+                    default_deployment_group: default_deployment_group,
+                    resolution_control: @resolution_control
                 )
 
                 network_deployer.deploy(

--- a/test/network_generation/test_system_network_generator.rb
+++ b/test/network_generation/test_system_network_generator.rb
@@ -13,7 +13,12 @@ module Syskit
                     @requirements = component_m.to_instance_requirements
                 end
 
-                subject { SystemNetworkGenerator.new(Roby::Plan.new) }
+                subject do
+                    SystemNetworkGenerator.new(
+                        Roby::Plan.new,
+                        default_deployment_group: default_deployment_group
+                    )
+                end
 
                 it "adds instanciated tasks as permanent tasks" do
                     flexmock(requirements).should_receive(:instanciate)
@@ -80,7 +85,13 @@ module Syskit
                     @task = cmp.test_child
                 end
 
-                subject { SystemNetworkGenerator.new(Roby::ExecutablePlan.new) }
+                subject do
+                    SystemNetworkGenerator.new(
+                        Roby::ExecutablePlan.new,
+                        default_deployment_group: default_deployment_group
+                    )
+                end
+
                 it "sets missing devices from its selections" do
                     task.requirements.push_dependency_injection(Syskit::DependencyInjection.new(dev_m => device))
                     subject.allocate_devices(task)
@@ -101,15 +112,20 @@ module Syskit
             end
 
             describe "#compute_system_network" do
+                subject do
+                    SystemNetworkGenerator.new(
+                        Roby::ExecutablePlan.new,
+                        default_deployment_group: default_deployment_group
+                    )
+                end
+
                 it "runs the validate_abstract_network handler if asked to" do
-                    generator = SystemNetworkGenerator.new(plan)
-                    flexmock(generator).should_receive(:validate_abstract_network).once
-                    generator.compute_system_network([], validate_abstract_network: true)
+                    flexmock(subject).should_receive(:validate_abstract_network).once
+                    subject.compute_system_network([], validate_abstract_network: true)
                 end
                 it "runs the validate_generated_network handler if asked to" do
-                    generator = SystemNetworkGenerator.new(plan)
-                    flexmock(generator).should_receive(:validate_generated_network).once
-                    generator.compute_system_network([], validate_generated_network: true)
+                    flexmock(subject).should_receive(:validate_generated_network).once
+                    subject.compute_system_network([], validate_generated_network: true)
                 end
 
                 describe "early deploy" do
@@ -232,17 +248,18 @@ module Syskit
                     end
 
                     local_net_gen = SystemNetworkGenerator.new(
-                        Roby::Plan.new,
+                        plan = Roby::Plan.new,
                         default_deployment_group: Models::DeploymentGroup.new,
-                        early_deploy: true, lazy_deploy: true
+                        early_deploy: true
                     )
-                    toplevel_tasks = local_net_gen.compute_system_network(
+                    local_net_gen.compute_system_network(
                         [task_m.to_instance_requirements
                                .use_deployment(deployment_m)],
                         validate_deployed_network: true
                     )
+                    task = plan.find_tasks(task_m).not_abstract.first
                     assert_equal(
-                        "Periodic", toplevel_tasks.first.orogen_model.activity_type.name
+                        "Periodic", task.orogen_model.activity_type.name
                     )
                 end
 
@@ -452,17 +469,17 @@ module Syskit
                             Chain 1:
                               T<id:X> pending
                                 arguments:
-                                  orocos_name: "task1",
-                                  read_only: false,
+                                  arg: 1,
                                   conf: ["default"],
-                                  arg: 1
+                                  read_only: false,
+                                  orocos_name: "task1"
                             Chain 2:
                               T<id:X> pending
                                 arguments:
-                                  orocos_name: "task1",
-                                  read_only: false,
+                                  arg: 2,
                                   conf: ["default"],
-                                  arg: 2
+                                  read_only: false,
+                                  orocos_name: "task1"
                         MSG
                         errors.zip(requirement_tasks).each do |error, task|
                             assert_exception(error, task.planned_task, expected_message)
@@ -533,7 +550,12 @@ module Syskit
                         task_m.provides srv_m, as: "test"
                     end
 
-                    subject { SystemNetworkGenerator.new(plan) }
+                    subject do
+                        SystemNetworkGenerator.new(
+                            plan,
+                            default_deployment_group: default_deployment_group
+                        )
+                    end
 
                     def compute_system_network(*requirements)
                         requirements = requirements.map(&:to_instance_requirements)
@@ -544,6 +566,7 @@ module Syskit
                     end
 
                     it "keeps the compositions' optional dependencies that are not abstract" do
+                        syskit_stub_configured_deployment(task_m)
                         cmp = compute_system_network(cmp_m.use("test" => task_m))
                         assert cmp.has_role?("test")
                     end
@@ -554,13 +577,20 @@ module Syskit
                     end
                     it "removes the compositions' optional dependencies that are still abstract" do
                         cmp = compute_system_network(cmp_m)
-                        assert !cmp.has_role?("test")
+                        refute cmp.has_role?("test")
                     end
                     it "enables the use of the abstract flag in InstanceRequirements to use an optional dep only if it is instanciated by other means" do
-                        cmp = compute_system_network(cmp_m.use("test" => task_m.to_instance_requirements.abstract))
+                        syskit_stub_configured_deployment(task_m)
+                        cmp = compute_system_network(
+                            cmp_m.use("test" => task_m.to_instance_requirements.abstract)
+                        )
                         refute cmp.has_role?("test")
                         execute { plan.remove_task(cmp) }
-                        cmp = compute_system_network(cmp_m.use("test" => task_m.to_instance_requirements.abstract), task_m)
+
+                        cmp = compute_system_network(
+                            cmp_m.use("test" => task_m.to_instance_requirements.abstract),
+                            task_m
+                        )
                         assert cmp.has_role?("test")
                     end
                 end

--- a/test/network_generation/test_system_network_generator.rb
+++ b/test/network_generation/test_system_network_generator.rb
@@ -307,45 +307,45 @@ module Syskit
                               T<id:X> pending
                                 arguments:
                                   arg: 2,
-                                  test_dev: MasterDeviceInstance(test[D]_dev),
                                   conf: ["default"],
-                                  read_only: false
+                                  read_only: false,
+                                  test_dev: MasterDeviceInstance(test[D]_dev)
                             Chain 2:
                               T<id:X> pending
                                 arguments:
                                   arg: 1,
-                                  test_dev: MasterDeviceInstance(test[D]_dev),
                                   conf: ["default"],
-                                  read_only: false
+                                  read_only: false,
+                                  test_dev: MasterDeviceInstance(test[D]_dev)
                             T<id:X>(arg: 2, conf: ["default"], read_only: false, test_dev: device(D, as: test)) is needed by the following definitions:
                               #<Class:0xXXXXXX>.use(
                                 t1 => T<id:X> pending
                                   arguments:
                                     arg: 1,
-                                    test_dev: MasterDeviceInstance(test[D]_dev),
                                     conf: ["default"],
                                     read_only: false,
+                                    test_dev: MasterDeviceInstance(test[D]_dev),
                                 t2 => T<id:X> pending
                                   arguments:
                                     arg: 2,
-                                    test_dev: MasterDeviceInstance(test[D]_dev),
                                     conf: ["default"],
-                                    read_only: false
+                                    read_only: false,
+                                    test_dev: MasterDeviceInstance(test[D]_dev)
                               )
                             T<id:X>(arg: 1, conf: ["default"], read_only: false, test_dev: device(D, as: test)) is needed by the following definitions:
                               #<Class:0xXXXXXX>.use(
                                 t1 => T<id:X> pending
                                   arguments:
                                     arg: 1,
-                                    test_dev: MasterDeviceInstance(test[D]_dev),
                                     conf: ["default"],
                                     read_only: false,
+                                    test_dev: MasterDeviceInstance(test[D]_dev),
                                 t2 => T<id:X> pending
                                   arguments:
                                     arg: 2,
-                                    test_dev: MasterDeviceInstance(test[D]_dev),
                                     conf: ["default"],
-                                    read_only: false
+                                    read_only: false,
+                                    test_dev: MasterDeviceInstance(test[D]_dev)
                               )
                         PP
                         errors.each do |err|
@@ -471,15 +471,15 @@ module Syskit
                                 arguments:
                                   arg: 1,
                                   conf: ["default"],
-                                  read_only: false,
-                                  orocos_name: "task1"
+                                  orocos_name: "task1",
+                                  read_only: false
                             Chain 2:
                               T<id:X> pending
                                 arguments:
                                   arg: 2,
                                   conf: ["default"],
-                                  read_only: false,
-                                  orocos_name: "task1"
+                                  orocos_name: "task1",
+                                  read_only: false
                         MSG
                         errors.zip(requirement_tasks).each do |error, task|
                             assert_exception(error, task.planned_task, expected_message)
@@ -628,16 +628,16 @@ module Syskit
                           T<id:X> pending
                             arguments:
                               arg: 2,
-                              test_dev: MasterDeviceInstance(test[D]_dev),
                               conf: default(["default"]),
-                              read_only: default(false)
+                              read_only: default(false),
+                              test_dev: MasterDeviceInstance(test[D]_dev)
                         Chain 2:
                           T<id:X> pending
                             arguments:
                               arg: 1,
-                              test_dev: MasterDeviceInstance(test[D]_dev),
                               conf: default(["default"]),
-                              read_only: default(false)
+                              read_only: default(false),
+                              test_dev: MasterDeviceInstance(test[D]_dev)
                     MSG
                     assert_equal expected, formatted.gsub(/<id:\d+>/, "<id:X>")
                 end

--- a/test/runtime/server/test_spawn_server.rb
+++ b/test/runtime/server/test_spawn_server.rb
@@ -46,7 +46,7 @@ module Syskit
 
                 it "refuses to connect if the server's certificate is unexpected" do
                     invalid_certfile_path = File.join(
-                        __dir__, "..", "remote_processes", "invalid-cert.crt"
+                        __dir__, "..", "..", "process_managers", "invalid-cert.crt"
                     )
 
                     e = assert_raises(OpenSSL::SSL::SSLError) do

--- a/test/test_exceptions.rb
+++ b/test/test_exceptions.rb
@@ -38,16 +38,16 @@ module Syskit
                   T<id:ID> pending
                     arguments:
                       arg: 2,
-                      test_dev: MasterDeviceInstance(test[D]_dev),
                       conf: default(["default"]),
-                      read_only: default(false)
+                      read_only: default(false),
+                      test_dev: MasterDeviceInstance(test[D]_dev)
                 Chain 2:
                   T<id:ID> pending
                     arguments:
                       arg: 1,
-                      test_dev: MasterDeviceInstance(test[D]_dev),
                       conf: default(["default"]),
-                      read_only: default(false)
+                      read_only: default(false),
+                      test_dev: MasterDeviceInstance(test[D]_dev)
             PP
             assert_equal expected, formatted.gsub(/<id:\d+>/, "<id:ID>").chomp
         end
@@ -87,17 +87,17 @@ module Syskit
                 Chain 1:
                   T<id:ID> pending
                     arguments:
-                      test_dev: MasterDeviceInstance(test[D]_dev),
                       arg: 2,
                       conf: ["default"],
-                      read_only: false
+                      read_only: false,
+                      test_dev: MasterDeviceInstance(test[D]_dev)
                 Chain 2:
                   T<id:ID> pending
                     arguments:
-                      test_dev: MasterDeviceInstance(test[D]_dev),
                       arg: 1,
                       conf: ["default"],
-                      read_only: false
+                      read_only: false,
+                      test_dev: MasterDeviceInstance(test[D]_dev)
                 T<id:ID>(arg: 2, conf: ["default"], read_only: false, \
                 test_dev: device(D, as: test)) is needed by the following definitions:
                   Test.test2_def
@@ -142,9 +142,9 @@ module Syskit
                 Chain 1:
                   Driver<id:ID> pending
                     arguments:
-                      test_dev: MasterDeviceInstance(test[D]_dev),
                       conf: default(["default"]),
-                      read_only: default(false)
+                      read_only: default(false),
+                      test_dev: MasterDeviceInstance(test[D]_dev)
                   sink in_port connected via policy {} to source out_port of
                   Task<id:ID> pending
                     arguments:
@@ -154,9 +154,9 @@ module Syskit
                 Chain 2:
                   Driver<id:ID> pending
                     arguments:
-                      test_dev: MasterDeviceInstance(test[D]_dev),
                       conf: default(["default"]),
-                      read_only: default(false)
+                      read_only: default(false),
+                      test_dev: MasterDeviceInstance(test[D]_dev)
                   sink in_port connected via policy {} to source out_port of
                   Task<id:ID> pending
                     arguments:
@@ -196,7 +196,7 @@ module Syskit
                  .instanciate(plan)
 
             merge_solver = NetworkGeneration::MergeSolver.new(
-                plan, merge_task_contexts_with_same_agent: true
+                plan, merge_task_contexts_with_same_agent: Syskit.conf.early_deploy?
             )
             error_handler = NetworkGeneration::ResolutionErrorHandler.new(
                 plan, merge_solver
@@ -218,9 +218,9 @@ module Syskit
                 Chain 1:
                   <id:ID> pending
                     arguments:
+                      conf: default(["default"]),
                       driver_dev: MasterDeviceInstance(stubD[D]_dev),
                       orocos_name: "task",
-                      conf: default(["default"]),
                       read_only: default(false)
                   sink in_port connected via policy {} to source out_port of
                   <id:ID> pending
@@ -230,9 +230,9 @@ module Syskit
                 Chain 2:
                   <id:ID> pending
                     arguments:
+                      conf: default(["default"]),
                       driver_dev: MasterDeviceInstance(stubD[D]_dev),
                       orocos_name: "task",
-                      conf: default(["default"]),
                       read_only: default(false)
                   sink in_port connected via policy {} to source out_port of
                   <id:ID> pending
@@ -306,17 +306,17 @@ module Syskit
                 Chain 1:
                   <id:ID> pending
                     arguments:
-                      orocos_name: "task",
-                      read_only: false,
+                      arg: 1,
                       conf: ["default"],
-                      arg: 1
+                      orocos_name: "task",
+                      read_only: false
                 Chain 2:
                   <id:ID> pending
                     arguments:
-                      orocos_name: "task",
-                      read_only: false,
+                      arg: 2,
                       conf: ["default"],
-                      arg: 2
+                      orocos_name: "task",
+                      read_only: false
             PP
             assert_equal expected, formatted.gsub(/<id:\d+>/, "<id:ID>").chomp
         end
@@ -367,9 +367,9 @@ module Syskit
                 Chain 1:
                   <id:ID> pending
                     arguments:
+                      conf: ["default"],
                       orocos_name: "task",
-                      read_only: false,
-                      conf: ["default"]
+                      read_only: false
                   sink in_port connected via policy {} to source out_port of
                   <id:ID> pending
                     arguments:
@@ -378,9 +378,9 @@ module Syskit
                 Chain 2:
                   <id:ID> pending
                     arguments:
+                      conf: ["default"],
                       orocos_name: "task",
-                      read_only: false,
-                      conf: ["default"]
+                      read_only: false
                   sink in_port connected via policy {} to source out_port of
                   <id:ID> pending
                     arguments:

--- a/test/test_exceptions.rb
+++ b/test/test_exceptions.rb
@@ -166,6 +166,82 @@ module Syskit
             PP
             assert_equal expected, formatted.gsub(/<id:\d+>/, "<id:ID>").chomp
         end
+
+        it "properly sets up the merge solver to compute the failed chains" do
+            # Originally, the merge solver was NOT setup with early_deploy set,
+            # which led the exception to fail on pretty printing in case the merge
+            # was OK with early_deploy: false
+            #
+            # This essentially happens if the conflict appears because of an
+            # input that is not deployed
+            input_task_m = Syskit::TaskContext.new_submodel do
+                output_port "out", "/double"
+            end
+            device_m = Syskit::Device.new_submodel(name: "D")
+            task_m = Syskit::TaskContext.new_submodel do
+                input_port "in", "/double"
+                driver_for device_m, as: "driver"
+            end
+            syskit_stub_configured_deployment(task_m, "task")
+
+            cmp_m = Syskit::Composition.new_submodel
+            cmp_m.add task_m, as: "task"
+            cmp_m.add input_task_m, as: "input"
+            cmp_m.input_child.connect_to cmp_m.task_child
+
+            dev = syskit_stub_device(device_m, as: "stubD")
+            cmp_m.use("task" => dev.with_arguments(orocos_name: "task"))
+                 .instanciate(plan)
+            cmp_m.use("task" => dev.with_arguments(orocos_name: "task"))
+                 .instanciate(plan)
+
+            merge_solver = NetworkGeneration::MergeSolver.new(
+                plan, merge_task_contexts_with_same_agent: true
+            )
+            error_handler = NetworkGeneration::ResolutionErrorHandler.new(
+                plan, merge_solver
+            )
+            NetworkGeneration::SystemNetworkGenerator
+                .new(plan, error_handler: error_handler, early_deploy: true)
+                .validate_generated_network
+
+            failure = error_handler.resolution_failures.find do
+                _1.original_exception.kind_of?(ConflictingDeviceAllocation)
+            end
+            e = failure.original_exception
+            assert e
+            formatted = PP.pp(e, +"")
+
+            expected = <<~PP.chomp
+                device 'stubD' of type D is assigned to two tasks that cannot be merged
+                Chain 1 cannot be merged in chain 2:
+                Chain 1:
+                  <id:ID> pending
+                    arguments:
+                      driver_dev: MasterDeviceInstance(stubD[D]_dev),
+                      orocos_name: "task",
+                      conf: default(["default"]),
+                      read_only: default(false)
+                  sink in_port connected via policy {} to source out_port of
+                  <id:ID> pending
+                    arguments:
+                      conf: default(["default"]),
+                      read_only: default(false)
+                Chain 2:
+                  <id:ID> pending
+                    arguments:
+                      driver_dev: MasterDeviceInstance(stubD[D]_dev),
+                      orocos_name: "task",
+                      conf: default(["default"]),
+                      read_only: default(false)
+                  sink in_port connected via policy {} to source out_port of
+                  <id:ID> pending
+                    arguments:
+                      conf: default(["default"]),
+                      read_only: default(false)
+            PP
+            assert_equal expected, formatted.gsub(/<id:\d+>/, "<id:ID>").chomp
+        end
     end
 
     describe ConflictingDeploymentAllocation do
@@ -176,25 +252,21 @@ module Syskit
         before do
             Roby.app.using_task_library "orogen_syskit_tests"
 
-            task_m = OroGen.orogen_syskit_tests.Empty
-            cmp_m = Syskit::Composition.new_submodel
-            cmp_m.add task_m, as: "task"
+            @task_m = Syskit::TaskContext.new_submodel do
+                input_port "in", "/double"
+                output_port "out", "/double"
+            end
+            syskit_stub_configured_deployment(@task_m, "task")
 
+            @cmp_m = Syskit::Composition.new_submodel
+            @cmp_m.add(@task_m, as: "task")
+
+            @net_gen_plan = Roby::Plan.new
             @net_gen = NetworkGeneration::SystemNetworkGenerator.new(
-                @net_gen_plan = Roby::Plan.new,
-                default_deployment_group: default_deployment_group,
-                early_deploy: true
-            )
-            @net_gen.default_deployment_group.use_deployment(
-                OroGen::Deployments.syskit_tests_empty => "test_"
+                @net_gen_plan,
+                default_deployment_group: default_deployment_group, early_deploy: true
             )
             @net_gen.merge_solver.merge_task_contexts_with_same_agent = true
-
-            @profile = Actions::Profile.new("Test")
-            @profile.define("test1", cmp_m)
-                    .use("task" => task_m.with_arguments(arg: 1))
-            @profile.define("test2", cmp_m)
-                    .use("task" => task_m.with_arguments(arg: 2))
 
             @old_early_deply = Syskit.conf.early_deploy?
             Syskit.conf.early_deploy = true
@@ -204,8 +276,14 @@ module Syskit
             Syskit.conf.early_deploy = @old_early_deply
         end
 
-        it "displays deployment allocation conflicts, depicts one failed merge chain " \
-           "and list non deployed toplevel definitions" do
+        it "displays deployment allocation conflicts, shows that the tasks themselves " \
+           "are in conflict and list non deployed toplevel definitions" do
+            profile = Actions::Profile.new("Test")
+            profile.define("test1", @cmp_m)
+                   .use("task" => @task_m.with_arguments(arg: 1))
+            profile.define("test2", @cmp_m)
+                   .use("task" => @task_m.with_arguments(arg: 2))
+
             e = assert_raises(ConflictingDeploymentAllocation) do
                 net_gen.compute_system_network(
                     [profile.test1_def, profile.test2_def]
@@ -214,32 +292,100 @@ module Syskit
             formatted = PP.pp(e, +"")
 
             expected = <<~PP.chomp
-                deployed task 'test_syskit_tests_empty' from deployment \
-                'syskit_tests_empty' defined in 'orogen_syskit_tests' on \
-                'localhost' is assigned to 2 tasks. Below is the list of \
-                the dependent non-deployed actions. Right after the list is \
-                a detailed explanation of why the first two tasks are not merged:
-                OroGen.orogen_syskit_tests.Empty<id:ID>(arg: 1, conf: ["default"], \
-                orocos_name: test_syskit_tests_empty, read_only: false) is needed by the following definitions:
+                deployed task 'task' from deployment \
+                'task' defined in '' on 'stubs' is assigned to 2 tasks. Below is \
+                the list of the dependent non-deployed actions. Right after the \
+                list is a detailed explanation of why the first two tasks are not merged:
+                <id:ID>(arg: 1, conf: ["default"], orocos_name: task, read_only: false) \
+                is needed by the following definitions:
                   Test.test1_def
-                OroGen.orogen_syskit_tests.Empty<id:ID>(arg: 2, conf: ["default"], \
-                orocos_name: test_syskit_tests_empty, read_only: false) is needed by the following definitions:
+                <id:ID>(arg: 2, conf: ["default"], orocos_name: task, read_only: false) \
+                is needed by the following definitions:
                   Test.test2_def
                 Chain 1 cannot be merged in chain 2:
                 Chain 1:
-                  OroGen.orogen_syskit_tests.Empty<id:ID> pending
+                  <id:ID> pending
                     arguments:
-                      arg: 1,
-                      conf: ["default"],
+                      orocos_name: "task",
                       read_only: false,
-                      orocos_name: "test_syskit_tests_empty"
+                      conf: ["default"],
+                      arg: 1
                 Chain 2:
-                  OroGen.orogen_syskit_tests.Empty<id:ID> pending
+                  <id:ID> pending
                     arguments:
-                      arg: 2,
-                      conf: ["default"],
+                      orocos_name: "task",
                       read_only: false,
-                      orocos_name: "test_syskit_tests_empty"
+                      conf: ["default"],
+                      arg: 2
+            PP
+            assert_equal expected, formatted.gsub(/<id:\d+>/, "<id:ID>").chomp
+        end
+
+        it "properly sets up the merge solver to compute the failed chains" do
+            # Originally, the merge solver was NOT setup with early_deploy set,
+            # which led the exception to fail on pretty printing in case the merge
+            # was OK with early_deploy: false
+            #
+            # This essentially happens if the conflict appears because of an
+            # input that is not deployed
+            input_task_m = Syskit::TaskContext.new_submodel do
+                output_port "out", "/double"
+            end
+            @cmp_m.add input_task_m, as: "input"
+            @cmp_m.input_child.connect_to @cmp_m.task_child
+            profile = Actions::Profile.new("Test")
+            profile.define("test1", @cmp_m)
+            profile.define("test2", @cmp_m)
+
+            error_handler = NetworkGeneration::ResolutionErrorHandler.new(
+                net_gen.plan, net_gen.merge_solver
+            )
+            net_gen.compute_system_network(
+                [profile.test1_def, profile.test2_def],
+                error_handler: error_handler
+            )
+            failure = error_handler.resolution_failures.find do
+                _1.original_exception.kind_of?(ConflictingDeploymentAllocation)
+            end
+            e = failure.original_exception
+            assert e
+            formatted = PP.pp(e, +"")
+
+            expected = <<~PP.chomp
+                deployed task 'task' from deployment \
+                'task' defined in '' on \
+                'stubs' is assigned to 2 tasks. Below is the list of \
+                the dependent non-deployed actions. Right after the list is \
+                a detailed explanation of why the first two tasks are not merged:
+                <id:ID>(conf: ["default"], \
+                orocos_name: task, read_only: false) is needed by the following definitions:
+                  Test.test1_def
+                <id:ID>(conf: ["default"], \
+                orocos_name: task, read_only: false) is needed by the following definitions:
+                  Test.test2_def
+                Chain 1 cannot be merged in chain 2:
+                Chain 1:
+                  <id:ID> pending
+                    arguments:
+                      orocos_name: "task",
+                      read_only: false,
+                      conf: ["default"]
+                  sink in_port connected via policy {} to source out_port of
+                  <id:ID> pending
+                    arguments:
+                      conf: ["default"],
+                      read_only: false
+                Chain 2:
+                  <id:ID> pending
+                    arguments:
+                      orocos_name: "task",
+                      read_only: false,
+                      conf: ["default"]
+                  sink in_port connected via policy {} to source out_port of
+                  <id:ID> pending
+                    arguments:
+                      conf: ["default"],
+                      read_only: false
             PP
             assert_equal expected, formatted.gsub(/<id:\d+>/, "<id:ID>").chomp
         end

--- a/test/test_exceptions.rb
+++ b/test/test_exceptions.rb
@@ -122,10 +122,15 @@ module Syskit
             robot = Robot::RobotDefinition.new
             robot.device device_m, as: "test"
 
-            plan.add(driver1 = driver_m.new(test_dev: robot.test_dev))
-            plan.add(driver2 = driver_m.new(test_dev: robot.test_dev))
-            plan.add(task1 = task_m.new(arg: 1))
-            plan.add(task2 = task_m.new(arg: 2))
+            driver1 = driver_m.new(
+                plan: plan, test_dev: robot.test_dev, orocos_name: "driver"
+            )
+            driver2 = driver_m.new(
+                plan: plan, test_dev: robot.test_dev, orocos_name: "driver"
+            )
+            task1 = task_m.new(plan: plan, arg: 1, orocos_name: "task")
+            task2 = task_m.new(plan: plan, arg: 2, orocos_name: "task")
+
             task1.out_port.connect_to driver1.in_port
             task2.out_port.connect_to driver2.in_port
             e = assert_raises(ConflictingDeviceAllocation) do
@@ -143,6 +148,7 @@ module Syskit
                   Driver<id:ID> pending
                     arguments:
                       conf: default(["default"]),
+                      orocos_name: "driver",
                       read_only: default(false),
                       test_dev: MasterDeviceInstance(test[D]_dev)
                   sink in_port connected via policy {} to source out_port of
@@ -150,11 +156,13 @@ module Syskit
                     arguments:
                       arg: 1,
                       conf: default(["default"]),
+                      orocos_name: "task",
                       read_only: default(false)
                 Chain 2:
                   Driver<id:ID> pending
                     arguments:
                       conf: default(["default"]),
+                      orocos_name: "driver",
                       read_only: default(false),
                       test_dev: MasterDeviceInstance(test[D]_dev)
                   sink in_port connected via policy {} to source out_port of
@@ -162,6 +170,7 @@ module Syskit
                     arguments:
                       arg: 2,
                       conf: default(["default"]),
+                      orocos_name: "task",
                       read_only: default(false)
             PP
             assert_equal expected, formatted.gsub(/<id:\d+>/, "<id:ID>").chomp

--- a/test/test_exceptions.rb
+++ b/test/test_exceptions.rb
@@ -183,8 +183,7 @@ module Syskit
             @net_gen = NetworkGeneration::SystemNetworkGenerator.new(
                 @net_gen_plan = Roby::Plan.new,
                 default_deployment_group: default_deployment_group,
-                early_deploy: true,
-                lazy_deploy: Syskit.conf.lazy_deploy?
+                early_deploy: true
             )
             @net_gen.default_deployment_group.use_deployment(
                 OroGen::Deployments.syskit_tests_empty => "test_"

--- a/test/test_exceptions.rb
+++ b/test/test_exceptions.rb
@@ -183,7 +183,8 @@ module Syskit
             @net_gen = NetworkGeneration::SystemNetworkGenerator.new(
                 @net_gen_plan = Roby::Plan.new,
                 default_deployment_group: default_deployment_group,
-                early_deploy: true
+                early_deploy: true,
+                lazy_deploy: Syskit.conf.lazy_deploy?
             )
             @net_gen.default_deployment_group.use_deployment(
                 OroGen::Deployments.syskit_tests_empty => "test_"
@@ -215,7 +216,7 @@ module Syskit
 
             expected = <<~PP.chomp
                 deployed task 'test_syskit_tests_empty' from deployment \
-                'test_syskit_tests_empty' defined in 'orogen_syskit_tests' on \
+                'syskit_tests_empty' defined in 'orogen_syskit_tests' on \
                 'localhost' is assigned to 2 tasks. Below is the list of \
                 the dependent non-deployed actions. Right after the list is \
                 a detailed explanation of why the first two tasks are not merged:
@@ -229,17 +230,17 @@ module Syskit
                 Chain 1:
                   OroGen.orogen_syskit_tests.Empty<id:ID> pending
                     arguments:
-                      orocos_name: "test_syskit_tests_empty",
-                      read_only: false,
+                      arg: 1,
                       conf: ["default"],
-                      arg: 1
+                      read_only: false,
+                      orocos_name: "test_syskit_tests_empty"
                 Chain 2:
                   OroGen.orogen_syskit_tests.Empty<id:ID> pending
                     arguments:
-                      orocos_name: "test_syskit_tests_empty",
-                      read_only: false,
+                      arg: 2,
                       conf: ["default"],
-                      arg: 2
+                      read_only: false,
+                      orocos_name: "test_syskit_tests_empty"
             PP
             assert_equal expected, formatted.gsub(/<id:\d+>/, "<id:ID>").chomp
         end


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-roby/pull/377

The core issue was that some tests were not executed with the relevant feature flags because of missing defaults. In addition, starting to develop bundles with early deploy ON by default led to triggering some bugs in error reporting.

Fix both, and add unit tests.