### PR TITLE
chore: explicitly pass file descriptors to create interfaces in subcommands

### DIFF
--- a/lib/syskit.rb
+++ b/lib/syskit.rb
@@ -25,6 +25,8 @@ require "syskit/instance_requirements"
 require "syskit/orogen_namespace"
 
 module Syskit
+    BIN_DIR = File.expand_path(File.join("..", "bin"), __dir__)
+
     # @api private
     #
     # Definition of Syskit's built-in process managers

--- a/test/cli/test_gen_main.rb
+++ b/test/cli/test_gen_main.rb
@@ -8,12 +8,15 @@ module Syskit
         describe "syskit gen" do
             include Roby::Test::ArubaMinitest
 
+            # Override path to CLI command to use ArubaMinitest helpers
+            def roby_bin
+                File.join(Syskit::BIN_DIR, "syskit")
+            end
+
             def assert_app_valid(*args)
-                port = roby_allocate_port
-                syskit_run = run_command(
-                    ["syskit", "run", "--port=#{port}", *args].join(" ")
-                )
-                syskit_quit = run_command "syskit quit --retry --host=localhost:#{port}"
+                roby_allocate_interface_server
+                syskit_run = run_roby_run(args.join(" "))
+                syskit_quit = run_roby_client("quit --retry")
                 assert_command_stops syskit_run
                 assert_command_stops syskit_quit
 

--- a/test/cli/test_main.rb
+++ b/test/cli/test_main.rb
@@ -54,10 +54,10 @@ module Roby
                 end
 
                 it "forwards a Roby CLI command defined through Thor" do
-                    port = roby_allocate_port
-                    run_cmd = run_command "roby run --port=#{port}"
-                    run_command_and_stop "roby wait --host=localhost:#{port}"
-                    run_command_and_stop "roby quit --host=localhost:#{port}"
+                    roby_allocate_interface_server
+                    run_cmd = run_roby_run
+                    run_roby_client_and_stop "wait"
+                    run_roby_client_and_stop "quit"
                     assert_command_stops run_cmd
                 end
             end


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-roby/pull/378

The current method of getting a random port from the kernel and assuming it won't be given to some other process in the time needed to start subcommands is not working in CI with parallel execution. We get a significant number of heisenbugs out of it.

This requires a fork of aruba until the functionality of passing FDs do subcommands gets integrated there.